### PR TITLE
Fix bug if fence language is an empty space

### DIFF
--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -335,8 +335,8 @@ class DocutilsRenderer:
         text = token.content
         if token.info:
             # Ensure that we'll have an empty string if info exists but is only spaces
-            info = info.strip()
-        language = info.split()[0] if info else ""
+            token.info = token.info.strip()
+        language = token.info.split()[0] if token.info else ""
 
         if language.startswith("{") and language.endswith("}"):
             return self.render_directive(token)

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -333,7 +333,10 @@ class DocutilsRenderer:
 
     def render_fence(self, token):
         text = token.content
-        language = token.info.split()[0] if token.info else ""
+        if token.info:
+            # Ensure that we'll have an empty string if info exists but is only spaces
+            info = info.strip()
+        language = info.split()[0] if info else ""
 
         if language.startswith("{") and language.endswith("}"):
             return self.render_directive(token)


### PR DESCRIPTION
closes https://github.com/executablebooks/jupyter-book/issues/695

This tackles an edge-case where the code fence is used with an empty space after the back-ticks

I'm not quite sure how to test this, since it seems like it should be part of the commonmark test suite but they apparently don't test for it (?) 