### PR TITLE
🚀 RELEASE: v0.12.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.10 - 2020-09-21
+
+🐛 FIX: allow dates to be parsed in frontmatter.
+: This fixes a bug that would raise errors at parse time if non-string date objects were in front-matter YAML. See [#253](https://github.com/executablebooks/MyST-Parser/pull/253)
+
 ## 0.12.9 - 2020-09-08
 
 ✨ NEW: Auto-generate heading anchors.

--- a/myst_parser/__init__.py
+++ b/myst_parser/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.12.9"
+__version__ = "0.12.10"
 
 
 def setup(app):


### PR DESCRIPTION
This brings in the datetime bugfix...the only other PRs were documentation typo fixes I believe