### PR TITLE
adding more getting started docs

### DIFF
--- a/docs/using/intro.md
+++ b/docs/using/intro.md
@@ -71,13 +71,14 @@ markdown documents. This means that you can use the `.md` extension for your pag
 and write MyST markdown in these pages.
 
 ```{tip}
-MyST markdown is kind-of like two flavors of markdown wrapped in one.
+MyST markdown is a mixture of two flavors of markdown:
 
-It supports [CommonMark Markdown](https://commonmark.org/) - the base flavor of markdown
-that is a standard across many communities.
+It supports all the syntax of **[CommonMark Markdown](https://commonmark.org/)** at its
+base. This is a community standard flavor of markdown used across many projects.
 
-It also supports [MyST Markdown syntax](syntax), an extended set of markdown syntax
-that has Sphinx-specific functionality and extra features.
+In addition, it includes several extensions **in addition to CommonMark**
+(often described as [MyST Markdown syntax](syntax)). These add extra syntax features
+designed to work with the Sphinx ecosystem (and inspired by reStructuredText)
 ```
 
 The following sections cover a few core syntax patterns in MyST markdown, you can

--- a/docs/using/intro.md
+++ b/docs/using/intro.md
@@ -76,7 +76,7 @@ MyST markdown is a mixture of two flavors of markdown:
 It supports all the syntax of **[CommonMark Markdown](https://commonmark.org/)** at its
 base. This is a community standard flavor of markdown used across many projects.
 
-In addition, it includes several extensions **in addition to CommonMark**
+In addition, it includes **several extensions to CommonMark**
 (often described as [MyST Markdown syntax](syntax)). These add extra syntax features
 designed to work with the Sphinx ecosystem (and inspired by reStructuredText)
 ```
@@ -91,11 +91,44 @@ Directives are kind-of like functions that are designed for writing content. Sph
 and reStructuredText use directives extensively. Here's how a directive looks in
 MyST markdown:
 
+````{margin} Alternative options syntax
+If you've got a lot of options for your directive, or have a value that is really
+long (e.g., that spans multiple lines), then you can also wrap your options in
+`---` lines and write them as YAML. For example:
+
+```yaml
+---
+key1: val1
+key2: |
+  val line 1
+  val line 2
+---
+```
+````
+
 ````
 ```{directivename} <directive arguments>
 :optionname: <valuename>
+
 <directive content>
 ```
+````
+
+````{admonition} MyST vs. rST
+:class: warning
+For those who are familiar with reStructuredText, here is the equivalent in rST:
+
+```rst
+.. directivename: <directive-arguments>
+  :optionname: <valuename>
+
+  <directive content>
+```
+
+Note that almost all documentation in the Sphinx ecosystem is written with
+reStructuredText (MyST is only a few months old). That means you'll likely see examples
+that have rST structure. You can modify any rST to work with MyST. Use this page,
+and [the syntax page](syntax) to help guide you.
 ````
 
 As seen above, there are four main parts to consider when writing directives.
@@ -113,9 +146,8 @@ For example, here's an **`admonition`** directive:
 
 ````
 ```{admonition} Here's my title
----
-class: warning
----
+:class: warning
+
 Here's my admonition content
 ```
 ````
@@ -124,9 +156,8 @@ As you can see, we've used each of the four pieces described above to configure 
 directive. Here's how it looks when rendered:
 
 ```{admonition} Here's my title
----
-class: warning
----
+:class: warning
+
 Here's my admonition content
 ```
 
@@ -139,6 +170,12 @@ in-line with text instead of in a separate block. They have the following form:
 
 ```
 {rolename}`role content`
+```
+
+For those who are familiar with reStructuredText, here is the equivalent in rST:
+
+```rst
+:rolename:`role content`
 ```
 
 As you can see, roles are a bit more simple than directives, though some roles allow

--- a/docs/using/intro.md
+++ b/docs/using/intro.md
@@ -40,21 +40,119 @@ To use the MyST parser in Sphinx, simply add: `extensions = ["myst_parser"]` to 
 
 Naturally this site is generated with Sphinx and MyST!
 
+## How does MyST parser relate to Sphinx?
+
+The Sphinx documentation engine supports a number of different input types. By default,
+it reads **reStructuredText** (`.rst`) files. Sphinx uses a **parser** to parse input files
+into its own internal document model (which is provided by a core Python project,
+[docutils](https://docutils.sourceforge.io/)).
+
+Developers can *extend Sphinx* to support other kinds of input files. Any content file
+can be read into the Sphinx document structure, provided that somebody writes a
+**parser** for that file. Once a content file has been parsed into Sphinx, it behaves
+nearly the same way as any other content file, regardless of the language in which it
+was written.
+
+The MyST-parser is a Sphinx parser for the MyST markdown language. When you use it,
+Sphinx will know how to parse content files that contain MyST markdown (by default,
+Sphinx will assume any files ending in `.md` are written in MyST markdown).
+
+```{note}
+Sphinx will still be able to parse files written in `.rst`. Activating this parser
+simply adds another parser, and Sphinx will still be able to use its default parser
+for `.rst` files.
+```
+
+(intro/writing)=
 ## Writing MyST in Sphinx
 
-Once you've enabled the `myst-parser` in Sphinx, it will be able to parser your MyST
+Once you've enabled the `myst-parser` in Sphinx, it will be able to parse your MyST
 markdown documents. This means that you can use the `.md` extension for your pages,
-and write markdown in one of the following two flavors:
+and write MyST markdown in these pages.
 
-* [CommonMark Markdown](https://commonmark.org/) - the base flavor of markdown that is
-  a standard across many communities.
-* [MyST Markdown](syntax) - an extended flavor of CommonMark that includes syntax for
-  Sphinx-specific functionality.
+```{tip}
+MyST markdown is kind-of like two flavors of markdown wrapped in one.
 
-For example, you can include standard markdown like links: `[mylink](https://google.com)`
-or MyST-specific syntax like roles: `` {myrole}`role content` ``.
+It supports [CommonMark Markdown](https://commonmark.org/) - the base flavor of markdown
+that is a standard across many communities.
 
-For more information about the syntax that you can use with MyST markdown, see {doc}`syntax`.
+It also supports [MyST Markdown syntax](syntax), an extended set of markdown syntax
+that has Sphinx-specific functionality and extra features.
+```
+
+The following sections cover a few core syntax patterns in MyST markdown, you can
+find a more exhaustive list in {doc}`syntax`.
+
+### Block-level directives with MyST markdown
+
+The most important functionality available with MyST markdown is writing **directives**.
+Directives are kind-of like functions that are designed for writing content. Sphinx
+and reStructuredText use directives extensively. Here's how a directive looks in
+MyST markdown:
+
+````
+```{directivename} <directive arguments>
+:optionname: <valuename>
+<directive content>
+```
+````
+
+As seen above, there are four main parts to consider when writing directives.
+
+* **the directive name** is kind of like the function name. Different names trigger
+  different functionality. They are wrapped in `{}` brackets.
+* **directive arguments** come just after the directive name. They can be used
+  to trigger behavior in the directive.
+* **directive options** come just after the first line of the directive. They also
+  control behavior of the directive.
+* **directive content** is markdown that you put inside the directive. The directive
+  often displays the content in a special way.
+
+For example, here's an **`admonition`** directive:
+
+````
+```{admonition} Here's my title
+---
+class: warning
+---
+Here's my admonition content
+```
+````
+
+As you can see, we've used each of the four pieces described above to configure this
+directive. Here's how it looks when rendered:
+
+```{admonition} Here's my title
+---
+class: warning
+---
+Here's my admonition content
+```
+
+For more information about using directives with MyST, see {ref}`syntax/directives`.
+
+### In-line roles with MyST Markdown
+
+Roles are another core Sphinx tool. They behave similarly to directives, but are given
+in-line with text instead of in a separate block. They have the following form:
+
+```
+{rolename}`role content`
+```
+
+As you can see, roles are a bit more simple than directives, though some roles allow
+for more complex syntax inside their content area. For example, the `ref` role is used
+to make references to other sections of your documentation, and allows you to specify
+the displayed text as well as the reference itself within the role:
+
+```
+{ref}`My displayed text <my-ref>`
+```
+
+For example, the following reference role: `` {ref}`Check out this reference <syntax/roles>` ``
+will be rendered as {ref}`Check out this reference <syntax/roles>`.
+
+For more information about roles, see {ref}`syntax/roles`.
 
 ```{tip}
 Check out the [MyST-Markdown VS Code extension](https://marketplace.visualstudio.com/items?itemName=ExecutableBookProject.myst-highlight),

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -14,6 +14,10 @@ ecosystem.
 Below is a summary of the syntax 'tokens' parsed,
 and further details of a few major extensions from the CommonMark flavor of markdown.
 
+```{seealso}
+For an introduction to writing Directives and Roles with MyST markdown, see {ref}`intro/writing`.
+```
+
 % ```{seealso}
 % {ref}`MyST Extended AST Tokens API <api/tokens>`
 % ```
@@ -23,12 +27,19 @@ described in the [CommonMark Spec](https://spec.commonmark.org/0.29/), which the
 
 % TODO link to markdown-it documentation
 
-## Block Tokens
+## Block Tokens Summary
 
 Block tokens span multiple lines of content. They are broken down into two sections:
 
 * {ref}`extended-block-tokens` contains *extra* tokens that are not in CommonMark.
 * {ref}`commonmark-block-tokens` contains CommonMark tokens that also work, for reference.
+
+In addition to these summaries of block-level syntax, see {ref}`extra-markdown-syntax`.
+
+```{note}
+Because MyST markdown was inspired by functionality that exists in reStructuredText,
+we have shown equivalent rST syntax for many MyST markdown features below.
+```
 
 (extended-block-tokens)=
 ### Extended block tokens
@@ -154,16 +165,17 @@ Block tokens span multiple lines of content. They are broken down into two secti
   - ```md
     any *text*
     ```
-
 `````
 
-## Span (Inline) Tokens
+## Span (Inline) Tokens Summary
 
 Span (or inline) tokens are defined on a single line of content. They are broken down into two
 sections below:
 
 * {ref}`extended-span-tokens` contains *extra* tokens that are not in CommonMark.
 * {ref}`commonmark-span-tokens` contains CommonMark tokens that also work, for reference.
+
+In addition to these summaries of inline syntax, see {ref}`extra-markdown-syntax`.
 
 (extended-span-tokens)=
 ### Extended inline tokens
@@ -310,34 +322,14 @@ Will generate this admonition:
 This is my note
 ```
 
-For directives that are meant to parse content for your site, you may use
-markdown as the markup language inside...
-
-````md
-```{admonition} My markdown link
-Here is [markdown link syntax](https://jupyter.org)
-```
-````
-
-```{admonition} My markdown link
-Here is [markdown link syntax](https://jupyter.org)
-```
-
-As a short-hand for directives that require no arguments, and when no paramter options are used (see below),
-you may start the content directly after the directive name.
-
-````md
-```{note} Notes require **no** arguments, so content can start here.
-```
-````
-
-```{note} Notes require **no** arguments, so content can start here.
-```
-
 ### Parameterizing directives
 
-For directives that take parameters as input, you may parameterize them by
-beginning your directive content with YAML frontmatter. This needs to be
+For directives that take parameters as input, there are two ways to parameterize them.
+In each case, the options themselves are given as `key: value` pairs. An example of
+each is shown below:
+
+**Using YAML frontmatter**. A block of YAML front-matter just after the
+first line of the directive will be parsed as options for the directive. This needs to be
 surrounded by `---` lines. Everything in between will be parsed by YAML and
 passed as keyword arguments to your directive. For example:
 
@@ -369,7 +361,11 @@ print('my 1st line')
 print(f'my {a}nd line')
 ```
 
-As a short-hand alternative, more closely resembling the reStructuredText syntax, options may also be denoted by an initial block, whereby all lines start with '`:`', for example:
+**Short-hand options with `:` characters**. If you only need one or two options for your
+directive and wish to save lines, you may also specify directive options as a collection
+of lines just after the first line of the directive, each preceding with `:`.
+
+For example:
 
 ````md
 ```{code-block} python
@@ -381,6 +377,33 @@ print('my 1st line')
 print(f'my {a}nd line')
 ```
 ````
+
+### How directives parse content
+
+Some directives parse the content that is in their content block. This
+means that MyST markdown can be written in the content areas of any directives written
+in MyST markdown. For example:
+
+````md
+```{admonition} My markdown link
+Here is [markdown link syntax](https://jupyter.org)
+```
+````
+
+```{admonition} My markdown link
+Here is [markdown link syntax](https://jupyter.org)
+```
+
+As a short-hand for directives that require no arguments, and when no paramter options are used (see below),
+you may start the content directly after the directive name.
+
+````md
+```{note} Notes require **no** arguments, so content can start here.
+```
+````
+
+```{note} Notes require **no** arguments, so content can start here.
+```
 
 ### Nesting directives
 
@@ -511,13 +534,28 @@ label: euler
 Euler's identity, equation {math:numref}`euler`, was elected one of the
 most beautiful mathematical formulas.
 
+### How roles parse content
+
+The content of roles is parsed differently depending on the role that you've used.
+Some roles expect inputs that will be used to change functionality. For example,
+the `ref` role will assume that input content is a reference to some other part of the
+site. However, other roles may use the MyST parser to parse the input as content.
+
+Some roles also **extend their functionality** depending on the content that you pass.
+For example, following the `ref` example above, if you pass a string like this:
+`Content to display <myref>`, then the `ref` will display `Content to display` and use
+`myref` as the reference to look up.
+
+How roles parse this content depends on the author that created the role.
+
+(extra-markdown-syntax)=
 ## Extra markdown syntax
 
-Here is some extra markdown syntax which provides functionality in rST that doesn't
+In addition to roles and directives, MyST supports extra markdown syntax that doesn't
 exist in CommonMark. In most cases, these are syntactic short-cuts to calling
 roles and directives. We'll cover some common ones below.
 
-This tale describes the rST and MyST equivalents:
+This table describes the rST and MyST equivalents:
 
 ````{list-table}
 ---


### PR DESCRIPTION
This adds some more getting started information and background on Sphinx / parsers / roles / directives / etc. It tries to address a few more of @amueller's points about assumptions we're making about readers.

The biggest addition is a section describing what directives / roles are, their structure, and a bit of information about what they do. I'm thinking of this content as a complement to what is in `syntax.md`, which is more like a "reference" and complete set of information.