### PR TITLE
🐛 FIX: doc reference resolution for singlehtml/latex

### DIFF
--- a/docs/using/intro.md
+++ b/docs/using/intro.md
@@ -147,7 +147,7 @@ For those who are familiar with reStructuredText, here is the equivalent in rST:
 
 Note that almost all documentation in the Sphinx ecosystem is written with
 reStructuredText (MyST is only a few months old).
-That means you'll likely see examples that have rST structure. You can modify any rST to work with MyST. Use this page, and [the syntax page](syntax) to help guide you.
+That means you'll likely see examples that have rST structure. You can modify any rST to work with MyST. Use this page, and [the syntax page](./syntax.md) to help guide you.
 ````
 
 As seen above, there are four main parts to consider when writing directives.

--- a/myst_parser/myst_refs.py
+++ b/myst_parser/myst_refs.py
@@ -10,7 +10,7 @@ from typing import cast
 from docutils import nodes
 from docutils.nodes import document, Element
 
-from sphinx import addnodes
+from sphinx import addnodes, version_info
 from sphinx.addnodes import pending_xref
 from sphinx.locale import __
 from sphinx.transforms.post_transforms import ReferencesResolver
@@ -60,7 +60,11 @@ class MystReferenceResolver(ReferencesResolver):
                         self.env,
                         node,
                         contnode,
-                        allowed_exceptions=(NoUri,),
+                        **(
+                            dict(allowed_exceptions=(NoUri,))
+                            if version_info[0] > 2
+                            else {}
+                        ),
                     )
                     node["reftype"] = "myst"
                     # still not found? warn if node wishes to be warned about or

--- a/myst_parser/myst_refs.py
+++ b/myst_parser/myst_refs.py
@@ -56,7 +56,11 @@ class MystReferenceResolver(ReferencesResolver):
                     # this means it is picked up by extensions like intersphinx
                     node["reftype"] = "any"
                     newnode = self.app.emit_firstresult(
-                        "missing-reference", self.env, node, contnode
+                        "missing-reference",
+                        self.env,
+                        node,
+                        contnode,
+                        allowed_exceptions=(NoUri,),
                     )
                     node["reftype"] = "myst"
                     # still not found? warn if node wishes to be warned about or

