### PR TITLE
✨ Add the eval-rst directive

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,6 +69,7 @@ myst_amsmath_enable = True
 myst_admonition_enable = True
 myst_html_img_enable = True
 myst_dmath_enable = True
+myst_url_schemes = ("http", "https", "mailto")
 
 
 def run_apidoc(app):
@@ -127,6 +128,7 @@ nitpick_ignore = [
     ("py:class", "docutils.nodes.Element"),
     ("py:class", "docutils.parsers.rst.directives.misc.Include"),
     ("py:class", "docutils.nodes.document"),
+    ("py:class", "docutils.parsers.rst.Parser"),
 ]
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ and extensibility of Sphinx with the simplicity and readability of Markdown.
 MyST has the following main features:
 
 * **[A markdown parser for Sphinx](parse-with-sphinx)**. You can write your entire
-  {doc}`Sphinx documentation <sphinx:usage/quickstart>` in markdown.
+  {doc}`Sphinx documentation <sphinx:usage/quickstart>` in Markdown.
 * **[Call Sphinx directives and roles from within Markdown](syntax/directives)**,
   allowing you to extend your document via Sphinx extensions.
 * **[Extended Markdown syntax for useful rST features](extended-block-tokens)**, such

--- a/docs/using/howto.md
+++ b/docs/using/howto.md
@@ -2,6 +2,49 @@
 
 This page describes several common uses of MyST parser and how to accomplish them.
 
+(howto/include-rst)=
+## Include rST files into a Markdown file
+
+As explained in [this section](syntax/directives/parsing), all MyST directives will parse their content as Markdown.
+Therefore, using the conventional `include` directive, will parse the file contents as Markdown:
+
+````md
+```{include} snippets/include-md.md
+```
+````
+
+```{include} snippets/include-md.md
+```
+
+To include rST, we must first "wrap" the directive in the [eval-rst directive](syntax/directives/parsing):
+
+````md
+```{eval-rst}
+.. include:: snippets/include-rst.rst
+```
+````
+
+```{eval-rst}
+.. include:: snippets/include-rst.rst
+```
+
+(howto/autodoc)=
+## Use `sphinx.ext.autodoc` in Markdown files
+
+The [sphinx.ext.autodoc](sphinx:sphinx.ext.autodoc) is currently hard-coded to write rST, and so can not be used as a conventional MyST directive.
+Instead the special [eval-rst directive](syntax/directives/parsing) can be used to "wrap" the autodoc directives:
+
+```{eval-rst}
+.. autoclass:: myst_parser.mocking.MockRSTParser
+    :show-inheritance:
+    :members: parse
+```
+
+As with other objects in MyST, this can then be referenced:
+
+- Using the role `` {py:class}`myst_parser.mocking.MockRSTParser` ``: {py:class}`myst_parser.mocking.MockRSTParser`
+- Using the Markdown syntax `[MockRSTParser](myst_parser.mocking.MockRSTParser)`: [MockRSTParser](myst_parser.mocking.MockRSTParser)
+
 ## Show backticks inside raw markdown blocks
 
 If you'd like to show backticks inside of your markdown, you can do so by nesting them
@@ -28,7 +71,7 @@ hi
 ```
 ````
 
-(autosectionlabel)=
+(howto/autosectionlabel)=
 ## Automatically create targets for section headers
 
 If you'd like to *automatically* generate targets for each of your section headers,

--- a/docs/using/intro.md
+++ b/docs/using/intro.md
@@ -12,7 +12,7 @@ it in the Sphinx documentation engine.
 Installing the MyST parser provides access to two tools:
 
 * A MyST-to-docutils parser and renderer.
-* A Sphinx parser that utilizes the above tool in building your documenation.
+* A Sphinx parser that utilizes the above tool in building your documentation.
 
 To install the MyST parser, run the following in a
 [Conda environment](https://docs.conda.io) (recommended):
@@ -43,11 +43,11 @@ Naturally this site is generated with Sphinx and MyST!
 
 :::{admonition,tip} You can use both MyST and reStructuredText
 
-Activating the MyST parser will simply *enable* parsing markdown files with MyST, and the rST
-parser that ships with Sphinx by default will still work the same way. You can have
-combinations of both markdown and rST files in your documentation, and Sphinx will
-choose the right parser based on each file's extension. Sphinx features
-like cross-references will work just fine between the pages.
+Activating the MyST parser will simply *enable* parsing markdown files with MyST, and the rST parser that ships with Sphinx by default will still work the same way.
+You can have combinations of both markdown and rST files in your documentation, and Sphinx will choose the right parser based on each file's extension.
+Sphinx features like cross-references will work just fine between the pages.
+
+You can even inject raw rST into Markdown files! (see [this explanation](syntax/directives/parsing))
 :::
 
 :::{admonition,seealso} Want to add Jupyter Notebooks to your documentation?
@@ -146,9 +146,8 @@ For those who are familiar with reStructuredText, here is the equivalent in rST:
 ```
 
 Note that almost all documentation in the Sphinx ecosystem is written with
