### PR TITLE
🔧 MAINTAIN: Stricter mypy config

### DIFF
--- a/myst_parser/__init__.py
+++ b/myst_parser/__init__.py
@@ -42,7 +42,9 @@ def setup_sphinx(app: "Sphinx"):
 
 def create_myst_config(app):
     from sphinx.util import logging
-    from sphinx.util.console import bold
+
+    # Ignore type checkers because the attribute is dynamically assigned
+    from sphinx.util.console import bold  # type: ignore[attr-defined]
 
     from myst_parser.main import MdParserConfig
 

--- a/myst_parser/cli.py
+++ b/myst_parser/cli.py
@@ -6,25 +6,25 @@ from myst_parser.main import MdParserConfig, default_parser
 
 def print_anchors(args=None):
     """ """
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
+    arg_parser = argparse.ArgumentParser()
+    arg_parser.add_argument(
         "input",
         nargs="?",
         type=argparse.FileType("r"),
         default=sys.stdin,
         help="Input file (default stdin)",
     )
-    parser.add_argument(
+    arg_parser.add_argument(
         "-o",
         "--output",
         type=argparse.FileType("w"),
         default=sys.stdout,
         help="Output file (default stdout)",
     )
-    parser.add_argument(
+    arg_parser.add_argument(
         "-l", "--level", type=int, default=2, help="Maximum heading level."
     )
-    args = parser.parse_args(args)
+    args = arg_parser.parse_args(args)
     parser = default_parser(MdParserConfig(renderer="html", heading_anchors=args.level))
 
     def _filter_plugin(state):

--- a/myst_parser/sphinx_renderer.py
+++ b/myst_parser/sphinx_renderer.py
@@ -203,23 +203,24 @@ def minimal_sphinx_app(
             self._warning = StringIO()
             logging.setup(self, self._status, self._warning)
 
-            self.tags = Tags(None)
+            self.tags = Tags([])
             self.config = Config({}, confoverrides or {})
             self.config.pre_init_values()
             self._init_i18n()
             for extension in builtin_extensions:
                 self.registry.load_extension(self, extension)
             # fresh env
-            self.doctreedir = None
+            self.doctreedir = ""
             self.srcdir = srcdir
             self.confdir = None
-            self.outdir = None
-            self.project = Project(srcdir=srcdir, source_suffix=".md")
-            self.project.docnames = ["mock_docname"]
+            self.outdir = ""
+            self.project = Project(srcdir=srcdir, source_suffix={".md": "markdown"})
+            self.project.docnames = {"mock_docname"}
             self.env = BuildEnvironment()
             self.env.setup(self)
             self.env.temp_data["docname"] = "mock_docname"
-            self.builder = None
+            # Ignore type checkers because we disrespect superclass typing here
+            self.builder = None  # type: ignore[assignment]
 
             if not with_builder:
                 return
@@ -236,7 +237,7 @@ def minimal_sphinx_app(
                 # creating a builder attempts to make the doctreedir
                 self.doctreedir = tempdir
                 self.builder = self.create_builder(buildername)
-            self.doctreedir = None
+            self.doctreedir = ""
 
     app = MockSphinx(
         confoverrides=configuration, srcdir=sourcedir, raise_on_warning=raise_on_warning

--- a/tox.ini
+++ b/tox.ini
@@ -67,3 +67,6 @@ markers =
 
 [mypy]
 show_error_codes = true
+check_untyped_defs = true
+strict_equality = true
+no_implicit_optional = true


### PR DESCRIPTION
Mainly adds `check_untyped_defs = true` so that mypy does some basic type analysis even when type annotations are not present.