### PR TITLE
🧪 TESTS: Add extra backticks case for gettext

### DIFF
--- a/tests/test_sphinx/sourcedirs/gettext/index.md
+++ b/tests/test_sphinx/sourcedirs/gettext/index.md
@@ -25,6 +25,8 @@
 
 **bold** text 11
 
+Extra ```backticks```
+
 </div>
 
     **skip** text

--- a/tests/test_sphinx/test_sphinx_builds/test_gettext.pot
+++ b/tests/test_sphinx/test_sphinx_builds/test_gettext.pot
@@ -59,3 +59,7 @@ msgstr ""
 #: ../../index.md:26
 msgid "**bold** text 11"
 msgstr ""
+
+#: ../../index.md:28
+msgid "Extra ```backticks```"
+msgstr ""


### PR DESCRIPTION
This will be relevant to an issue I'm going to open on mdformat.