-reStructuredText (MyST is only a few months old). That means you'll likely see examples
-that have rST structure. You can modify any rST to work with MyST. Use this page,
-and [the syntax page](syntax) to help guide you.
+reStructuredText (MyST is only a few months old).
+That means you'll likely see examples that have rST structure. You can modify any rST to work with MyST. Use this page, and [the syntax page](syntax) to help guide you.
 ````
 
 As seen above, there are four main parts to consider when writing directives.

--- a/docs/using/snippets/include-md.md
+++ b/docs/using/snippets/include-md.md
@@ -1,0 +1,1 @@
+Hallo I'm from a Markdown file, [with a reference](howto/autodoc).

--- a/docs/using/snippets/include-rst.rst
+++ b/docs/using/snippets/include-rst.rst
@@ -1,0 +1,1 @@
+Hallo I'm from an rST file, :ref:`with a reference <howto/autodoc>`.

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -18,10 +18,6 @@ and further details of a few major extensions from the CommonMark flavor of mark
 For an introduction to writing Directives and Roles with MyST markdown, see {ref}`intro/writing`.
 :::
 
-% ```{seealso}
-% {ref}`MyST Extended AST Tokens API <api/tokens>`
-% ```
-
 MyST builds on the tokens defined by markdown-it, to extend the syntax
 described in the [CommonMark Spec](https://spec.commonmark.org/0.29/), which the parser is tested against.
 
@@ -389,11 +385,13 @@ print(f'my {a}nd line')
 ```
 ````
 
+(syntax/directives/parsing)=
 ### How directives parse content
 
-Some directives parse the content that is in their content block. This
-means that MyST markdown can be written in the content areas of any directives written
-in MyST markdown. For example:
+Some directives parse the content that is in their content block.
+MyST parses this content **as Markdown**.
+
+This means that MyST markdown can be written in the content areas of any directives written in MyST markdown. For example:
 
 ````md
 ```{admonition} My markdown link
@@ -405,7 +403,7 @@ Here is [markdown link syntax](https://jupyter.org)
 Here is [markdown link syntax](https://jupyter.org)
 ```
 
-As a short-hand for directives that require no arguments, and when no paramter options are used (see below),
+As a short-hand for directives that require no arguments, and when no parameter options are used (see below),
 you may start the content directly after the directive name.
 
 ````md
@@ -416,10 +414,41 @@ you may start the content directly after the directive name.
 ```{note} Notes require **no** arguments, so content can start here.
 ```
 
+For special cases, MySt also offers the `eval-rst` directive.
+This will parse the content **as ReStructuredText**:
+
+````md
+```{eval-rst}
+.. figure:: img/fun-fish.png
+  :width: 100px
+  :name: rst-fun-fish
+
+  Party time!
+
+A reference from inside: ref:`rst-fun-fish`
+
+A reference from outside: :ref:`syntax/directives/parsing`
+```
+````
+
+```{eval-rst}
+.. figure:: img/fun-fish.png
+  :width: 100px
+  :name: rst-fun-fish
+
+  Party time!
+
+A reference from inside: ref:`rst-fun-fish`
+
+A reference from outside: :ref:`syntax/directives/parsing`
+```
+
+Note how the text is integrated into the rest of the document, so we can also reference [party fish](rst-fun-fish) anywhere else in the documentation.
+
 ### Nesting directives
 
-You can nest directives by ensuring that the ticklines corresponding to the
-outermost directive are longer than the ticklines for the inner directives.
+You can nest directives by ensuring that the tick-lines corresponding to the
+outermost directive are longer than the tick-lines for the inner directives.
 For example, nest a warning inside a note block like so:
 
 `````md
@@ -912,7 +941,7 @@ to them.
 ```{tip}
 If you'd like to *automatically* generate targets for each of your section headers,
 check out the [`autosectionlabel`](https://www.sphinx-doc.org/en/master/usage/extensions/autosectionlabel.html)
-sphinx feature. See {ref}`autosectionlabel` for more details.
+sphinx feature. See {ref}`howto/autosectionlabel` for more details.
 ```
 
 Target headers are defined with this syntax:

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -374,11 +374,6 @@ class DocutilsRenderer:
             pseudosource = ("\n" * token.map[0]) + token.content
             # actually parse the rst into our document
             MockRSTParser().parse(pseudosource, newdoc)
-            for node in newdoc.traverse():
-                if node.line:
-                    # keep line numbers aligned
-                    node.line += token.map[0]
-                node.source = self.document["source"]
             for node in newdoc:
                 if node["names"]:
                     self.document.note_explicit_target(node, node)

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -366,15 +366,19 @@ class DocutilsRenderer:
         if not self.config.get("commonmark_only", False) and language == "{eval_rst}":
             # copy necessary elements (source, line no, env, reporter)
             newdoc = make_document()
+            newdoc["source"] = self.document["source"]
+            newdoc.settings = self.document.settings
             newdoc.reporter = self.reporter
-            newdoc.settings.env = self.document.settings.env
             # actually parse the rst into our document
             RSTParser().parse(token.content, newdoc)
-            self.add_line_and_source_path(newdoc, token)
             for node in newdoc.traverse():
                 if node.line:
                     # keep line numbers aligned
                     node.line += token.map[0]
+                node.source = self.document["source"]
+            for node in newdoc:
+                if node["names"]:
+                    self.document.note_explicit_target(node, node)
             self.current_node.extend(newdoc[:])
             return
         elif (

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -363,7 +363,7 @@ class DocutilsRenderer:
             token.info = token.info.strip()
         language = token.info.split()[0] if token.info else ""
 
-        if not self.config.get("commonmark_only", False) and language == "{eval_rst}":
+        if not self.config.get("commonmark_only", False) and language == "{eval-rst}":
             # copy necessary elements (source, line no, env, reporter)
             newdoc = make_document()
             newdoc["source"] = self.document["source"]

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -369,6 +369,13 @@ class DocutilsRenderer:
             and language.endswith("}")
         ):
             return self.render_directive(token)
+        elif language == "eval_rst":
+            newdoc = make_document()
+            newdoc.settings.env = self.document.settings.env
+            RSTParser().parse(token.content, newdoc)
+            self.add_line_and_source_path(newdoc, token)
+            self.current_node.extend(newdoc[:])
+            return
 
         if not language:
             try:

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -370,8 +370,10 @@ class DocutilsRenderer:
             newdoc["source"] = self.document["source"]
             newdoc.settings = self.document.settings
             newdoc.reporter = self.reporter
+            # pad the line numbers artificially so they offset with the fence block
+            pseudosource = ("\n" * token.map[0]) + token.content
             # actually parse the rst into our document
-            MockRSTParser().parse(token.content, newdoc)
+            MockRSTParser().parse(pseudosource, newdoc)
             for node in newdoc.traverse():
                 if node.line:
                     # keep line numbers aligned

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -31,6 +31,7 @@ from myst_parser.mocking import (
     MockStateMachine,
     MockingError,
     MockIncludeDirective,
+    MockRSTParser,
 )
 from .parse_directives import parse_directive_text, DirectiveParsingError
 from .parse_html import HTMLImgParser
@@ -370,7 +371,7 @@ class DocutilsRenderer:
             newdoc.settings = self.document.settings
             newdoc.reporter = self.reporter
             # actually parse the rst into our document
-            RSTParser().parse(token.content, newdoc)
+            MockRSTParser().parse(token.content, newdoc)
             for node in newdoc.traverse():
                 if node.line:
                     # keep line numbers aligned

--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -441,11 +441,10 @@ class MockIncludeDirective:
 
 
 class MockRSTParser(RSTParser):
-    """
-    RSTParser which avoids a negative side effect.
-    """
+    """RSTParser which avoids a negative side effect."""
 
-    def parse(self, *args, **kwargs):
+    def parse(self, inputstring: str, document: nodes.document):
+        """Parse the input to populate the document AST."""
         from docutils.parsers.rst import roles
 
         should_restore = False
@@ -453,7 +452,7 @@ class MockRSTParser(RSTParser):
             should_restore = True
             blankrole = roles._roles[""]
 
-        super().parse(*args, **kwargs)
+        super().parse(inputstring, document)
 
         if should_restore:
             roles._roles[""] = blankrole

--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -451,9 +451,9 @@ class MockRSTParser(RSTParser):
         should_restore = False
         if '' in roles._roles:
             should_restore = True
-            blankrole = roles._roles['']
+            blankrole = roles._roles[""]
 
         super().parse(*args, **kwargs)
 
         if should_restore:
-            roles._roles[''] = blankrole
+            roles._roles[""] = blankrole

--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -449,7 +449,7 @@ class MockRSTParser(RSTParser):
         from docutils.parsers.rst import roles
 
         should_restore = False
-        if '' in roles._roles:
+        if "" in roles._roles:
             should_restore = True
             blankrole = roles._roles[""]
 

--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -4,7 +4,7 @@ import sys
 from typing import List, Optional, Tuple, Type
 
 from docutils import nodes
-from docutils.parsers.rst import Directive, DirectiveError
+from docutils.parsers.rst import Directive, DirectiveError, Parser as RSTParser
 from docutils.parsers.rst.directives.misc import Include
 from docutils.parsers.rst.languages import get_language
 from docutils.parsers.rst.states import Inliner, RSTStateMachine, Body
@@ -438,3 +438,22 @@ class MockIncludeDirective:
                 del node["name"]
             node["names"].append(name)
             self.renderer.document.note_explicit_target(node, node)
+
+
+class MockRSTParser(RSTParser):
+    """
+    RSTParser which avoids a negative side effect.
+    """
+
+    def parse(self, *args, **kwargs):
+        from docutils.parsers.rst import roles
+
+        should_restore = False
+        if '' in roles._roles:
+            should_restore = True
+            blankrole = roles._roles['']
+
+        super().parse(*args, **kwargs)
+
+        if should_restore:
+            roles._roles[''] = blankrole

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,12 @@ setup(
             "beautifulsoup4",
         ],
         # Note: This is only required for internal use
-        "rtd": ["sphinxcontrib-bibtex", "ipython", "sphinx-book-theme", "sphinx_tabs"],
+        "rtd": [
+            "sphinxcontrib-bibtex",
+            "ipython",
+            "sphinx-book-theme>=0.0.36",
+            "sphinx_tabs",
+        ],
     },
     zip_safe=True,
 )

--- a/tests/test_renderers/fixtures/eval_rst.md
+++ b/tests/test_renderers/fixtures/eval_rst.md
@@ -1,6 +1,6 @@
 eval_rst link
 .
-```eval_rst
+```{eval_rst}
 `MyST Parser <https://myst-parser.readthedocs.io/>`_
 ```
 .
@@ -13,7 +13,7 @@ eval_rst link
 
 eval_rst bold
 .
-```eval_rst
+```{eval_rst}
 **bold**
 .
 <document source="notset">

--- a/tests/test_renderers/fixtures/eval_rst.md
+++ b/tests/test_renderers/fixtures/eval_rst.md
@@ -1,0 +1,23 @@
+eval_rst link
+.
+```eval_rst
+`MyST Parser <https://myst-parser.readthedocs.io/>`_
+```
+.
+<document source="notset">
+    <paragraph>
+        <reference name="MyST Parser" refuri="https://myst-parser.readthedocs.io/">
+            MyST Parser
+        <target ids="myst-parser" names="myst\ parser" refuri="https://myst-parser.readthedocs.io/">
+.
+
+eval_rst bold
+.
+```eval_rst
+**bold**
+.
+<document source="notset">
+    <paragraph>
+        <strong>
+            bold
+.

--- a/tests/test_renderers/fixtures/eval_rst.md
+++ b/tests/test_renderers/fixtures/eval_rst.md
@@ -1,6 +1,6 @@
-eval_rst link
+eval-rst link
 .
-```{eval_rst}
+```{eval-rst}
 `MyST Parser <https://myst-parser.readthedocs.io/>`_
 ```
 .
@@ -11,9 +11,9 @@ eval_rst link
         <target ids="myst-parser" names="myst\ parser" refuri="https://myst-parser.readthedocs.io/">
 .
 
-eval_rst bold
+eval-rst bold
 .
-```{eval_rst}
+```{eval-rst}
 **bold**
 .
 <document source="notset">

--- a/tests/test_renderers/fixtures/reporter_warnings.md
+++ b/tests/test_renderers/fixtures/reporter_warnings.md
@@ -84,16 +84,12 @@ lines
 
 .. unknown:: some text
 
-.. automodule:: idontexist
-   :members:
+:unknown:`a`
 ```
 .
 source/path:10: (ERROR/3) Unknown directive type "unknown".
 
 .. unknown:: some text
 
-source/path:12: (ERROR/3) Unknown directive type "automodule".
-
-.. automodule:: idontexist
-   :members:
+source/path:12: (ERROR/3) Unknown interpreted text role "unknown".
 .

--- a/tests/test_renderers/fixtures/reporter_warnings.md
+++ b/tests/test_renderers/fixtures/reporter_warnings.md
@@ -71,3 +71,29 @@ Non-consecutive headings:
 .
 source/path:2: (WARNING/2) Non-consecutive header level increase; 1 to 3
 .
+Warnings in eval-rst
+.
+some external
+
+lines
+
+```{eval-rst}
+some internal
+
+lines
+
+.. unknown:: some text
+
+.. automodule:: idontexist
+   :members:
+```
+.
+source/path:10: (ERROR/3) Unknown directive type "unknown".
+
+.. unknown:: some text
+
+source/path:12: (ERROR/3) Unknown directive type "automodule".
+
+.. automodule:: idontexist
+   :members:
+.

--- a/tests/test_renderers/test_fixtures.py
+++ b/tests/test_renderers/test_fixtures.py
@@ -148,3 +148,15 @@ def test_containers(line, title, input, expected, monkeypatch):
         for text in (document.pformat(), expected)
     ]
     assert _actual == _expected
