### PR TITLE
Move sphinx into main requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
           keys:
             - cache-pip
       - run: |
-          pip install --user -e .[sphinx,rtd]
+          pip install --user -e .[rtd]
       - save_cache:
           key: cache-pip
           paths:

--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,5 @@ dmypy.json
 .pyre/
 
 _archive/
+
+.DS_Store

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,6 +16,6 @@
     "python.linting.flake8Enabled": true,
     "python.linting.enabled": true,
     "autoDocstring.customTemplatePath": "docstring.fmt.mustache",
-    "python.pythonPath": "/anaconda/envs/ebp/bin/python",
+    "python.pythonPath": "/Users/chrisjsewell/opt/miniconda3/envs/ebp/bin/python",
     "restructuredtext.confPath": "${workspaceFolder}/docs"
 }

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ conda install -c conda-forge myst-parser
 or
 
 ```bash
-pip install myst-parser[sphinx]
+pip install myst-parser
 ```
 
 Or for package development:
@@ -30,7 +30,7 @@ Or for package development:
 git clone https://github.com/executablebooks/MyST-Parser
 cd MyST-Parser
 git checkout master
-pip install -e .[sphinx,code_style,testing,rtd]
+pip install -e .[code_style,testing,rtd]
 ```
 
 To use the MyST parser in Sphinx, simply add: `extensions = ["myst_parser"]` to your `conf.py`.

--- a/docs/develop/contributing.md
+++ b/docs/develop/contributing.md
@@ -14,7 +14,7 @@ To install `myst-parser` for development, take the following steps:
 git clone https://github.com/executablebooks/MyST-Parser
 cd MyST-Parser
 git checkout master
-pip install -e .[sphinx,code_style,testing,rtd]
+pip install -e .[code_style,testing,rtd]
 ```
 
 ## Code Style

--- a/docs/using/intro.md
+++ b/docs/using/intro.md
@@ -23,7 +23,7 @@ conda install -c conda-forge myst-parser
 or
 
 ```bash
-pip install myst-parser[sphinx]
+pip install myst-parser
 ```
 
 [pypi-badge]: https://img.shields.io/pypi/v/myst-parser.svg

--- a/setup.py
+++ b/setup.py
@@ -37,9 +37,14 @@ setup(
     ],
     keywords="markdown lexer parser development docutils sphinx",
     python_requires=">=3.6",
-    install_requires=["markdown-it-py~=0.4.5"],
+    install_requires=[
+        "markdown-it-py~=0.4.5",
+        "pyyaml",
+        "docutils>=0.15",
+        "sphinx>=2,<3",
+    ],
     extras_require={
-        "sphinx": ["pyyaml", "docutils>=0.15", "sphinx>=2,<3"],
+        "sphinx": [],  # left in for back-compatability
         "code_style": ["flake8<3.8.0,>=3.7.0", "black", "pre-commit==1.17.0"],
         "testing": [
             "coverage",
@@ -48,6 +53,7 @@ setup(
             "pytest-regressions",
             "beautifulsoup4",
         ],
+        # Note: This is only required for internal use
         "rtd": ["sphinxcontrib-bibtex", "ipython", "sphinx-book-theme", "sphinx_tabs"],
     },
     zip_safe=True,


### PR DESCRIPTION
Sphinx was originally set as an extra requirement, when myst-parser contained plugins for the markdown parser. This is no longer the case, so it is now not likely that the package would be used without sphinx, and just overcomplicates things to have to install `myst-parser[sphinx]`, rather than just `myst-parser`.
Note the `sphinx` extra has been left in (as an empty list) so that existing requirements files do not break.