### PR TITLE
using rst notes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ MyST has the following main features:
 * **[A superset of CommonMark markdown][commonmark]**. Any CommonMark markdown
   (such as Jupyter Notebook markdown) is natively supported by the MyST parser.
 
+You may use MyST markdown **in addition to** using reStructuredText in Sphinx.
 See {doc}`using/intro` to get started.
 
 ```{note}

--- a/docs/using/intro.md
+++ b/docs/using/intro.md
@@ -46,7 +46,8 @@ Naturally this site is generated with Sphinx and MyST!
 Activating the MyST parser will simply *enable* parsing markdown files with MyST, and the rST
 parser that ships with Sphinx by default will still work the same way. You can have
 combinations of both markdown and rST files in your documentation, and Sphinx will
-choose the right parser based on each file's extension.
+choose the right parser based on each file's extension. Sphinx features
+like cross-references will work just fine between the pages.
 ```
 
 ## How does MyST parser relate to Sphinx?

--- a/docs/using/intro.md
+++ b/docs/using/intro.md
@@ -40,6 +40,15 @@ To use the MyST parser in Sphinx, simply add: `extensions = ["myst_parser"]` to 
 
 Naturally this site is generated with Sphinx and MyST!
 
+```{admonition} You can use both MyST and reStructuredText
+:class: tip
+
+Activating the MyST parser will simply *enable* parsing markdown files with MyST, and the rST
+parser that ships with Sphinx by default will still work the same way. You can have
+combinations of both markdown and rST files in your documentation, and Sphinx will
+choose the right parser based on each file's extension.
+```
+
 ## How does MyST parser relate to Sphinx?
 
 The Sphinx documentation engine supports a number of different input types. By default,


### PR DESCRIPTION
Adds some notes about how users can use MyST _alongside_ rST. @asmeurer think this would help get this message across?

here's how it looks: https://myst-parser--182.org.readthedocs.build/en/182/using/intro.html#enable-myst-in-sphinx