### PR TITLE
[TST] add test for multiple arguments in index directive

### DIFF
--- a/tests/test_renderers/fixtures/sphinx_directives.md
+++ b/tests/test_renderers/fixtures/sphinx_directives.md
@@ -127,6 +127,19 @@ index (`sphinx.directives.other.Index`):
 .
 
 --------------------------------
+index (`sphinx.directives.other.Index`):
+.
+```{index}
+single: Python; Runtime
+single: Julia
+```
+.
+<document source="notset">
+    <index entries="('single',\ 'Python;\ Runtime',\ 'index-0',\ '',\ None) ('single',\ 'Julia',\ 'index-0',\ '',\ None)" inline="False">
+    <target refid="index-0">
+.
+
+--------------------------------
 seealso (`sphinx.directives.other.SeeAlso`):
 .
 ```{seealso}


### PR DESCRIPTION
Adds a test case for multiple arguments for `index` directive. 

@chrisjsewell is the parsing of arguments done here or in `markdown_it_py`?