### PR TITLE
✨ NEW: Add setting HTML metadata

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,7 @@ copyright = "2020, Executable Book Project"
 author = "Executable Book Project"
 
 master_doc = "index"
+language = "en"
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/using/intro.md
+++ b/docs/using/intro.md
@@ -246,6 +246,12 @@ To do so, use the keywords beginning `myst_`.
 * - `myst_heading_anchors`
   - `None`
   - Enable auto-generated heading anchors, up to a maximum level, [see here](syntax/header-anchors) for details.
+* - `myst_substitutions`
+  - `{}`
+  - A mapping of keys to substitutions, used globally for all MyST documents when the "substitution" extension is enabled.
+* - `myst_html_meta`
+  - `{}`
+  - A mapping of keys to HTML metadata, used globally for all MyST documents. See [](syntax/html_meta).
 `````
 
 List of extensions:
@@ -259,7 +265,7 @@ List of extensions:
 - "linkify": automatically identify "bare" web URLs and add hyperlinks
 - "replacements": automatically convert some common typographic texts
 - "smartquotes": automatically convert standard quotations to their opening/closing variants
-- "substitution": substitute keys
+- "substitution": substitute keys, see the [substitutions syntax](syntax/substitutions) for details
 
 Math specific, when `"dollarmath"` activated, see the [Math syntax](syntax/math) for more details:
 

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -806,6 +806,70 @@ Top-matter is also used for the [substitution syntax extension](syntax/substitut
 and can be used to store information for blog posting (see [ablog's myst-parser support](https://ablog.readthedocs.io/manual/markdown/)).
 :::
 
+(syntax/html_meta)=
+
+### Setting HTML Metadata
+
+The front-matter can contain the special key `html_meta`; a dict with data to add to the generated HTML as [`<meta>` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta).
+This is equivalent to using the [RST `meta` directive](https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#html-metadata).
+
+HTML metadata can also be added globally in the `conf.py` *via* the `myst_html_meta` variable, in which case it will be added to all MyST documents.
+for each document, the `myst_html_meta` dict will be updated by the document level front-matter `html_meta`, with the front-matter taking precedence.
+
+:::{tabbed} Sphinx Configuration
+
+```python
+language = "en"
+myst_html_meta = {
+    "description lang=en": "metadata description",
+    "description lang=fr": "description des métadonnées",
+    "keywords": "Sphinx, MyST",
+    "property=og:locale":  "en_US"
+}
+```
+
+:::
+
+:::{tabbed} MyST Front-Matter
+
+```yaml
+---
+html_meta:
+  "description lang=en": "metadata description"
+  "description lang=fr": "description des métadonnées"
+  "keywords": "Sphinx, MyST"
+  "property=og:locale": "en_US"
+---
+```
+
+:::
+
+:::{tabbed} RestructuredText
+
+```restructuredtext
+.. meta::
+   :description lang=en: metadata description
+   :description lang=fr: description des métadonnées
+   :keywords: Sphinx, MyST
+   :property=og:locale: en_US
+```
+
+:::
+
+:::{tabbed} HTML Output
+
+```html
+<html lang="en">
+  <head>
+    <meta content="metadata description" lang="en" name="description" xml:lang="en" />
+    <meta content="description des métadonnées" lang="fr" name="description" xml:lang="fr" />
+    <meta name="keywords" content="Sphinx, MyST">
+    <meta content="en_US" property="og:locale" />
+```
+
+:::
+
+
 (syntax/comments)=
 
 ## Comments

--- a/myst_parser/main.py
+++ b/myst_parser/main.py
@@ -1,4 +1,4 @@
-from typing import Dict, Iterable, List, Optional, Tuple
+from typing import Dict, Iterable, List, Optional, Tuple, Union
 
 import attr
 from attr.validators import deep_iterable, deep_mapping, in_, instance_of, optional
@@ -96,11 +96,17 @@ class MdParserConfig:
         default=None, validator=optional(in_([1, 2, 3, 4, 5, 6, 7]))
     )
 
-    substitutions: Dict[str, str] = attr.ib(
+    substitutions: Dict[str, Union[str, int, float]] = attr.ib(
         factory=dict,
         validator=deep_mapping(
             instance_of(str), instance_of((str, int, float)), instance_of(dict)
         ),
+        repr=lambda v: str(list(v)),
+    )
+
+    html_meta: Dict[str, str] = attr.ib(
+        factory=dict,
+        validator=deep_mapping(instance_of(str), instance_of(str), instance_of(dict)),
         repr=lambda v: str(list(v)),
     )
 
@@ -197,6 +203,7 @@ def default_parser(config: MdParserConfig) -> MarkdownIt:
             ),
             "myst_url_schemes": config.url_schemes,
             "myst_substitutions": config.substitutions,
+            "myst_html_meta": config.html_meta,
         }
     )
 

--- a/myst_parser/sphinx_parser.py
+++ b/myst_parser/sphinx_parser.py
@@ -9,6 +9,8 @@ from sphinx.parsers import Parser
 from sphinx.util import logging
 from sphinx.util.docutils import sphinx_domains
 
+from markdown_it.token import Token
+from markdown_it.utils import AttrDict
 from myst_parser.main import default_parser, MdParserConfig
 
 
@@ -177,6 +179,7 @@ class MystParser(Parser):
 
         :param inputstring: The source string to parse
         :param document: The root docutils node to add AST elements to
+
         """
         if renderer == "sphinx":
             config = document.settings.env.myst_config
@@ -184,7 +187,13 @@ class MystParser(Parser):
             config = MdParserConfig()
         parser = default_parser(config)
         parser.options["document"] = document
-        parser.render(inputstring)
+        env = AttrDict()
+        tokens = parser.parse(inputstring, env)
+        if not tokens or tokens[0].type != "front_matter":
+            # we always add front matter, so that we can merge it with global keys,
+            # specified in the sphinx configuration
+            tokens = [Token("front_matter", "", 0, content={}, map=[0, 0])] + tokens
+        parser.renderer.render(tokens, parser.options, env)
 
 
 def parse(app: Sphinx, text: str, docname: str = "index") -> nodes.document:

--- a/tests/test_renderers/fixtures/reporter_warnings.md
+++ b/tests/test_renderers/fixtures/reporter_warnings.md
@@ -45,6 +45,19 @@ expected the node content, but found '<stream end>'
         ^
 .
 
+Bad HTML Meta
+.
+---
+html_meta:
+  empty:
+  name noequals: value
+
+---
+.
+source/path:: (ERROR/3) Error parsing meta tag attribute "empty": No content.
+source/path:: (ERROR/3) Error parsing meta tag attribute "name noequals": no '=' in noequals.
+.
+
 Directive parsing error:
 .
 

--- a/tests/test_renderers/fixtures/syntax_elements.md
+++ b/tests/test_renderers/fixtures/syntax_elements.md
@@ -633,6 +633,51 @@ a: {
             a: {
 .
 
+Front Matter HTML Meta
+.
+---
+html_meta:
+    keywords: Sphinx, documentation, builder
+    description lang=en: An amusing story
+    description lang=fr: Un histoire amusant
+    http-equiv=Content-Type: text/html; charset=ISO-8859-1
+---
+.
+<document source="notset">
+    <pending>
+        .. internal attributes:
+             .transform: docutils.transforms.components.Filter
+             .details:
+               component: 'writer'
+               format: 'html'
+               nodes:
+                 <meta content="Sphinx, documentation, builder" name="keywords">
+    <pending>
+        .. internal attributes:
+             .transform: docutils.transforms.components.Filter
+             .details:
+               component: 'writer'
+               format: 'html'
+               nodes:
+                 <meta content="An amusing story" lang="en" name="description">
+    <pending>
+        .. internal attributes:
+             .transform: docutils.transforms.components.Filter
+             .details:
+               component: 'writer'
+               format: 'html'
+               nodes:
+                 <meta content="Un histoire amusant" lang="fr" name="description">
+    <pending>
+        .. internal attributes:
+             .transform: docutils.transforms.components.Filter
+             .details:
+               component: 'writer'
+               format: 'html'
+               nodes:
+                 <meta content="text/html; charset=ISO-8859-1" http-equiv="Content-Type">
+.
+
 --------------------------
 Full Test:
 .

--- a/tests/test_renderers/test_error_reporting.py
+++ b/tests/test_renderers/test_error_reporting.py
@@ -13,6 +13,10 @@ FIXTURE_PATH = Path(__file__).parent.joinpath("fixtures")
 @pytest.mark.parametrize(
     "line,title,input,expected",
     read_fixture_file(FIXTURE_PATH.joinpath("reporter_warnings.md")),
+    ids=[
+        f"{i[0]}-{i[1]}"
+        for i in read_fixture_file(FIXTURE_PATH / "reporter_warnings.md")
+    ],
 )
 def test_basic(line, title, input, expected):
     document = make_document("source/path")

--- a/tests/test_renderers/test_fixtures.py
+++ b/tests/test_renderers/test_fixtures.py
@@ -19,6 +19,9 @@ def test_minimal_sphinx():
 @pytest.mark.parametrize(
     "line,title,input,expected",
     read_fixture_file(FIXTURE_PATH.joinpath("syntax_elements.md")),
+    ids=[
+        f"{i[0]}-{i[1]}" for i in read_fixture_file(FIXTURE_PATH / "syntax_elements.md")
+    ],
 )
 def test_syntax_elements(line, title, input, expected):
     document = to_docutils(input, in_sphinx_env=True)
@@ -29,7 +32,9 @@ def test_syntax_elements(line, title, input, expected):
 
 
 @pytest.mark.parametrize(
-    "line,title,input,expected", read_fixture_file(FIXTURE_PATH.joinpath("tables.md"))
+    "line,title,input,expected",
+    read_fixture_file(FIXTURE_PATH.joinpath("tables.md")),
+    ids=[f"{i[0]}-{i[1]}" for i in read_fixture_file(FIXTURE_PATH / "tables.md")],
 )
 def test_tables(line, title, input, expected):
     document = to_docutils(input, in_sphinx_env=True)
@@ -42,6 +47,10 @@ def test_tables(line, title, input, expected):
 @pytest.mark.parametrize(
     "line,title,input,expected",
     read_fixture_file(FIXTURE_PATH.joinpath("directive_options.md")),
+    ids=[
+        f"{i[0]}-{i[1]}"
+        for i in read_fixture_file(FIXTURE_PATH / "directive_options.md")
+    ],
 )
 def test_directive_options(line, title, input, expected):
     document = to_docutils(input)
@@ -54,6 +63,9 @@ def test_directive_options(line, title, input, expected):
 @pytest.mark.parametrize(
     "line,title,input,expected",
     read_fixture_file(FIXTURE_PATH.joinpath("docutil_roles.md")),
+    ids=[
+        f"{i[0]}-{i[1]}" for i in read_fixture_file(FIXTURE_PATH / "docutil_roles.md")
+    ],
 )
 def test_docutils_roles(line, title, input, expected):
     document = to_docutils(input)
@@ -66,6 +78,10 @@ def test_docutils_roles(line, title, input, expected):
 @pytest.mark.parametrize(
     "line,title,input,expected",
     read_fixture_file(FIXTURE_PATH.joinpath("docutil_directives.md")),
+    ids=[
+        f"{i[0]}-{i[1]}"
+        for i in read_fixture_file(FIXTURE_PATH / "docutil_directives.md")
+    ],
 )
 def test_docutils_directives(line, title, input, expected):
     # TODO fix skipped directives
@@ -82,6 +98,10 @@ def test_docutils_directives(line, title, input, expected):
 @pytest.mark.parametrize(
     "line,title,input,expected",
     read_fixture_file(FIXTURE_PATH.joinpath("sphinx_directives.md")),
+    ids=[
+        f"{i[0]}-{i[1]}"
+        for i in read_fixture_file(FIXTURE_PATH / "sphinx_directives.md")
+    ],
 )
 def test_sphinx_directives(line, title, input, expected):
     # TODO fix skipped directives
@@ -102,6 +122,7 @@ def test_sphinx_directives(line, title, input, expected):
 @pytest.mark.parametrize(
     "line,title,input,expected",
     read_fixture_file(FIXTURE_PATH.joinpath("sphinx_roles.md")),
+    ids=[f"{i[0]}-{i[1]}" for i in read_fixture_file(FIXTURE_PATH / "sphinx_roles.md")],
 )
 def test_sphinx_roles(line, title, input, expected):
     if title.startswith("SKIP"):
@@ -120,6 +141,7 @@ def test_sphinx_roles(line, title, input, expected):
 @pytest.mark.parametrize(
     "line,title,input,expected",
     read_fixture_file(FIXTURE_PATH.joinpath("amsmath.md")),
+    ids=[f"{i[0]}-{i[1]}" for i in read_fixture_file(FIXTURE_PATH / "amsmath.md")],
 )
 def test_amsmath(line, title, input, expected, monkeypatch):
     monkeypatch.setattr(SphinxRenderer, "_random_label", lambda self: "mock-uuid")
@@ -137,6 +159,7 @@ def test_amsmath(line, title, input, expected, monkeypatch):
 @pytest.mark.parametrize(
     "line,title,input,expected",
     read_fixture_file(FIXTURE_PATH.joinpath("containers.md")),
+    ids=[f"{i[0]}-{i[1]}" for i in read_fixture_file(FIXTURE_PATH / "containers.md")],
 )
 def test_containers(line, title, input, expected, monkeypatch):
     monkeypatch.setattr(SphinxRenderer, "_random_label", lambda self: "mock-uuid")
@@ -154,6 +177,7 @@ def test_containers(line, title, input, expected, monkeypatch):
 @pytest.mark.parametrize(
     "line,title,input,expected",
     read_fixture_file(FIXTURE_PATH.joinpath("eval_rst.md")),
+    ids=[f"{i[0]}-{i[1]}" for i in read_fixture_file(FIXTURE_PATH / "eval_rst.md")],
 )
 def test_evalrst_elements(line, title, input, expected):
     document = to_docutils(input, in_sphinx_env=True)
@@ -166,6 +190,10 @@ def test_evalrst_elements(line, title, input, expected):
 @pytest.mark.parametrize(
     "line,title,input,expected",
     read_fixture_file(FIXTURE_PATH.joinpath("definition_lists.md")),
+    ids=[
+        f"{i[0]}-{i[1]}"
+        for i in read_fixture_file(FIXTURE_PATH / "definition_lists.md")
+    ],
 )
 def test_definition_lists(line, title, input, expected):
     document = to_docutils(

--- a/tests/test_sphinx/conftest.py
+++ b/tests/test_sphinx/conftest.py
@@ -35,6 +35,7 @@ import os
 import pathlib
 import shutil
 
+from bs4 import BeautifulSoup
 import pytest
 from sphinx.testing.path import path
 
@@ -79,8 +80,6 @@ def get_sphinx_app_output(file_regression):
 
         if regress_html:
             # only regress the inner body, since other sections are non-deterministic
-            from bs4 import BeautifulSoup
-
             soup = BeautifulSoup(content, "html.parser")
             doc_div = soup.findAll("div", {"class": "documentwrapper"})[0]
             text = doc_div.prettify()

--- a/tests/test_sphinx/sourcedirs/extended_syntaxes/conf.py
+++ b/tests/test_sphinx/sourcedirs/extended_syntaxes/conf.py
@@ -1,6 +1,11 @@
 extensions = ["myst_parser"]
+language = "en"
 exclude_patterns = ["_build"]
 myst_disable_syntax = ["emphasis"]
 myst_dmath_allow_space = False
 mathjax_config = {}
 myst_enable_extensions = ["dollarmath", "amsmath", "deflist", "colon_fence", "linkify"]
+myst_html_meta = {
+    "description lang=en": "meta description",
+    "property=og:locale": "en_US",
+}

--- a/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.xml
@@ -1,4 +1,6 @@
 <document source="index.md">
+    <meta content="meta description" lang="en" name="description">
+    <meta content="en_US" property="og:locale">
     <section ids="test" names="test">
         <title>
             Test


### PR DESCRIPTION
Can be added globally,
as configuration `myst_html_meta`,
or at the document level,
in the front-matter under key `html_meta`.