### PR TITLE
📚 DOCS: `link to contributing guide in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![Conda][conda-badge]][conda-link]
 [![PyPI - Downloads][install-badge]][install-link]
 
-An extended commonmark compliant parser, with bridges to docutils & sphinx.
+An extended [CommonMark](https://commonmark.org)-compliant parser, with bridges to [Docutils](https://docutils.sourceforge.io) and [Sphinx](https://www.sphinx-doc.org).
 
 ## Usage
 
@@ -39,7 +39,7 @@ To use the MyST parser in Sphinx, simply add: `extensions = ["myst_parser"]` to 
 ## Contributing
 
 We welcome all contributions!
-See the [Contributing Guide](https://myst-parser.readthedocs.io/en/latest/master/contributing.html) for more details.
+See the [Contributing Guide](https://myst-parser.readthedocs.io/en/latest/develop/index.html) for more details.
 
 [github-ci]: https://github.com/executablebooks/MyST-Parser/workflows/continuous-integration/badge.svg?branch=master
 [github-link]: https://github.com/executablebooks/MyST-Parser


### PR DESCRIPTION
Along the way, fix capitalization and add a few more links:
CommonMark, Docutils, Sphinx.

For the contributing guide url I used "index.html"

https://myst-parser.readthedocs.io/en/latest/develop/index.html

Alternatively one could just replace "master" with "develop"
in the former url, and point to "contributing.html":

https://myst-parser.readthedocs.io/en/latest/develop/contributing.html

Pros and cons of each choice. The page "index.html" links
to the code of conduct of the Executable Book Project and
to the page "contributing.html". The page "contributing.html"
links to the Executable Book Project's contributing guide.
