### PR TITLE
🔧 MAINTAIN: Linter improvements

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 max-line-length = 88
-ignore=E203,W503
+extend-ignore = E203

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,15 +30,18 @@ repos:
     - id: black
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.0
     hooks:
     - id: flake8
+      additional_dependencies:
+        - flake8-comprehensions
+        - flake8-bugbear
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.812
     hooks:
     - id: mypy
-      args: [--config-file=tox.ini, --show-error-codes]
+      args: [--config-file=tox.ini]
       additional_dependencies:
       - sphinx~=3.3
       - markdown-it-py~=0.6.0

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -168,7 +168,7 @@ class DocutilsRenderer:
         nested_tokens = new_tokens
 
         # render
-        for i, nest_token in enumerate(nested_tokens):
+        for nest_token in nested_tokens:
             # skip hidden?
             if f"render_{nest_token.type}" in self.rules:
                 self.rules[f"render_{nest_token.type}"](nest_token)
@@ -253,7 +253,7 @@ class DocutilsRenderer:
         nested_tokens = new_tokens
 
         # render
-        for i, nest_token in enumerate(nested_tokens):
+        for nest_token in nested_tokens:
             # skip hidden?
             if f"render_{nest_token.type}" in self.rules:
                 self.rules[f"render_{nest_token.type}"](nest_token)
@@ -276,7 +276,7 @@ class DocutilsRenderer:
         self.current_node = current_node
 
     def render_children(self, token: Union[Token, NestedTokens]):
-        for i, child in enumerate(token.children or []):
+        for child in token.children or []:
             if f"render_{child.type}" in self.rules:
                 self.rules[f"render_{child.type}"](child)
             else:
@@ -320,11 +320,11 @@ class DocutilsRenderer:
         self._level_to_elem[level] = section
 
         # Prune level to limit
-        self._level_to_elem = dict(
-            (section_level, section)
+        self._level_to_elem = {
+            section_level: section
             for section_level, section in self._level_to_elem.items()
             if section_level <= level
-        )
+        }
 
     def renderInlineAsText(self, tokens: List[Token]) -> str:
         """Special kludge for image `alt` attributes to conform CommonMark spec.

--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -180,7 +180,11 @@ class MockState:
         nested_renderer = DocutilsRenderer(self._renderer.md)
         options = {k: v for k, v in self._renderer.config.items()}
         options.update(
-            dict(document=self.document, current_node=paragraph, output_footnotes=False)
+            {
+                "document": self.document,
+                "current_node": paragraph,
+                "output_footnotes": False,
+            }
         )
         nested_renderer.render(tokens, options, self._renderer.env)
         return paragraph.children, messages

--- a/myst_parser/myst_refs.py
+++ b/myst_parser/myst_refs.py
@@ -60,7 +60,7 @@ class MystReferenceResolver(ReferencesResolver):
                         node,
                         contnode,
                         **(
-                            dict(allowed_exceptions=(NoUri,))
+                            {"allowed_exceptions": (NoUri,)}
                             if version_info[0] > 2
                             else {}
                         ),

--- a/myst_parser/parse_html.py
+++ b/myst_parser/parse_html.py
@@ -361,7 +361,7 @@ class Tree(object):
             count = 0
 
         # It pops all the items which do not match with the closing tag.
-        for i in range(0, count):
+        for _ in range(0, count):
             self.stack.pop()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -66,3 +66,4 @@ markers =
 
 
 [mypy]
+show_error_codes = true


### PR DESCRIPTION
- add flake8-comprehensions and flake8-bugbear
- move mypy cli arg to configuration file
- use flake8 `extend-ignore` to extend, not override, default ignores