--- a/myst_parser/sphinx_renderer.py
+++ b/myst_parser/sphinx_renderer.py
@@ -33,6 +33,7 @@ class SphinxRenderer(DocutilsRenderer):
     def handle_cross_reference(self, token, destination):
         """Create nodes for references that are not immediately resolvable."""
         wrap_node = addnodes.pending_xref(
+            refdoc=self.document.settings.env.docname,
             reftarget=unquote(destination),
             reftype="myst",
             refdomain=None,  # Added to enable cross-linking

--- a/tests/test_renderers/fixtures/syntax_elements.md
+++ b/tests/test_renderers/fixtures/syntax_elements.md
@@ -390,11 +390,11 @@ Title
         <title>
             Title
         <paragraph>
-            <pending_xref refdomain="True" refexplicit="True" reftarget="target" reftype="myst" refwarn="True">
+            <pending_xref refdoc="mock_docname" refdomain="True" refexplicit="True" reftarget="target" reftype="myst" refwarn="True">
                 <inline classes="xref myst">
                     alt1
         <paragraph>
-            <pending_xref refdomain="True" refexplicit="False" reftarget="target2" reftype="myst" refwarn="True">
+            <pending_xref refdoc="mock_docname" refdomain="True" refexplicit="False" reftarget="target2" reftype="myst" refwarn="True">
                 <inline classes="xref myst">
         <paragraph>
             <reference refuri="https://www.google.com">
@@ -489,7 +489,7 @@ Link Definition in directive:
 <document source="notset">
     <note>
         <paragraph>
-            <pending_xref refdomain="True" refexplicit="True" reftarget="link" reftype="myst" refwarn="True">
+            <pending_xref refdoc="mock_docname" refdomain="True" refexplicit="True" reftarget="link" reftype="myst" refwarn="True">
                 <inline classes="xref myst">
                     a
 .
@@ -514,7 +514,7 @@ Link Definition in nested directives:
     <note>
     <note>
         <paragraph>
-            <pending_xref refdomain="True" refexplicit="True" reftarget="link" reftype="myst" refwarn="True">
+            <pending_xref refdoc="mock_docname" refdomain="True" refexplicit="True" reftarget="link" reftype="myst" refwarn="True">
                 <inline classes="xref myst">
                     ref1
 
@@ -699,6 +699,6 @@ a = 1
         <literal_block language="::python" xml:space="preserve">
             a = 1
         <paragraph>
-            <pending_xref refdomain="True" refexplicit="False" reftarget="target" reftype="myst" refwarn="True">
+            <pending_xref refdoc="mock_docname" refdomain="True" refexplicit="False" reftarget="target" reftype="myst" refwarn="True">
                 <inline classes="xref myst">
 .

--- a/tests/test_renderers/test_myst_refs/duplicate.xml
+++ b/tests/test_renderers/test_myst_refs/duplicate.xml
@@ -3,5 +3,5 @@
         Title
     <target refid="index">
     <paragraph>
-        <pending_xref refdomain="True" refexplicit="False" reftarget="index" reftype="myst" refwarn="True">
+        <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="index" reftype="myst" refwarn="True">
             <inline classes="xref myst">

--- a/tests/test_renderers/test_myst_refs/missing.xml
+++ b/tests/test_renderers/test_myst_refs/missing.xml
@@ -1,4 +1,4 @@
 <document source="root/index.md">
     <paragraph>
-        <pending_xref refdomain="" refexplicit="False" reftarget="ref" reftype="myst" refwarn="True">
+        <pending_xref refdoc="index" refdomain="" refexplicit="False" reftarget="ref" reftype="myst" refwarn="True">
             <inline classes="xref myst">

--- a/tests/test_sphinx/sourcedirs/references_singlehtml/conf.py
+++ b/tests/test_sphinx/sourcedirs/references_singlehtml/conf.py
@@ -1,0 +1,5 @@
+extensions = [
+    "myst_parser",
+]
+master_doc = "index"
+exclude_patterns = ["_build"]

--- a/tests/test_sphinx/sourcedirs/references_singlehtml/index.md
+++ b/tests/test_sphinx/sourcedirs/references_singlehtml/index.md
@@ -1,0 +1,11 @@
+# Title
+
+```{toctree}
+other/index
+```
+
+{doc}`other/other`
+
+{any}`other/other`
+
+[](./other/other.md)

--- a/tests/test_sphinx/sourcedirs/references_singlehtml/other/index.md
+++ b/tests/test_sphinx/sourcedirs/references_singlehtml/other/index.md
@@ -1,0 +1,6 @@
+# Other Index
+
+```{toctree}
+other
+other2
+```

--- a/tests/test_sphinx/sourcedirs/references_singlehtml/other/other.md
+++ b/tests/test_sphinx/sourcedirs/references_singlehtml/other/other.md
@@ -1,0 +1,7 @@
+# Other Title
+
+{doc}`other2`
+
+{any}`other2`
+
+[](./other2.md)

--- a/tests/test_sphinx/sourcedirs/references_singlehtml/other/other2.md
+++ b/tests/test_sphinx/sourcedirs/references_singlehtml/other/other2.md
@@ -1,0 +1,1 @@
+# Other 2 Title

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -44,7 +44,7 @@ def test_references(
     get_sphinx_app_output,
     remove_sphinx_builds,
 ):
-    """basic test."""
+    """Test reference resolution."""
     app.build()
 
     assert "build succeeded" in status.getvalue()  # Build succeeded
@@ -70,7 +70,7 @@ def test_references_singlehtml(
     get_sphinx_app_output,
     remove_sphinx_builds,
 ):
-    """basic test."""
+    """Test reference resolution for singlehtml builds."""
     app.build()
 
     assert "build succeeded" in status.getvalue()  # Build succeeded

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -57,6 +57,42 @@ def test_references(
 
 
 @pytest.mark.sphinx(
+    buildername="singlehtml",
+    srcdir=os.path.join(SOURCE_DIR, "references_singlehtml"),
+    freshenv=True,
+    confoverrides={"nitpicky": True},
+)
+def test_references_singlehtml(
+    app,
+    status,
+    warning,
+    get_sphinx_app_doctree,
+    get_sphinx_app_output,
+    remove_sphinx_builds,
+):
+    """basic test."""
+    app.build()
+
+    assert "build succeeded" in status.getvalue()  # Build succeeded
+    warnings = warning.getvalue().strip()
+    assert warnings == ""
+
+    # try:
+    #     get_sphinx_app_doctree(app, docname="index", regress=True)
+    # finally:
+    #     get_sphinx_app_doctree(app, docname="index", resolve=True, regress=True)
+
+    try:
+        get_sphinx_app_doctree(app, docname="other/other", regress=True)
+    finally:
+        get_sphinx_app_doctree(app, docname="other/other", resolve=True, regress=True)
+
+    get_sphinx_app_output(
+        app, filename="index.html", buildername="singlehtml", regress_html=True
+    )
+
+
+@pytest.mark.sphinx(
     buildername="html",
     srcdir=os.path.join(SOURCE_DIR, "extended_syntaxes"),
     freshenv=True,

--- a/tests/test_sphinx/test_sphinx_builds/test_includes.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_includes.xml
@@ -37,7 +37,7 @@
             <paragraph>
                 <image alt="alt" candidates="{'?': 'https://example.com'}" uri="https://example.com">
             <paragraph>
-                <pending_xref refdomain="True" refexplicit="True" reftarget="index.md" reftype="myst" refwarn="True">
+                <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="index.md" reftype="myst" refwarn="True">
                     <inline classes="xref myst">
                         text
             <paragraph>

--- a/tests/test_sphinx/test_sphinx_builds/test_references.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.xml
@@ -19,27 +19,27 @@
                 <emphasis>
                     syntax
         <paragraph>
-            <pending_xref refdomain="True" refexplicit="False" reftarget="title" reftype="myst" refwarn="True">
+            <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="title" reftype="myst" refwarn="True">
                 <inline classes="xref myst">
         <paragraph>
-            <pending_xref refdomain="True" refexplicit="True" reftarget="title" reftype="myst" refwarn="True">
+            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="title" reftype="myst" refwarn="True">
                 <inline classes="xref myst">
                     plain text
         <paragraph>
-            <pending_xref refdomain="True" refexplicit="True" reftarget="title" reftype="myst" refwarn="True">
+            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="title" reftype="myst" refwarn="True">
                 <inline classes="xref myst">
                     nested 
                     <emphasis>
                         syntax
         <paragraph>
-            <pending_xref refdomain="True" refexplicit="False" reftarget="index.md" reftype="myst" refwarn="True">
+            <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="index.md" reftype="myst" refwarn="True">
                 <inline classes="xref myst">
         <paragraph>
-            <pending_xref refdomain="True" refexplicit="True" reftarget="index.md" reftype="myst" refwarn="True">
+            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="index.md" reftype="myst" refwarn="True">
                 <inline classes="xref myst">
                     plain text
         <paragraph>
-            <pending_xref refdomain="True" refexplicit="True" reftarget="index.md" reftype="myst" refwarn="True">
+            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="index.md" reftype="myst" refwarn="True">
                 <inline classes="xref myst">
                     nested 
                     <emphasis>
@@ -58,6 +58,6 @@
                 insidecodeblock
         <paragraph>
             I am outside the 
-            <pending_xref refdomain="True" refexplicit="True" reftarget="insidecodeblock" reftype="myst" refwarn="True">
+            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="insidecodeblock" reftype="myst" refwarn="True">
                 <inline classes="xref myst">
                     fence

--- a/tests/test_sphinx/test_sphinx_builds/test_references_singlehtml.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_references_singlehtml.html
@@ -1,0 +1,90 @@
+<div class="documentwrapper">
+ <div class="bodywrapper">
+  <div class="body" role="main">
+   <div class="section" id="title">
+    <h1>
+     Title
+     <a class="headerlink" href="#title" title="Permalink to this headline">
+      ¶
+     </a>
+    </h1>
+    <div class="toctree-wrapper compound">
+     <span id="document-other/index">
+     </span>
+     <div class="section" id="other-index">
+      <h2>
+       Other Index
+       <a class="headerlink" href="#other-index" title="Permalink to this headline">
+        ¶
+       </a>
+      </h2>
+      <div class="toctree-wrapper compound">
+       <span id="document-other/other">
+       </span>
+       <div class="section" id="other-title">
+        <h3>
+         Other Title
+         <a class="headerlink" href="#other-title" title="Permalink to this headline">
+          ¶
+         </a>
+        </h3>
+        <p>
+         <a class="reference internal" href="index.html#document-other/other2">
+          <span class="doc">
+           Other 2 Title
+          </span>
+         </a>
+        </p>
+        <p>
+         <a class="reference internal" href="index.html#document-other/other2">
+          <span class="doc">
+           Other 2 Title
+          </span>
+         </a>
+        </p>
+        <p>
+         <a class="reference internal" href="index.html#document-other/other2">
+          <span class="doc std std-doc">
+           Other 2 Title
+          </span>
+         </a>
+        </p>
+       </div>
+       <span id="document-other/other2">
+       </span>
+       <div class="section" id="other-2-title">
+        <h3>
+         Other 2 Title
+         <a class="headerlink" href="#other-2-title" title="Permalink to this headline">
+          ¶
+         </a>
+        </h3>
+       </div>
+      </div>
+     </div>
+    </div>
+    <p>
+     <a class="reference internal" href="index.html#document-other/other">
+      <span class="doc">
+       Other Title
+      </span>
+     </a>
+    </p>
+    <p>
+     <a class="reference internal" href="index.html#document-other/other">
+      <span class="doc">
+       Other Title
+      </span>
+     </a>
+    </p>
+    <p>
+     <a class="reference internal" href="index.html#document-other/other">
+      <span class="doc std std-doc">
+       Other Title
+      </span>
+     </a>
+    </p>
+   </div>
+  </div>
+ </div>
+</div>

--- a/tests/test_sphinx/test_sphinx_builds/test_references_singlehtml.resolved.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references_singlehtml.resolved.xml
@@ -1,0 +1,16 @@
+<document source="other.md">
+    <section ids="other-title" names="other\ title">
+        <title>
+            Other Title
+        <paragraph>
+            <reference internal="True" refuri="index.html#document-other/other2">
+                <inline classes="doc">
+                    Other 2 Title
+        <paragraph>
+            <reference internal="True" refuri="index.html#document-other/other2">
+                <inline classes="doc doc doc">
+                    Other 2 Title
+        <paragraph>
+            <reference internal="True" refuri="index.html#document-other/other2">
+                <inline classes="doc std std-doc">
+                    Other 2 Title

--- a/tests/test_sphinx/test_sphinx_builds/test_references_singlehtml.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references_singlehtml.xml
@@ -1,0 +1,15 @@
+<document source="other.md">
+    <section ids="other-title" names="other\ title">
+        <title>
+            Other Title
+        <paragraph>
+            <pending_xref refdoc="other/other" refdomain="std" refexplicit="False" reftarget="other2" reftype="doc" refwarn="True">
+                <inline classes="xref std std-doc">
+                    other2
+        <paragraph>
+            <pending_xref refdoc="other/other" refdomain="" refexplicit="False" reftarget="other2" reftype="any" refwarn="True">
+                <literal classes="xref any">
+                    other2
+        <paragraph>
+            <pending_xref refdoc="other/other" refdomain="True" refexplicit="False" reftarget="./other2.md" reftype="myst" refwarn="True">
+                <inline classes="xref myst">

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@
 # then then deleting compiled files has been found to fix it: `find . -name \*.pyc -delete`
 
 [tox]
-envlist = py{36,37,38}-sphinx{2,3}
+envlist = py37-sphinx3
 
 [testenv]
 # only recreate the environment when we use `tox -r`
@@ -26,9 +26,7 @@ commands = pytest {posargs}
 
 [testenv:docs-{update,clean}]
 extras = rtd
-deps =
-    ipython<=7.11.0  # required by coconut
 whitelist_externals = rm
 commands =
     clean: rm -rf docs/_build
-    sphinx-build {posargs} -nW --keep-going -b html docs/ docs/_build/html
+    sphinx-build -nW --keep-going -b {posargs:html} docs/ docs/_build/{posargs:html}


### PR DESCRIPTION
These reference resolutions are passed to the "missing-reference" event, and require the `node["refdoc"]` attribute to be available, which was missing for `[text](./path/to/file.md)` type references.