### PR TITLE
👌 IMPROVE: integer footnote references

### DIFF
--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -1010,15 +1010,15 @@ All footnote definitions are collected, and displayed at the bottom of the page 
 Note that un-referenced footnote definitions will not be displayed.
 
 ```md
-- This is an auto-numbered footnote reference.[^myref]
 - This is a manually-numbered footnote reference.[^3]
+- This is an auto-numbered footnote reference.[^myref]
 
 [^myref]: This is an auto-numbered footnote definition.
 [^3]: This is a manually-numbered footnote definition.
 ```
 
-- This is an auto-numbered footnote reference.[^myref]
 - This is a manually-numbered footnote reference.[^3]
+- This is an auto-numbered footnote reference.[^myref]
 
 [^myref]: This is an auto-numbered footnote definition.
 [^3]: This is a manually-numbered footnote definition.

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -1002,27 +1002,34 @@ See the [extended image syntax guide](syntax/images).
 
 Footnotes use the [pandoc specification](https://pandoc.org/MANUAL.html#footnotes).
 Their labels **start with `^`** and can then be any alpha-numeric string (no spaces), which is case-insensitive.
-The actual label is not displayed in the rendered text; instead they are numbered, in the order which they are referenced.
-All footnote definitions are collected, and displayed at the bottom of the page (ordered by number).
+
+- If the label is an integer, then it will always use that integer for the rendered label (i.e. they are manually numbered).
+- For any other labels, they will be auto-numbered in the order which they are referenced, skipping any manually numbered labels.
+
+All footnote definitions are collected, and displayed at the bottom of the page (in the order they are referenced).
 Note that un-referenced footnote definitions will not be displayed.
 
 ```md
-This is a footnote reference.[^myref]
+- This is an auto-numbered footnote reference.[^myref]
+- This is a manually-numbered footnote reference.[^3]
 
-[^myref]: This **is** the footnote definition.
+[^myref]: This is an auto-numbered footnote definition.
+[^3]: This is a manually-numbered footnote definition.
 ```
 
-This is a footnote reference.[^myref]
+- This is an auto-numbered footnote reference.[^myref]
+- This is a manually-numbered footnote reference.[^3]
 
-[^myref]: This **is** the footnote definition.
+[^myref]: This is an auto-numbered footnote definition.
+[^3]: This is a manually-numbered footnote definition.
 
 Any preceding text after a footnote definitions, which is
-indented by four or more spaces, will also be included in the footnote definition, e.g.
+indented by four or more spaces, will also be included in the footnote definition, and the text is rendered as MyST Markdown, e.g.
 
 ```md
 A longer footnote definition.[^mylongdef]
 
-[^mylongdef]: This is the footnote definition.
+[^mylongdef]: This is the _**footnote definition**_.
 
     That continues for all indented lines
 
@@ -1036,7 +1043,7 @@ This is not part of the footnote.
 
 A longer footnote definition.[^mylongdef]
 
-[^mylongdef]: This is the footnote definition.
+[^mylongdef]: This is the _**footnote definition**_.
 
     That continues for all indented lines
 

--- a/tests/test_sphinx/test_sphinx_builds/test_footnotes.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_footnotes.html
@@ -35,10 +35,10 @@
     </p>
     <p>
      <a class="footnote-reference brackets" href="#id7" id="id5">
-      5
+      123
      </a>
      <a class="footnote-reference brackets" href="#id7" id="id6">
-      5
+      123
      </a>
     </p>
     <hr class="footnotes docutils"/>
@@ -96,7 +96,7 @@
      </dd>
      <dt class="label" id="id7">
       <span class="brackets">
-       5
+       123
       </span>
       <span class="fn-backref">
        (

--- a/tests/test_sphinx/test_sphinx_builds/test_footnotes.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_footnotes.xml
@@ -16,11 +16,11 @@
             <footnote_reference auto="1" docname="footnote_md" ids="id4" refid="b">
                 4
         <paragraph>
-            <footnote_reference auto="1" docname="footnote_md" ids="id5" refid="id7">
-                5
+            <footnote_reference docname="footnote_md" ids="id5" refid="id7">
+                123
              
-            <footnote_reference auto="1" docname="footnote_md" ids="id6" refid="id7">
-                5
+            <footnote_reference docname="footnote_md" ids="id6" refid="id7">
+                123
         <transition classes="footnotes">
         <footnote auto="1" backrefs="id1" docname="footnote_md" ids="c" names="c">
             <label>
@@ -44,8 +44,8 @@
                 4
             <paragraph>
                 a footnote before its reference
-        <footnote auto="1" backrefs="id5 id6" docname="footnote_md" ids="id7" names="123">
+        <footnote backrefs="id5 id6" docname="footnote_md" ids="id7" names="123">
             <label>
-                5
+                123
             <paragraph>
                 multiple references footnote


### PR DESCRIPTION
If the label is an integer, then it will always use this integer for the rendered label (i.e. they are manually numbered).

fixes #195 