### PR TITLE
👌 IMPROVE: substitution logic

### DIFF
--- a/docs/develop/architecture.md
+++ b/docs/develop/architecture.md
@@ -10,18 +10,18 @@ is a well-structured Python parser for CommonMark text. It also defines an exten
 point to include more syntax in parsed files. The MyST parser uses this extension
 point to define its own syntax options (e.g., for Sphinx roles and directives).
 
-The result of this parser is a Mistletoe AST.
+The result of this parser is a markdown-it token stream.
 
 ## A docutils renderer
 
-The MyST parser also defines a docutils renderer for the Mistletoe AST. This allows us
-to convert parsed elements of a MyST markdown file into docutils.
+The MyST parser also defines a docutils renderer for the markdown-it token stream.
+This allows us to convert parsed elements of a MyST markdown file into docutils.
 
 ## A Sphinx parser
 
 Finally, the MyST parser provides a parser for Sphinx, the documentation generation
 system. This parser does the following:
 
-* Parse markdown files with the MyST Mistletoe parser
+* Parse markdown files with the markdown-it parser, including MyST specific plugins
 * Convert these files into docutils objects using the MyST docutils renderer
 * Provide these to Sphinx in order to use in building your site.

--- a/docs/using/syntax-optional.md
+++ b/docs/using/syntax-optional.md
@@ -11,6 +11,7 @@ substitutions:
     :alt: fishy
     :width: 200px
     ```
+  key4: example
 ---
 
 (syntax/optional)=
@@ -110,6 +111,7 @@ substitutions:
     :alt: fishy
     :width: 200px
     ```
+  key4: example
 ---
 ````
 
