### PR TITLE
👌 IMPROVE: mathjax_config override

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,5 +6,5 @@ coverage:
         threshold: 0.5%
     patch:
       default:
-        target: 85%
+        target: 80%
         threshold: 0.5%

--- a/docs/using/intro.md
+++ b/docs/using/intro.md
@@ -271,9 +271,9 @@ Math specific, see the [Math syntax](syntax/math) for more details:
 * - `myst_amsmath_enable`
   - `False`
   - Enable direct parsing of [amsmath LaTeX environments](https://ctan.org/pkg/amsmath)
-* - `myst_override_mathjax`
+* - `myst_update_mathjax`
   - `True`
-  - If using [sphinx.ext.mathjax](https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.mathjax) (the default) then `mathjax_config` will be overridden,
+  - If using [sphinx.ext.mathjax](https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.mathjax) (the default) then `mathjax_config` will be updated,
   to ignore `$` delimiters and LaTeX environments, which should instead be handled by
   `myst_dmath_enable` and `myst_amsmath_enable` respectively.
 `````

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -759,22 +759,20 @@ See [the extended syntax option](syntax/amsmath).
 
 When building HTML using the [sphinx.ext.mathjax](https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.mathjax) extension (enabled by default), its default configuration is to also search for `$` delimiters and LaTeX environments (see [the tex2jax preprocessor](https://docs.mathjax.org/en/v2.7-latest/options/preprocessors/tex2jax.html#configure-tex2jax)).
 
-Since such parsing is already covered by the plugins above, MyST-Parser disables this behaviour by overriding the `mathjax_config` option with:
+Since such parsing is already covered by the plugins above, MyST-Parser disables this behaviour by overriding the `mathjax_config['tex2jax']` option with:
 
 ```python
-mathjax_config = {
-  "tex2jax": {
+mathjax_config["tex2jax"] = {
   "inlineMath": [["\\(", "\\)"]],
   "displayMath": [["\\[", "\\]"]],
   "processRefs": False,
   "processEnvironments": False,
-  }
 }
 ```
 
 Since these delimiters are how `sphinx.ext.mathjax` wraps the math content in the built HTML documents.
 
-To inhibit this override, set `myst_override_mathjax=False`.
+To inhibit this override, set `myst_update_mathjax=False`.
 
 (syntax/frontmatter)=
 

--- a/myst_parser/__init__.py
+++ b/myst_parser/__init__.py
@@ -52,7 +52,7 @@ def create_myst_config(app):
         app.env.myst_config = MdParserConfig()
 
     # https://docs.mathjax.org/en/v2.7-latest/options/preprocessors/tex2jax.html#configure-tex2jax
-    if app.env.myst_config.override_mathjax:
+    if app.config.mathjax_config is None and app.env.myst_config.update_mathjax:
         app.config.mathjax_config = {
             "tex2jax": {
                 "inlineMath": [["\\(", "\\)"]],
@@ -60,4 +60,17 @@ def create_myst_config(app):
                 "processRefs": False,
                 "processEnvironments": False,
             }
+        }
+    elif app.env.myst_config.update_mathjax:
+        if "tex2jax" in app.config.mathjax_config:
+            logger.warning(
+                "`mathjax_config['tex2jax']` is set, but `myst_update_mathjax` is True,"
+                " and so this will be overridden. "
+                "Set `myst_update_mathjax = False` if you wish to use your own config"
+            )
+        app.config.mathjax_config["tex2jax"] = {
+            "inlineMath": [["\\(", "\\)"]],
+            "displayMath": [["\\[", "\\]"]],
+            "processRefs": False,
+            "processEnvironments": False,
         }

--- a/myst_parser/__init__.py
+++ b/myst_parser/__init__.py
@@ -64,8 +64,8 @@ def create_myst_config(app):
     elif app.env.myst_config.update_mathjax:
         if "tex2jax" in app.config.mathjax_config:
             logger.warning(
-                "`mathjax_config['tex2jax']` is set, but `myst_update_mathjax` is True,"
-                " and so this will be overridden. "
+                "`mathjax_config['tex2jax']` is set, but `myst_update_mathjax = True`, "
+                "and so this will be overridden. "
                 "Set `myst_update_mathjax = False` if you wish to use your own config"
             )
         app.config.mathjax_config["tex2jax"] = {

--- a/myst_parser/main.py
+++ b/myst_parser/main.py
@@ -37,7 +37,7 @@ class MdParserConfig:
     amsmath_enable: bool = attr.ib(default=False, validator=instance_of(bool))
     deflist_enable: bool = attr.ib(default=False, validator=instance_of(bool))
 
-    override_mathjax: bool = attr.ib(default=True, validator=instance_of(bool))
+    update_mathjax: bool = attr.ib(default=True, validator=instance_of(bool))
 
     admonition_enable: bool = attr.ib(default=False, validator=instance_of(bool))
 

--- a/tests/test_sphinx/sourcedirs/extended_syntaxes/conf.py
+++ b/tests/test_sphinx/sourcedirs/extended_syntaxes/conf.py
@@ -2,5 +2,6 @@ extensions = ["myst_parser"]
 exclude_patterns = ["_build"]
 myst_disable_syntax = ["emphasis"]
 myst_dmath_allow_space = False
+mathjax_config = {}
 myst_amsmath_enable = True
 myst_deflist_enable = True


### PR DESCRIPTION
Instead of overriding all of `mathjax_config`, now only the "tex2jax" key will be added/replaced.
If the user has specifically set  `mathjax_config["tex2jax"]`, a warning will also be logged, that it is being overriden.