### PR TITLE
🐛 FIX: allow dates to be parsed in frontmatter

### DIFF
--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 from typing import List
+from datetime import date
 
 import yaml
 
@@ -937,7 +938,7 @@ def dict_to_docinfo(data):
     docinfo = nodes.docinfo()
 
     for key, value in data.items():
-        if not isinstance(value, (str, int, float)):
+        if not isinstance(value, (str, int, float, date)):
             value = json.dumps(value)
         value = str(value)
         field_node = nodes.field()

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -6,7 +6,7 @@ import json
 import os
 import re
 from typing import List
-from datetime import date
+from datetime import date, datetime
 
 import yaml
 
@@ -938,7 +938,7 @@ def dict_to_docinfo(data):
     docinfo = nodes.docinfo()
 
     for key, value in data.items():
-        if not isinstance(value, (str, int, float, date)):
+        if not isinstance(value, (str, int, float, date, datetime)):
             value = json.dumps(value)
         value = str(value)
         field_node = nodes.field()


### PR DESCRIPTION
This is a small fix to prevent front-matter dates from breaking the docutils parser.

@chrisjsewell could you recommend where a test should go for this?

closes https://github.com/executablebooks/MyST-Parser/issues/252