### PR TITLE
✨ NEW: Add warning types `myst.subtype`

### DIFF
--- a/docs/using/howto.md
+++ b/docs/using/howto.md
@@ -169,3 +169,25 @@ like so:
 ```md
 {ref}`path/to/file_1:My Subtitle`
 ```
+
+(howto/warnings)=
+## Suppress warnings
+
+In general, if your build logs any warnings, you should either fix them or [raise an Issue](https://github.com/executablebooks/MyST-Parser/issues/new/choose) if you think the warning is erroneous.
+However, in some circumstances if you wish to suppress the warning you can use the [`suppress_warnings`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-suppress_warnings) configuration option.
+All myst-parser warnings are prepended by their type, e.g. to suppress:
+
+```md
+# Title
+### Subtitle
+```
+
+```
+WARNING: Non-consecutive header level increase; 1 to 3 [myst.header]
+```
+
+Add to your `conf.py`:
+
+```python
+suppress_warnings = ["myst.header"]
+```

--- a/myst_parser/html_to_nodes.py
+++ b/myst_parser/html_to_nodes.py
@@ -47,9 +47,12 @@ def html_to_nodes(
     try:
         root = tokenize_html(text).strip(inplace=True, recurse=False)
     except Exception:
-        return [
-            renderer.reporter.warning("HTML could not be parsed", line=line_number)
-        ] + default_html(text, renderer.document["source"], line_number)
+        msg_node = renderer.create_warning(
+            "HTML could not be parsed", line=line_number, subtype="html"
+        )
+        return ([msg_node] if msg_node else []) + default_html(
+            text, renderer.document["source"], line_number
+        )
 
     if len(root) < 1:
         # if empty

--- a/myst_parser/myst_refs.py
+++ b/myst_parser/myst_refs.py
@@ -140,11 +140,19 @@ class MystReferenceResolver(ReferencesResolver):
             except NotImplementedError:
                 # the domain doesn't yet support the new interface
                 # we have to manually collect possible references (SLOW)
+                if not getattr(domain, "__module__", "").startswith("sphinx."):
+                    logger.warning(
+                        f"Domain '{domain.__module__}::{domain.name}' has not "
+                        "implemented a `resolve_any_xref` method [myst.domains]",
+                        type="myst",
+                        subtype="domains",
+                        once=True,
+                    )
                 for role in domain.roles:
                     res = domain.resolve_xref(
                         self.env, refdoc, self.app.builder, role, target, node, contnode
                     )
-                    if res and isinstance(res[0], nodes.Element):
+                    if len(res) and isinstance(res[0], nodes.Element):
                         results.append((f"{domain.name}:{role}", res))
 
         # now, see how many matches we got...
@@ -160,9 +168,11 @@ class MystReferenceResolver(ReferencesResolver):
             logger.warning(
                 __(
                     f"more than one target found for 'myst' cross-reference {target}: "
-                    f"could be {candidates}"
+                    f"could be {candidates} [myst.ref]"
                 ),
                 location=node,
+                type="myst",
+                subtype="ref",
             )
 
         res_role, newnode = results[0]

--- a/tests/test_renderers/fixtures/containers.md
+++ b/tests/test_renderers/fixtures/containers.md
@@ -25,7 +25,7 @@ Nested notes:
     <important>
         <system_message level="2" line="1" source="notset" type="WARNING">
             <paragraph>
-                comma-separated classes are deprecated, use `:class:` option instead
+                comma-separated classes are deprecated, use `:class:` option instead [myst.deprecation]
         <note classes="other">
             <paragraph>
                 <emphasis>
@@ -42,7 +42,7 @@ Admonition with title:
 <document source="notset">
     <system_message level="2" line="1" source="notset" type="WARNING">
         <paragraph>
-            comma-separated classes are deprecated, use `:class:` option instead
+            comma-separated classes are deprecated, use `:class:` option instead [myst.deprecation]
     <admonition classes="other">
         <title>
             A 

--- a/tests/test_renderers/fixtures/sphinx_directives.md
+++ b/tests/test_renderers/fixtures/sphinx_directives.md
@@ -178,7 +178,7 @@ acks (`sphinx.directives.other.Acks`):
 .
 
 --------------------------------
-hlist (`sphinx.directives.other.HList`):
+SPHINX3.5 hlist (`sphinx.directives.other.HList`):
 .
 ```{hlist}
 
@@ -186,7 +186,7 @@ hlist (`sphinx.directives.other.HList`):
 ```
 .
 <document source="notset">
-    <hlist>
+    <hlist ncolumns="2">
         <hlistcol>
             <bullet_list>
                 <list_item>

--- a/tests/test_renderers/test_fixtures.py
+++ b/tests/test_renderers/test_fixtures.py
@@ -108,15 +108,18 @@ def test_sphinx_directives(line, title, input, expected):
     # TODO test domain directives
     if title.startswith("SKIP"):
         pytest.skip(title)
-    if title.startswith("SPHINX3") and sphinx.version_info[0] < 3:
+    elif title.startswith("SPHINX3") and sphinx.version_info[0] < 3:
         pytest.skip(title)
     document = to_docutils(input, in_sphinx_env=True)
-    print(document.pformat())
     _actual, _expected = [
         "\n".join([ll.rstrip() for ll in text.splitlines()])
         for text in (document.pformat(), expected)
     ]
-    assert _actual == _expected
+    try:
+        assert _actual == _expected
+    except AssertionError:
+        print(document.pformat())
+        raise
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
All parsing warnings are assigned a type/subtype,
and also the messages are appended with them.
These warning types can be suppressed
with the sphinx `suppress_warnings` config option.