### PR TITLE
🐛 FIX: convert directive option values to string

### DIFF
--- a/myst_parser/parse_directives.py
+++ b/myst_parser/parse_directives.py
@@ -154,7 +154,7 @@ def parse_directive_options(
                 value = str(value)
             else:
                 raise DirectiveParsingError(
-                    f'option "{name}"s value not string (enclose with ""): {value}'
+                    f'option "{name}" value not string (enclose with ""): {value}'
                 )
         try:
             converted_value = convertor(value)

--- a/myst_parser/parse_directives.py
+++ b/myst_parser/parse_directives.py
@@ -33,6 +33,7 @@ from the content.
 This is to allow for separation between the option block and content.
 
 """
+import datetime
 import re
 from textwrap import dedent
 from typing import Callable, Dict, Type
@@ -143,14 +144,19 @@ def parse_directive_options(
     options_spec = directive_class.option_spec  # type: Dict[str, Callable]
     for name, value in list(options.items()):
         convertor = options_spec.get(name, None)
+        if convertor is None:
+            raise DirectiveParsingError(f"Unknown option: {name}")
         if value is True or value is None:
             value = ""  # flag converter requires no argument
-        if convertor is None:
-            raise DirectiveParsingError("Unknown option: {}".format(name))
+        if isinstance(value, (int, float, datetime.date, datetime.datetime)):
+            # convertor always requires string input
+            value = str(value)
+        if not isinstance(value, str):
+            raise DirectiveParsingError(
+                f'option "{name}"s value not string (enclose with ""): {value}'
+            )
         try:
-            converted_value = convertor(
-                str(value)
-            )  # convertor always requires string input
+            converted_value = convertor(value)
         except (ValueError, TypeError) as error:
             raise DirectiveParsingError(
                 "Invalid option value: (option: '{}'; value: {})\n{}".format(

--- a/myst_parser/parse_directives.py
+++ b/myst_parser/parse_directives.py
@@ -146,15 +146,16 @@ def parse_directive_options(
         convertor = options_spec.get(name, None)
         if convertor is None:
             raise DirectiveParsingError(f"Unknown option: {name}")
-        if value is True or value is None:
-            value = ""  # flag converter requires no argument
-        if isinstance(value, (int, float, datetime.date, datetime.datetime)):
-            # convertor always requires string input
-            value = str(value)
         if not isinstance(value, str):
-            raise DirectiveParsingError(
-                f'option "{name}"s value not string (enclose with ""): {value}'
-            )
+            if value is True or value is None:
+                value = ""  # flag converter requires no argument
+            elif isinstance(value, (int, float, datetime.date, datetime.datetime)):
+                # convertor always requires string input
+                value = str(value)
+            else:
+                raise DirectiveParsingError(
+                    f'option "{name}"s value not string (enclose with ""): {value}'
+                )
         try:
             converted_value = convertor(value)
         except (ValueError, TypeError) as error:

--- a/myst_parser/parse_directives.py
+++ b/myst_parser/parse_directives.py
@@ -143,12 +143,14 @@ def parse_directive_options(
     options_spec = directive_class.option_spec  # type: Dict[str, Callable]
     for name, value in list(options.items()):
         convertor = options_spec.get(name, None)
-        if value is True:
+        if value is True or value is None:
             value = ""  # flag converter requires no argument
         if convertor is None:
             raise DirectiveParsingError("Unknown option: {}".format(name))
         try:
-            converted_value = convertor(value)
+            converted_value = convertor(
+                str(value)
+            )  # convertor always requires string input
         except (ValueError, TypeError) as error:
             raise DirectiveParsingError(
                 "Invalid option value: (option: '{}'; value: {})\n{}".format(

--- a/tests/test_renderers/fixtures/reporter_warnings.md
+++ b/tests/test_renderers/fixtures/reporter_warnings.md
@@ -93,3 +93,15 @@ source/path:10: (ERROR/3) Unknown directive type "unknown".
 
 source/path:12: (ERROR/3) Unknown interpreted text role "unknown".
 .
+
+bad-option-value
+.
+```{note}
+:class: [1]
+```
+.
+source/path:1: (ERROR/3) Directive 'note': option "class" value not string (enclose with ""): [1]
+
+:class: [1]
+
+.

--- a/tests/test_sphinx/test_sphinx_builds/test_includes.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_includes.html
@@ -98,8 +98,8 @@
 </pre>
       </div>
      </div>
-     <pre class="code python literal-block"><code><span class="ln">1 </span><span class="keyword">def</span> <span class="name function">a_func</span><span class="punctuation">(</span><span class="name">param</span><span class="punctuation">):</span>
-<span class="ln">2 </span>    <span class="name builtin">print</span><span class="punctuation">(</span><span class="name">param</span><span class="punctuation">)</span></code></pre>
+     <pre class="code python literal-block"><code><span class="ln">0 </span><span class="keyword">def</span> <span class="name function">a_func</span><span class="punctuation">(</span><span class="name">param</span><span class="punctuation">):</span>
+<span class="ln">1 </span>    <span class="name builtin">print</span><span class="punctuation">(</span><span class="name">param</span><span class="punctuation">)</span></code></pre>
      <div class="highlight-default notranslate">
       <div class="highlight">
        <pre><span></span><span class="n">This</span> <span class="n">should</span> <span class="n">be</span> <span class="o">*</span><span class="n">literal</span><span class="o">*</span>
@@ -111,8 +111,8 @@
 </pre>
       </div>
      </div>
-     <pre class="literal-block" id="literal-ref"><span class="ln">1 </span>Lots
-<span class="ln">2 </span>of</pre>
+     <pre class="literal-block" id="literal-ref"><span class="ln">0 </span>Lots
+<span class="ln">1 </span>of</pre>
      <div class="section" id="a-sub-sub-heading">
       <h3>
        A Sub-sub-Heading

--- a/tests/test_sphinx/test_sphinx_builds/test_includes.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_includes.xml
@@ -68,7 +68,7 @@
                     )
             <literal_block classes="code python" source="include_code.py" xml:space="preserve">
                 <inline classes="ln">
-                    1 
+                    0 
                 <inline classes="keyword">
                     def
                  
@@ -82,7 +82,7 @@
                     ):
                 
                 <inline classes="ln">
-                    2 
+                    1 
                     
                 <inline classes="name builtin">
                     print
@@ -101,10 +101,10 @@
                 so we can select some
             <literal_block ids="literal-ref" names="literal_ref" source="include_literal.txt" xml:space="preserve">
                 <inline classes="ln">
-                    1 
+                    0 
                 Lots
                 <inline classes="ln">
-                    2 
+                    1 
                 of
             <section ids="a-sub-sub-heading" names="a\ sub-sub-heading">
                 <title>


### PR DESCRIPTION
docutils directives always expect options to be strings, but we parse them as YAML, and so e.g. ints and floats should be converted back. Also None should be converted to an empty string.

fixes #289 