### PR TITLE
👌 IMPROVE: `MdParserConfig.substitutions`

### DIFF
--- a/myst_parser/main.py
+++ b/myst_parser/main.py
@@ -98,7 +98,7 @@ class MdParserConfig:
     substitutions: Dict[str, str] = attr.ib(
         factory=dict,
         validator=deep_mapping(instance_of(str), instance_of(str), instance_of(dict)),
-        repr=lambda v: str(list(v))
+        repr=lambda v: str(list(v)),
     )
 
     sub_delimiters: Tuple[str, str] = attr.ib(default=("{", "}"))

--- a/myst_parser/main.py
+++ b/myst_parser/main.py
@@ -97,7 +97,7 @@ class MdParserConfig:
 
     substitutions: Dict[str, str] = attr.ib(
         factory=dict,
-        validator=deep_mapping(instance_of(str), instance_of(str), instance_of(dict)),
+        validator=deep_mapping(instance_of(str), instance_of((str, int, float)), instance_of(dict)),
         repr=lambda v: str(list(v)),
     )
 

--- a/myst_parser/main.py
+++ b/myst_parser/main.py
@@ -98,6 +98,7 @@ class MdParserConfig:
     substitutions: Dict[str, str] = attr.ib(
         factory=dict,
         validator=deep_mapping(instance_of(str), instance_of(str), instance_of(dict)),
+        repr=lambda v: str(list(v))
     )
 
     sub_delimiters: Tuple[str, str] = attr.ib(default=("{", "}"))

--- a/myst_parser/main.py
+++ b/myst_parser/main.py
@@ -97,7 +97,9 @@ class MdParserConfig:
 
     substitutions: Dict[str, str] = attr.ib(
         factory=dict,
-        validator=deep_mapping(instance_of(str), instance_of((str, int, float)), instance_of(dict)),
+        validator=deep_mapping(
+            instance_of(str), instance_of((str, int, float)), instance_of(dict)
+        ),
         repr=lambda v: str(list(v)),
     )
 


### PR DESCRIPTION
Show only names of substitutions, rather than the full key/value dictionary