### PR TITLE
[🐛 FIX,  📚 DOCS] Typo `myst-paser` -> `myst-parser`

### DIFF
--- a/docs/using/syntax-optional.md
+++ b/docs/using/syntax-optional.md
@@ -62,7 +62,7 @@ This text is **standard** _Markdown_
 ## Auto-generated header anchors
 
 A common, extended Markdown syntax is to use header bookmark links, locally; `[](#header-anchor)`, or cross-file `[](path/to/file.md#header-anchor)`.
-To achieve this, section headings must be assigned anchors, which can be achieved in `myst-paser`,
+To achieve this, section headings must be assigned anchors, which can be achieved in `myst-parser`,
 by setting `myst_heading_anchors = 2` in your `conf.py`.
 This configures heading anchors to be assigned to both `h1` and `h2` level headings.
 The anchor "slugs" created aim to follow the [GitHub implementation](https://github.com/Flet/github-slugger); lower-case text, removing punctuation, replacing spaces with `-`, uniqueness *via* suffix enumeration `-1`.


### PR DESCRIPTION
Fix a (presumed) typo.

