### PR TITLE
⬆️ UPGRADE: markdown-it-py v0.6.2

### DIFF
--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -1041,10 +1041,7 @@ class DocutilsRenderer:
            otherwise parse to nodes with all syntax rules.
 
         """
-
-        # TODO token.map was None when substituting an image in a table
-        # (should be fixed: https://github.com/executablebooks/markdown-it-py/pull/109)
-        position = token.map[0] if token.map else 9999
+        position = token.map[0]
 
         # front-matter substitutions take priority over config ones
         variable_context = {

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     keywords="markdown lexer parser development docutils sphinx",
     python_requires=">=3.6",
     install_requires=[
-        "markdown-it-py~=0.6.2",
+        "markdown-it-py==0.6.1",
         "mdit-py-plugins~=0.2.5",
         "pyyaml",
         "jinja2",  # required for substitutions, but let sphinx choose version

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,8 @@ setup(
     keywords="markdown lexer parser development docutils sphinx",
     python_requires=">=3.6",
     install_requires=[
-        "markdown-it-py~=0.6.0",
-        "mdit-py-plugins~=0.2.4",
+        "markdown-it-py~=0.6.2",
+        "mdit-py-plugins~=0.2.5",
         "pyyaml",
         "jinja2",  # required for substitutions, but let sphinx choose version
         "docutils>=0.15",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     keywords="markdown lexer parser development docutils sphinx",
     python_requires=">=3.6",
     install_requires=[
-        "markdown-it-py==0.6.1",
+        "markdown-it-py~=0.6.2",
         "mdit-py-plugins~=0.2.5",
         "pyyaml",
         "jinja2",  # required for substitutions, but let sphinx choose version


### PR DESCRIPTION
In particular, this fixes missing line mappings for table rows and their children