### PR TITLE
👌 IMPROVE: Error msg for unimplemented directives

### DIFF
--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -243,6 +243,8 @@ class MockState:
                 "https://myst-parser.readthedocs.io/en/latest/using/syntax.html#how-directives-parse-content"  # noqa: E501
             )
         else:
+            # The requested `name` is not a docutils Body element
+            # (such as "footnote", "block_quote", "paragraph", …)
             msg = f"{cls} has no attribute '{name}'"
         raise MockingError(msg).with_traceback(sys.exc_info()[2])
 

--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -240,7 +240,7 @@ class MockState:
             msg = (
                 f"{cls} has not yet implemented attribute '{name}'. "
                 "You can parse RST directly via the `{eval-rst}` directive: "
-                "https://myst-parser.readthedocs.io/en/latest/using/syntax.html#how-directives-parse-content"
+                "https://myst-parser.readthedocs.io/en/latest/using/syntax.html#how-directives-parse-content"  # noqa: E501
             )
         else:
             msg = f"{cls} has no attribute '{name}'"

--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -235,12 +235,15 @@ class MockState:
         """This method is only be called if the attribute requested has not
         been defined. Defined attributes will not be overridden.
         """
+        cls = type(self).__name__
         if hasattr(Body, name):
-            msg = "{cls} has not yet implemented attribute '{name}'".format(
-                cls=type(self).__name__, name=name
+            msg = (
+                f"{cls} has not yet implemented attribute '{name}'. "
+                "You can parse RST directly via the `{eval-rst}` directive: "
+                "https://myst-parser.readthedocs.io/en/latest/using/syntax.html#how-directives-parse-content"
             )
-            raise MockingError(msg).with_traceback(sys.exc_info()[2])
-        msg = "{cls} has no attribute {name}".format(cls=type(self).__name__, name=name)
+        else:
+            msg = f"{cls} has no attribute '{name}'"
         raise MockingError(msg).with_traceback(sys.exc_info()[2])
 
 


### PR DESCRIPTION
Suggest using `{eval-rst}` and link to its documentation.

As suggested in https://github.com/executablebooks/MyST-Parser/issues/284#issuecomment-756434092