+
+
+@pytest.mark.parametrize(
+    "line,title,input,expected",
+    read_fixture_file(FIXTURE_PATH.joinpath("eval_rst.md")),
+)
+def test_evalrst_elements(line, title, input, expected):
+    document = to_docutils(input, in_sphinx_env=True)
+    print(document.pformat())
+    assert "\n".join(
+        [ll.rstrip() for ll in document.pformat().splitlines()]
+    ) == "\n".join([ll.rstrip() for ll in expected.splitlines()])

--- a/tests/test_sphinx/sourcedirs/references/index.md
+++ b/tests/test_sphinx/sourcedirs/references/index.md
@@ -20,14 +20,14 @@
 
 [nested *syntax*](index.md)
 
-```{eval_rst}
+```{eval-rst}
 .. _insidecodeblock:
 
-I'm inside the eval_rst fence
+I am inside the eval-rst fence
 
 Referencing the :ref:`title`
 
 Still inside the codeblock insidecodeblock_
 ```
 
-I'm outside the [fence](insidecodeblock)
+I am outside the [fence](insidecodeblock)

--- a/tests/test_sphinx/sourcedirs/references/index.md
+++ b/tests/test_sphinx/sourcedirs/references/index.md
@@ -19,3 +19,15 @@
 [plain text](index.md)
 
 [nested *syntax*](index.md)
+
+```{eval_rst}
+.. _insidecodeblock:
+
+I'm inside the eval_rst fence
+
+Referencing the :ref:`title`
+
+Still inside the codeblock insidecodeblock_
+```
+
+I'm outside the [fence](insidecodeblock)

--- a/tests/test_sphinx/test_sphinx_builds/test_references.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.html
@@ -81,6 +81,23 @@
       </span>
      </a>
     </p>
+    <p id="insidecodeblock">
+     I’m inside the eval_rst fence
+    </p>
+    <p>
+     Referencing the
+     <a class="reference internal" href="#title">
+      <span class="std std-ref">
+       Title with nested a=1
+      </span>
+     </a>
+    </p>
+    <p>
+     Still inside the codeblock
+     <a class="reference internal" href="#insidecodeblock">
+      insidecodeblock
+     </a>
+    </p>
    </div>
   </div>
  </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_references.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.html
@@ -98,6 +98,14 @@
       insidecodeblock
      </a>
     </p>
+    <p>
+     I’m outside the
+     <a class="reference internal" href="#insidecodeblock">
+      <span class="std std-ref">
+       fence
+      </span>
+     </a>
+    </p>
    </div>
   </div>
  </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_references.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.html
@@ -82,7 +82,7 @@
      </a>
     </p>
     <p id="insidecodeblock">
-     I’m inside the eval_rst fence
+     I am inside the eval-rst fence
     </p>
     <p>
      Referencing the
@@ -99,7 +99,7 @@
      </a>
     </p>
     <p>
-     I’m outside the
+     I am outside the
      <a class="reference internal" href="#insidecodeblock">
       <span class="std std-ref">
        fence

--- a/tests/test_sphinx/test_sphinx_builds/test_references.resolved.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.resolved.xml
@@ -46,22 +46,20 @@
                     nested 
                     <emphasis>
                         syntax
-
         <target refid="insidecodeblock">
         <paragraph ids="insidecodeblock" names="insidecodeblock">
             I’m inside the eval_rst fence
         <paragraph>
-            Referencing the
+            Referencing the 
             <reference internal="True" refid="title">
                 <inline classes="std std-ref">
                     Title with nested a=1
         <paragraph>
-            Still inside the codeblock
+            Still inside the codeblock 
             <reference name="insidecodeblock" refid="insidecodeblock">
-                 insidecodeblock
-
+                insidecodeblock
         <paragraph>
-            I’m outside the
+            I’m outside the 
             <reference internal="True" refid="insidecodeblock">
                 <inline classes="std std-ref">
                     fence

--- a/tests/test_sphinx/test_sphinx_builds/test_references.resolved.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.resolved.xml
@@ -48,7 +48,7 @@
                         syntax
         <target refid="insidecodeblock">
         <paragraph ids="insidecodeblock" names="insidecodeblock">
-            I’m inside the eval_rst fence
+            I am inside the eval-rst fence
         <paragraph>
             Referencing the 
             <reference internal="True" refid="title">
@@ -59,7 +59,7 @@
             <reference name="insidecodeblock" refid="insidecodeblock">
                 insidecodeblock
         <paragraph>
-            I’m outside the 
+            I am outside the 
             <reference internal="True" refid="insidecodeblock">
                 <inline classes="std std-ref">
                     fence

--- a/tests/test_sphinx/test_sphinx_builds/test_references.resolved.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.resolved.xml
@@ -46,3 +46,22 @@
                     nested 
                     <emphasis>
                         syntax
+
+        <target refid="insidecodeblock">
+        <paragraph ids="insidecodeblock" names="insidecodeblock">
+            I’m inside the eval_rst fence
+        <paragraph>
+            Referencing the
+            <reference internal="True" refid="title">
+                <inline classes="std std-ref">
+                    Title with nested a=1
+        <paragraph>
+            Still inside the codeblock
+            <reference name="insidecodeblock" refid="insidecodeblock">
+                 insidecodeblock
+
+        <paragraph>
+            I’m outside the
+            <reference internal="True" refid="insidecodeblock">
+                <inline classes="std std-ref">
+                    fence

--- a/tests/test_sphinx/test_sphinx_builds/test_references.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.xml
@@ -46,7 +46,7 @@
                         syntax
         <target refid="insidecodeblock">
         <paragraph ids="insidecodeblock" names="insidecodeblock">
-            I’m inside the eval_rst fence
+            I am inside the eval-rst fence
         <paragraph>
             Referencing the 
             <pending_xref refdoc="index" refdomain="std" refexplicit="False" reftarget="title" reftype="ref" refwarn="True">
@@ -57,7 +57,7 @@
             <reference name="insidecodeblock" refid="insidecodeblock">
                 insidecodeblock
         <paragraph>
-            I’m outside the 
+            I am outside the 
             <pending_xref refdomain="True" refexplicit="True" reftarget="insidecodeblock" reftype="myst" refwarn="True">
                 <inline classes="xref myst">
                     fence

--- a/tests/test_sphinx/test_sphinx_builds/test_references.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.xml
@@ -44,22 +44,20 @@
                     nested 
                     <emphasis>
                         syntax
-
         <target refid="insidecodeblock">
         <paragraph ids="insidecodeblock" names="insidecodeblock">
             I’m inside the eval_rst fence
         <paragraph>
-            Referencing the
-            <pending_xref refdomain="True" refexplicit="True" reftarget="title" reftype="myst" refwarn="True">
-                <inline classes="std std-ref">
-                    Title with nested a=1
+            Referencing the 
+            <pending_xref refdoc="index" refdomain="std" refexplicit="False" reftarget="title" reftype="ref" refwarn="True">
+                <inline classes="xref std std-ref">
+                    title
         <paragraph>
-            Still inside the codeblock
-            <pending_xref refdomain="True" refexplicit="True" reftarget="insidecodeblock" reftype="myst" refwarn="True">
-                 insidecodeblock
-
+            Still inside the codeblock 
+            <reference name="insidecodeblock" refid="insidecodeblock">
+                insidecodeblock
         <paragraph>
-            I’m outside the
+            I’m outside the 
             <pending_xref refdomain="True" refexplicit="True" reftarget="insidecodeblock" reftype="myst" refwarn="True">
-                <inline classes="std std-ref">
+                <inline classes="xref myst">
                     fence

--- a/tests/test_sphinx/test_sphinx_builds/test_references.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.xml
@@ -44,3 +44,22 @@
                     nested 
                     <emphasis>
                         syntax
+
+        <target refid="insidecodeblock">
+        <paragraph ids="insidecodeblock" names="insidecodeblock">
+            I’m inside the eval_rst fence
+        <paragraph>
+            Referencing the
+            <pending_xref refdomain="True" refexplicit="True" reftarget="title" reftype="myst" refwarn="True">
+                <inline classes="std std-ref">
+                    Title with nested a=1
+        <paragraph>
+            Still inside the codeblock
+            <pending_xref refdomain="True" refexplicit="True" reftarget="insidecodeblock" reftype="myst" refwarn="True">
+                 insidecodeblock
+
+        <paragraph>
+            I’m outside the
+            <pending_xref refdomain="True" refexplicit="True" reftarget="insidecodeblock" reftype="myst" refwarn="True">
+                <inline classes="std std-ref">
+                    fence

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@
 # then then deleting compiled files has been found to fix it: `find . -name \*.pyc -delete`
 
 [tox]
-envlist = py{36,37,38}-sphinx{2,3},docs
+envlist = py{36,37,38}-sphinx{2,3}
 
 [testenv]
 # only recreate the environment when we use `tox -r`
@@ -24,9 +24,11 @@ deps =
     sphinx3: sphinx>=3,<4
 commands = pytest {posargs}
 
-[testenv:docs]
+[testenv:docs-{update,clean}]
 extras = rtd
+deps =
+    ipython<=7.11.0  # required by coconut
 whitelist_externals = rm
 commands =
-    rm -rf docs/_build
-    sphinx-build -nW --keep-going -b html docs/ docs/_build/html
+    clean: rm -rf docs/_build
+    sphinx-build {posargs} -nW --keep-going -b html docs/ docs/_build/html


### PR DESCRIPTION
Adds support the `eval-rst` directive, similar to recommonmark's version.  Fixes #164.

Examples (which I added unit tests for):

Links:

    ```{eval-rst}
    `MyST Parser <https://myst-parser.readthedocs.io/>`_
     ```

Bold text:

    ```{eval-rst}
    **bold**
     ```

Or as I'll use it in [ParlAI](https://github.com/facebookresearch/parlai). I tested this in my own repo.

    ```{eval-rst}
    .. automodule:: parlai.utils.bpe
       :members:
    ```
