### PR TITLE
Don't replace documentation content with a warning message

### DIFF
--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -285,13 +285,11 @@ class DocutilsRenderer:
         )
 
         if (level > parent_level) and (parent_level + 1 != level):
-            self.current_node.append(
-                self.reporter.warning(
-                    "Non-consecutive header level increase; {} to {}".format(
-                        parent_level, level
-                    ),
-                    line=section.line,
-                )
+            self.reporter.warning(
+                "Non-consecutive header level increase; {} to {}".format(
+                    parent_level, level
+                ),
+                line=section.line,
             )
 
         parent = self._level_to_elem[parent_level]


### PR DESCRIPTION
closes #302 

I don't know why this library replaces documentation text with warnings. This seems like a bad idea. Warnings should only be output in the console. Anyway, I just replaced the one instance that was breaking my build. I don't know why admonition titles are given a level of "2", but I'll let the maintainers figure that out.