### PR TITLE
🔧 MAINTAIN: Increase sphinx lower pinning to `v2.1`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "pyyaml",
         "jinja2",  # required for substitutions, but let sphinx choose version
         "docutils>=0.15",
-        "sphinx>=2,<4",
+        "sphinx>=2.1,<4",
     ],
     extras_require={
         "sphinx": [],  # left in for back-compatability


### PR DESCRIPTION
The EventManager initializer changed signature between 2.0 and 2.1.

MyST-Parser uses the >= 2.1 signature.

https://github.com/sphinx-doc/sphinx/blob/v2.0.1/sphinx/events.py#L44-L45
https://github.com/sphinx-doc/sphinx/blob/v2.1.0/sphinx/events.py#L50-L53