### PR TITLE
🔧 MAINT: pin sphinxcontrib-bibtex & fix deprecated doc config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,6 @@ html_title = ""
 html_theme_options = {
     "github_url": "https://github.com/executablebooks/MyST-Parser",
     "repository_url": "https://github.com/executablebooks/MyST-Parser",
-    "expand_sections": ["examples/index"],
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         ],
         # Note: This is only required for internal use
         "rtd": [
-            "sphinxcontrib-bibtex<2.0.0",
+            "sphinxcontrib-bibtex~=1.0.0",
             "ipython",
             "sphinx-book-theme>=0.0.36",
             "sphinx_tabs",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         ],
         # Note: This is only required for internal use
         "rtd": [
-            "sphinxcontrib-bibtex",
+            "sphinxcontrib-bibtex<2.0.0",
             "ipython",
             "sphinx-book-theme>=0.0.36",
             "sphinx_tabs",


### PR DESCRIPTION
Bump into this in #274 so pinning as mentioned in https://github.com/executablebooks/MyST-Parser/pull/274#issuecomment-748017517.