### PR TITLE
🐛 FIX: Render front-matter as `field_list`

### DIFF
--- a/docs/api/renderers.rst
+++ b/docs/api/renderers.rst
@@ -64,7 +64,7 @@ Additional Methods
 
 .. autofunction:: myst_parser.docutils_renderer.make_document
 
-.. autofunction:: myst_parser.docutils_renderer.dict_to_docinfo
+.. autofunction:: myst_parser.docutils_renderer.dict_to_field_list
 
 .. autofunction:: myst_parser.sphinx_renderer.minimal_sphinx_app
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -135,6 +135,7 @@ nitpick_ignore = [
     ("py:class", "docutils.nodes.system_message"),
     ("py:class", "docutils.statemachine.StringList"),
     ("py:class", "docutils.nodes.Element"),
+    ("py:class", "docutils.nodes.field_list"),
     ("py:class", "docutils.parsers.rst.directives.misc.Include"),
     ("py:class", "docutils.nodes.document"),
     ("py:class", "docutils.parsers.rst.Parser"),

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -786,13 +786,12 @@ To inhibit this override, set `myst_update_mathjax=False`.
 ## Front Matter
 
 This is a YAML block at the start of the document, as used for example in
-[jekyll](https://jekyllrb.com/docs/front-matter/). Sphinx intercepts these data and
-stores them within the global environment (as discussed
-[here](https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html)).
+[jekyll](https://jekyllrb.com/docs/front-matter/).
+Sphinx intercepts these data and stores them within the global environment
+(as discussed [here](https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html)).
 
-A classic use-case is to specify 'orphan' documents, that are not specified in any
-toctrees. For example, inserting the following syntax at the top of a page will cause
-Sphinx to treat it as an orphan page:
+A classic use-case is to specify 'orphan' documents, that are not specified in any toctrees.
+For example, inserting the following syntax at the top of a page will cause Sphinx to treat it as an orphan page:
 
 ```md
 ---
@@ -801,6 +800,11 @@ orphan: true
 
 This is an orphan document, not specified in any toctrees.
 ```
+
+:::{seealso}
+Top-matter is also used for the [substitution syntax extension](syntax/substitutions),
+and can be used to store information for blog posting (see [ablog's myst-parser support](https://ablog.readthedocs.io/manual/markdown/)).
+:::
 
 (syntax/comments)=
 

--- a/tests/test_renderers/fixtures/syntax_elements.md
+++ b/tests/test_renderers/fixtures/syntax_elements.md
@@ -595,7 +595,7 @@ c:
 ---
 .
 <document source="notset">
-    <docinfo>
+    <field_list>
         <field>
             <field_name>
                 a
@@ -661,7 +661,7 @@ a = 1
 [](target)
 .
 <document source="notset">
-    <docinfo>
+    <field_list>
         <field>
             <field_name>
                 a


### PR DESCRIPTION
This allows the `DocInfo` transform to correctly convert
bibliographic keys to specific nodes, which can be used by other transforms.