@@ -163,11 +165,9 @@ Substitutions will only be assessed where you would normally use Markdown, e.g. 
 {{ key1 }}
 ```
 
-:::
-
-:::{warning}
-One should be wary using block-level syntaxes (such as lists) for inline substitutions.
+One should also be wary of using unsuitable directives for inline substitutions.
 This may lead to unexpected outcomes.
+
 :::
 
 Substitution references are assessed as [Jinja2 expressions](http://jinja.palletsprojects.com) which can use [filters](https://jinja.palletsprojects.com/en/2.11.x/templates/#list-of-builtin-filters), and also contains the [Sphinx Environment](https://www.sphinx-doc.org/en/master/extdev/envapi.html) in the context (as `env`).
@@ -189,6 +189,28 @@ myst_sub_delimiters = ["|", "|"]
 
 Will parse: `|| "a" + "b" ||`.
 This should be changed with care though, so as not to affect other syntaxes.
+
+The exact logic for handling substitutions is:
+
+1. Combine global substitutions (specified in `conf.py`) with front-matter substitutions, to create a variable context (front-matter takes priority)
+2. Add the sphinx `env` to the variable context
+3. Create the string content to render using Jinja2 (passing it the variable context)
+4. If the substitution is inline and not a directive, render ignoring block syntaxes (like lists or block-quotes), otherwise render with all syntax rules.
+
+### Substitutions and URLs
+
+Substitutions cannot be directly used in URLs, such as `[a link](https://{{key4}}.com)` or `<https://{{key4}}.com>`.
+However, since Jinja2 substitutions allow for Python methods to be used, you can use string formatting or replacements:
+
+```md
+{{ '[a link](https://{}.com)'.format(key4) }}
+
+{{ '<https://myst-parser.readthedocs.io/en/latest/REPLACE.html>'.replace('REPLACE', env.docname) }}
+```
+
+{{ '[a link](https://{}.com)'.format(key4) }}
+
+{{ '<https://myst-parser.readthedocs.io/en/latest/REPLACE.html>'.replace('REPLACE', env.docname) }}
 
 (syntax/colon_fence)=
 

--- a/myst_parser/directives.py
+++ b/myst_parser/directives.py
@@ -52,12 +52,13 @@ class FigureMarkdown(SphinxDirective):
         node = nodes.Element()
         # TODO test that we are using myst parser
         # ensure html image enabled
-        enable_html_img = self.state._renderer.config.get("enable_html_img", False)
+        myst_extensions = self.state._renderer.config.get("myst_extensions", set())
         try:
-            self.state._renderer.config["enable_html_img"] = True
+            self.state._renderer.config.setdefault("myst_extensions", set())
+            self.state._renderer.config["myst_extensions"].add("html_image")
             self.state.nested_parse(self.content, self.content_offset, node)
         finally:
-            self.state._renderer.config["enable_html_img"] = enable_html_img
+            self.state._renderer.config["myst_extensions"] = myst_extensions
 
         if not len(node.children) == 2:
             return [

--- a/myst_parser/html_to_nodes.py
+++ b/myst_parser/html_to_nodes.py
@@ -35,8 +35,10 @@ def html_to_nodes(
     text: str, line_number: int, renderer: "DocutilsRenderer"
 ) -> List[nodes.Element]:
     """Convert HTML to docutils nodes."""
-    enable_html_img = renderer.config.get("enable_html_img", False)
-    enable_html_admonition = renderer.config.get("enable_html_admonition", False)
+    enable_html_img = "html_image" in renderer.config.get("myst_extensions", [])
+    enable_html_admonition = "html_admonition" in renderer.config.get(
+        "myst_extensions", []
+    )
 
     if not (enable_html_img or enable_html_admonition):
         return default_html(text, renderer.document["source"], line_number)

--- a/myst_parser/main.py
+++ b/myst_parser/main.py
@@ -185,14 +185,18 @@ def default_parser(config: MdParserConfig) -> MarkdownIt:
 
     md.options.update(
         {
-            "commonmark_only": False,
+            # standard options
             "typographer": typographer,
             "linkify": "linkify" in config.enable_extensions,
-            "enable_html_img": "html_image" in config.enable_extensions,
-            "enable_html_admonition": "html_admonition" in config.enable_extensions,
+            # myst options
+            "commonmark_only": False,
+            "myst_extensions": set(
+                config.enable_extensions + ["heading_anchors"]
+                if config.heading_anchors is not None
+                else []
+            ),
             "myst_url_schemes": config.url_schemes,
-            "enable_anchors": config.heading_anchors is not None,
-            "substitutions": config.substitutions,
+            "myst_substitutions": config.substitutions,
         }
     )
 
@@ -218,7 +222,7 @@ def to_docutils(
     :param document: the docutils root node to use (otherwise a new one will be created)
     :param in_sphinx_env: initialise a minimal sphinx environment (useful for testing)
     :param conf: the sphinx conf.py as a dictionary
-    :param srcdir: to parse to the mock sphinc env
+    :param srcdir: to parse to the mock sphinx env
 
     :returns: docutils document
     """

--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -121,7 +121,8 @@ class MockState:
         match_titles: bool = False,
         state_machine_class=None,
         state_machine_kwargs=None,
-    ):
+    ) -> None:
+        """Perform a nested parse of the input block, with ``node`` as the parent."""
         current_match_titles = self.state_machine.match_titles
         self.state_machine.match_titles = match_titles
         with self._renderer.current_node_context(node):
@@ -130,7 +131,7 @@ class MockState:
             )
         self.state_machine.match_titles = current_match_titles
 
-    def parse_target(self, block, block_text, lineno):
+    def parse_target(self, block, block_text, lineno: int):
         """
         Taken from https://github.com/docutils-mirror/docutils/blob/e88c5fb08d5cdfa8b4ac1020dd6f7177778d5990/docutils/parsers/rst/states.py#L1927  # noqa: E501
         """
@@ -143,7 +144,14 @@ class MockState:
         reference = "".join(["".join(line.split()) for line in block])
         return "refuri", unescape(reference)
 
-    def inline_text(self, text: str, lineno: int):
+    def inline_text(
+        self, text: str, lineno: int
+    ) -> Tuple[List[nodes.Element], List[nodes.Element]]:
+        """Parse text with only inline rules.
+
+        :return: (list of nodes, list of messages)
+
+        """
         # TODO return messages?
         messages = []
         paragraph = nodes.paragraph("")
@@ -170,7 +178,7 @@ class MockState:
     # U+2014 is an em-dash:
     attribution_pattern = re.compile("^((?:---?(?!-)|\u2014) *)(.+)")
 
-    def block_quote(self, lines: List[str], line_offset: int):
+    def block_quote(self, lines: List[str], line_offset: int) -> List[nodes.Element]:
         """Parse a block quote, which is a block of text,
         followed by an (optional) attribution.
 
@@ -231,7 +239,7 @@ class MockState:
     def build_table_row(self, rowdata, tableline):
         return Body.build_table_row(self, rowdata, tableline)
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str):
         """This method is only be called if the attribute requested has not
         been defined. Defined attributes will not be overridden.
         """

--- a/myst_parser/sphinx_renderer.py
+++ b/myst_parser/sphinx_renderer.py
@@ -29,9 +29,10 @@ LOGGER = logging.getLogger(__name__)
 
 
 class SphinxRenderer(DocutilsRenderer):
-    """A mistletoe renderer to populate (in-place) a `docutils.document` AST.
+    """A markdown-it-py renderer to populate (in-place) a `docutils.document` AST.
 
-    This is sub-class of `DocutilsRenderer` that handles sphinx cross-referencing.
+    This is sub-class of `DocutilsRenderer` that handles sphinx specific aspects,
+    such as cross-referencing.
     """
 
     @property

--- a/tests/test_html/test_html_to_nodes.py
+++ b/tests/test_html/test_html_to_nodes.py
@@ -19,7 +19,7 @@ def mock_renderer():
         return [node]
 
     return Mock(
-        config={"enable_html_img": True, "enable_html_admonition": True},
+        config={"myst_extensions": ["html_image", "html_admonition"]},
         document={"source": "source"},
         reporter=Mock(
             warning=Mock(return_value=nodes.system_message("warning")),

--- a/tests/test_sphinx/sourcedirs/substitutions/index.md
+++ b/tests/test_sphinx/sourcedirs/substitutions/index.md
@@ -1,6 +1,7 @@
 ---
 substitutions:
-  text: >
+  text: "- text"
+  text_with_nest: >
     output
     with *Markdown*
     {{ nested }}
@@ -11,15 +12,23 @@ substitutions:
     ```{note}
     A note {{ nested }}
     ```
+  inline_admonition: |
+    ```{note}
+    Inline note
+    ```
   override: Overriden by front matter
 
 ---
 
-{{ text }}
+{{ text_with_nest }}
 
 {{ admonition }}
 
-b {{ text }} d
+a {{ text }} b
+
+c {{ text_with_nest }} d
+
+e {{ inline_admonition }} f
 
 {{ conf }}
 
@@ -28,13 +37,13 @@ b {{ text }} d
 This will process the substitution
 
 ```{parsed-literal}
-{{ text }}
+{{ text_with_nest }}
 ```
 
 This will not process the substitution
 
 ```python
-{{ text }}
+{{ text_with_nest }}
 ```
 
 Using env and filters:

--- a/tests/test_sphinx/test_sphinx_builds/test_substitutions.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_substitutions.html
@@ -20,11 +20,27 @@
     </p>
    </div>
    <p>
-    b output with
+    a - text b
+   </p>
+   <p>
+    c output with
     <em>
      Markdown
     </em>
-    nested substitution d
+    nested substitution
+ d
+   </p>
+   <p>
+    e
+    <div class="admonition note">
+     <p class="admonition-title">
+      Note
+     </p>
+     <p>
+      Inline note
+     </p>
+    </div>
+    f
    </p>
    <p>
     This was from the conf
@@ -35,13 +51,14 @@
    <p>
     This will process the substitution
    </p>
-   <pre class="literal-block">output with <em>Markdown</em> nested substitution</pre>
+   <pre class="literal-block">output with <em>Markdown</em> nested substitution
+</pre>
    <p>
     This will not process the substitution
    </p>
    <div class="highlight-python notranslate">
     <div class="highlight">
-     <pre><span></span><span class="p">{{</span> <span class="n">text</span> <span class="p">}}</span>
+     <pre><span></span><span class="p">{{</span> <span class="n">text_with_nest</span> <span class="p">}}</span>
 </pre>
     </div>
    </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_substitutions.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_substitutions.xml
@@ -12,13 +12,24 @@
             A note 
             nested substitution
     <paragraph>
-        b 
+        a 
+        - text
+         b
+    <paragraph>
+        c 
         output with 
         <emphasis>
             Markdown
          
         nested substitution
+        
          d
+    <paragraph>
+        e 
+        <note>
+            <paragraph>
+                Inline note
+         f
     <paragraph>
         This was from the conf
     <paragraph>
@@ -31,10 +42,11 @@
             Markdown
          
         nested substitution
+        
     <paragraph>
         This will not process the substitution
     <literal_block language="python" xml:space="preserve">
-        {{ text }}
+        {{ text_with_nest }}
     <paragraph>
         Using env and filters:
     <paragraph>


### PR DESCRIPTION
Parse inline substitutions without block syntax rules, unless the substitution starts with a directive.

fixes #282