### PR TITLE
using sphinx book theme docs

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -1,0 +1,12 @@
+on: [status]
+
+jobs:
+  circleci_artifacts_redirector_job:
+    runs-on: ubuntu-latest
+    name: Run CircleCI artifacts redirector
+    steps:
+      - name: GitHub Action step
+        uses: larsoner/circleci-artifacts-redirector-action@master
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          artifact-path: 0/html/index.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,10 +50,12 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "pydata_sphinx_theme"
+html_theme = "sphinx_book_theme"
 html_logo = "_static/logo.png"
 html_theme_options = {
-    "github_url": "https://github.com/ExecutableBookProject/MyST-Parser"
+    "github_url": "https://github.com/ExecutableBookProject/MyST-Parser",
+    "repository_url": "https://github.com/ExecutableBookProject/MyST-Parser",
+    "expand_sections": ["using/index"],
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
             "pytest-regressions",
             "beautifulsoup4",
         ],
-        "rtd": ["sphinxcontrib-bibtex", "ipython", "pydata-sphinx-theme"],
+        "rtd": ["sphinxcontrib-bibtex", "ipython", "sphinx-book-theme"],
     },
     zip_safe=True,
 )


### PR DESCRIPTION
This uses the `sphinx-book-theme` for the documentation. Also adds a github action that previews the CircleCI artifact (which won't work on this PR but will work on subsequent ones)

Demo here: https://350-240151150-gh.circle-artifacts.com/0/html/index.html

For some reason, the glyphs in the admonition blocks aren't showing up in this theme. This seems somehow related to myst_parser, since it works fine in the same PR for myst_nb (https://github.com/ExecutableBookProject/MyST-NB/pull/164)

![image](https://user-images.githubusercontent.com/1839645/80042295-72e76080-84b3-11ea-839a-a5851387422a.png)
