### PR TITLE
🐛 FIX: docutils `v0.17` compatibility

### DIFF
--- a/docs/api/sphinx_parser.rst
+++ b/docs/api/sphinx_parser.rst
@@ -7,7 +7,7 @@ This class builds on the :py:class:`~myst_parser.sphinx_renderer.SphinxRenderer`
 to generate a parser for Sphinx, using the :ref:`Sphinx parser API <sphinx:parser-api>`:
 
 .. autoclass:: myst_parser.sphinx_parser.MystParser
-    :members: default_config, supported, parse
+    :members: supported, parse
     :undoc-members:
     :member-order: bysource
     :show-inheritance:

--- a/myst_parser/sphinx_parser.py
+++ b/myst_parser/sphinx_parser.py
@@ -1,8 +1,9 @@
 import time
 from os import path
 
-from docutils import frontend, nodes
+from docutils import nodes
 from docutils.core import publish_doctree
+from docutils.parsers.rst import Parser as RstParser
 from markdown_it.token import Token
 from markdown_it.utils import AttrDict
 from sphinx.application import Sphinx
@@ -20,166 +21,25 @@ class MystParser(Parser):
     """Docutils parser for Markedly Structured Text (MyST)."""
 
     supported = ("md", "markdown", "myst")
-    translate_section_name = None
+    """Aliases this parser supports."""
 
-    default_config: dict = {}
+    settings_spec = ("MyST Parser Options", None, RstParser.settings_spec[2])
+    """Runtime settings specification.
 
-    # these specs are copied verbatim from the docutils RST parser
-    settings_spec = (
-        "MyST Parser Options",
-        None,
-        (
-            (
-                'Recognize and link to standalone PEP references (like "PEP 258").',
-                ["--pep-references"],
-                {"action": "store_true", "validator": frontend.validate_boolean},
-            ),
-            (
-                "Base URL for PEP references "
-                '(default "http://www.python.org/dev/peps/").',
-                ["--pep-base-url"],
-                {
-                    "metavar": "<URL>",
-                    "default": "http://www.python.org/dev/peps/",
-                    "validator": frontend.validate_url_trailing_slash,
-                },
-            ),
-            (
-                'Template for PEP file part of URL. (default "pep-%04d")',
-                ["--pep-file-url-template"],
-                {"metavar": "<URL>", "default": "pep-%04d"},
-            ),
-            (
-                'Recognize and link to standalone RFC references (like "RFC 822").',
-                ["--rfc-references"],
-                {"action": "store_true", "validator": frontend.validate_boolean},
-            ),
-            (
-                'Base URL for RFC references (default "http://tools.ietf.org/html/").',
-                ["--rfc-base-url"],
-                {
-                    "metavar": "<URL>",
-                    "default": "http://tools.ietf.org/html/",
-                    "validator": frontend.validate_url_trailing_slash,
-                },
-            ),
-            (
-                "Set number of spaces for tab expansion (default 8).",
-                ["--tab-width"],
-                {
-                    "metavar": "<width>",
-                    "type": "int",
-                    "default": 8,
-                    "validator": frontend.validate_nonnegative_int,
-                },
-            ),
-            (
-                "Remove spaces before footnote references.",
-                ["--trim-footnote-reference-space"],
-                {"action": "store_true", "validator": frontend.validate_boolean},
-            ),
-            (
-                "Leave spaces before footnote references.",
-                ["--leave-footnote-reference-space"],
-                {"action": "store_false", "dest": "trim_footnote_reference_space"},
-            ),
-            (
-                "Disable directives that insert the contents of external file "
-                '("include" & "raw"); replaced with a "warning" system message.',
-                ["--no-file-insertion"],
-                {
-                    "action": "store_false",
-                    "default": 1,
-                    "dest": "file_insertion_enabled",
-                    "validator": frontend.validate_boolean,
-                },
-            ),
-            (
-                "Enable directives that insert the contents of external file "
-                '("include" & "raw").  Enabled by default.',
-                ["--file-insertion-enabled"],
-                {"action": "store_true"},
-            ),
-            (
-                'Disable the "raw" directives; replaced with a "warning" '
-                "system message.",
-                ["--no-raw"],
-                {
-                    "action": "store_false",
-                    "default": 1,
-                    "dest": "raw_enabled",
-                    "validator": frontend.validate_boolean,
-                },
-            ),
-            (
-                'Enable the "raw" directive.  Enabled by default.',
-                ["--raw-enabled"],
-                {"action": "store_true"},
-            ),
-            (
-                "Maximal number of characters in an input line. Default 10 000.",
-                ["--line-length-limit"],
-                {
-                    "metavar": "<length>",
-                    "default": 10000,
-                    "type": "int",
-                    "validator": frontend.validate_nonnegative_int,
-                },
-            ),
-            (
-                "Token name set for parsing code with Pygments: one of "
-                '"long", "short", or "none (no parsing)". Default is "long".',
-                ["--syntax-highlight"],
-                {
-                    "choices": ["long", "short", "none"],
-                    "default": "long",
-                    "metavar": "<format>",
-                },
-            ),
-            (
-                "Change straight quotation marks to typographic form: "
-                'one of "yes", "no", "alt[ernative]" (default "no").',
-                ["--smart-quotes"],
-                {
-                    "default": False,
-                    "metavar": "<yes/no/alt>",
-                    "validator": frontend.validate_ternary,
-                },
-            ),
-            (
-                'Characters to use as "smart quotes" for <language>. ',
-                ["--smartquotes-locales"],
-                {
-                    "metavar": "<language:quotes[,language:quotes,...]>",
-                    "action": "append",
-                    "validator": frontend.validate_smartquotes_locales,
-                },
-            ),
-            (
-                "Inline markup recognized at word boundaries only "
-                "(adjacent to punctuation or whitespace). "
-                "Force character-level inline markup recognition with "
-                '"\\ " (backslash + space). Default.',
-                ["--word-level-inline-markup"],
-                {"action": "store_false", "dest": "character_level_inline_markup"},
-            ),
-            (
-                "Inline markup recognized anywhere, regardless of surrounding "
-                "characters. Backslash-escapes must be used to avoid unwanted "
-                "markup recognition. Useful for East Asian languages. "
-                "Experimental.",
-                ["--character-level-inline-markup"],
-                {
-                    "action": "store_true",
-                    "default": False,
-                    "dest": "character_level_inline_markup",
-                },
-            ),
-        ),
-    )
+    Defines runtime settings and associated command-line options, as used by
+    `docutils.frontend.OptionParser`.  This is a tuple of:
+
+    - Option group title (string or `None` which implies no group, just a list
+      of single options).
+
+    - Description (string or `None`).
+
+    - A sequence of option tuples
+    """
 
     config_section = "myst parser"
     config_section_dependencies = ("parsers",)
+    translate_section_name = None
 
     def parse(
         self, inputstring: str, document: nodes.document, renderer: str = "sphinx"

--- a/myst_parser/sphinx_parser.py
+++ b/myst_parser/sphinx_parser.py
@@ -117,7 +117,7 @@ class MystParser(Parser):
                 {"action": "store_true"},
             ),
             (
-                'Maximal number of characters in an input line. Default 10 000.',
+                "Maximal number of characters in an input line. Default 10 000.",
                 ["--line-length-limit"],
                 {
                     "metavar": "<length>",

--- a/myst_parser/sphinx_parser.py
+++ b/myst_parser/sphinx_parser.py
@@ -117,6 +117,16 @@ class MystParser(Parser):
                 {"action": "store_true"},
             ),
             (
+                'Maximal number of characters in an input line. Default 10 000.',
+                ["--line-length-limit"],
+                {
+                    "metavar": "<length>",
+                    "default": 10000,
+                    "type": "int",
+                    "validator": frontend.validate_nonnegative_int,
+                },
+            ),
+            (
                 "Token name set for parsing code with Pygments: one of "
                 '"long", "short", or "none (no parsing)". Default is "long".',
                 ["--syntax-highlight"],

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "mdit-py-plugins~=0.2.5",
         "pyyaml",
         "jinja2",  # required for substitutions, but let sphinx choose version
-        "docutils>=0.15,<0.18",
+        "docutils>=0.15",
         "sphinx>=2,<4",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "mdit-py-plugins~=0.2.5",
         "pyyaml",
         "jinja2",  # required for substitutions, but let sphinx choose version
-        "docutils>=0.15",
+        "docutils>=0.15,<0.18",
         "sphinx>=2,<4",
     ],
     extras_require={
@@ -52,6 +52,7 @@ setup(
             "pytest-cov",
             "pytest-regressions",
             "beautifulsoup4",
+            "docutils>=0.17",  # this version changes some HTML tags
         ],
         # Note: This is only required for internal use
         "rtd": [

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.html
@@ -24,7 +24,7 @@
      side
     </p>
    </div>
-   <div class="section" id="header">
+   <section id="header">
     <span id="target">
     </span>
     <h1>
@@ -55,21 +55,23 @@
       </p>
      </div>
     </div>
-    <div class="figure align-default" id="id1">
+    <figure class="align-default" id="id1">
      <span id="target2">
      </span>
      <a class="reference external image-reference" href="https://www.google.com">
       <img alt="_images/example.jpg" src="_images/example.jpg" style="height: 40px;"/>
      </a>
-     <p class="caption">
-      <span class="caption-text">
-       Caption
-      </span>
-      <a class="headerlink" href="#id1" title="Permalink to this image">
-       ¶
-      </a>
-     </p>
-    </div>
+     <figcaption>
+      <p>
+       <span class="caption-text">
+        Caption
+       </span>
+       <a class="headerlink" href="#id1" title="Permalink to this image">
+        ¶
+       </a>
+      </p>
+     </figcaption>
+    </figure>
     <p>
      <img alt="alternative text" src="_images/example.jpg"/>
     </p>
@@ -225,7 +227,7 @@ paragraph
 </pre>
      </div>
     </div>
-   </div>
+   </section>
   </div>
  </div>
 </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_commonmark_only.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_commonmark_only.html
@@ -1,7 +1,7 @@
 <div class="documentwrapper">
  <div class="bodywrapper">
   <div class="body" role="main">
-   <div class="section" id="test">
+   <section id="test">
     <h1>
      Test
      <a class="headerlink" href="#test" title="Permalink to this headline">
@@ -22,7 +22,7 @@
       </span>
      </code>
     </p>
-   </div>
+   </section>
   </div>
  </div>
 </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.html
@@ -1,7 +1,7 @@
 <div class="documentwrapper">
  <div class="bodywrapper">
   <div class="body" role="main">
-   <div class="section" id="test">
+   <section id="test">
     <h1>
      Test
      <a class="headerlink" href="#test" title="Permalink to this headline">
@@ -96,37 +96,41 @@ b=2
       </p>
      </dd>
     </dl>
-    <div class="other figure align-default" id="target">
+    <figure class="other align-default" id="target">
      <img alt="fun-fish" src="_images/fun-fish.png"/>
-     <p class="caption">
-      <span class="caption-text">
-       This is a caption in **Markdown**
-      </span>
-      <a class="headerlink" href="#target" title="Permalink to this image">
-       ¶
-      </a>
-     </p>
-    </div>
-    <div class="other figure align-default" id="other-target">
+     <figcaption>
+      <p>
+       <span class="caption-text">
+        This is a caption in **Markdown**
+       </span>
+       <a class="headerlink" href="#target" title="Permalink to this image">
+        ¶
+       </a>
+      </p>
+     </figcaption>
+    </figure>
+    <figure class="other align-default" id="other-target">
      <a class="bg-primary mb-1 reference internal image-reference" href="_images/fun-fish.png">
       <img alt="fishy" class="bg-primary mb-1" src="_images/fun-fish.png" style="width: 200px;"/>
      </a>
-     <p class="caption">
-      <span class="caption-text">
-       This is a caption in **Markdown**
-      </span>
-      <a class="headerlink" href="#other-target" title="Permalink to this image">
-       ¶
-      </a>
-     </p>
-    </div>
+     <figcaption>
+      <p>
+       <span class="caption-text">
+        This is a caption in **Markdown**
+       </span>
+       <a class="headerlink" href="#other-target" title="Permalink to this image">
+        ¶
+       </a>
+      </p>
+     </figcaption>
+    </figure>
     <p>
      linkify URL:
      <a class="reference external" href="http://www.example.com">
       www.example.com
      </a>
     </p>
-   </div>
+   </section>
   </div>
  </div>
 </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_footnotes.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_footnotes.html
@@ -1,7 +1,7 @@
 <div class="documentwrapper">
  <div class="bodywrapper">
   <div class="body" role="main">
-   <div class="section" id="footnotes-with-markdown">
+   <section id="footnotes-with-markdown">
     <h1>
      Footnotes with Markdown
      <a class="headerlink" href="#footnotes-with-markdown" title="Permalink to this headline">
@@ -116,7 +116,7 @@
       </p>
      </dd>
     </dl>
-   </div>
+   </section>
   </div>
  </div>
 </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_includes.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_includes.html
@@ -1,14 +1,14 @@
 <div class="documentwrapper">
  <div class="bodywrapper">
   <div class="body" role="main">
-   <div class="section" id="main-title">
+   <section id="main-title">
     <h1>
      Main Title
      <a class="headerlink" href="#main-title" title="Permalink to this headline">
       ¶
      </a>
     </h1>
-    <div class="section" id="a-sub-heading-in-include">
+    <section id="a-sub-heading-in-include">
      <span id="inc-header">
      </span>
      <h2>
@@ -23,8 +23,8 @@
        syntax
       </em>
      </p>
-    </div>
-    <div class="section" id="a-sub-heading-in-nested-include">
+    </section>
+    <section id="a-sub-heading-in-nested-include">
      <h2>
       A Sub-Heading in Nested Include
       <a class="headerlink" href="#a-sub-heading-in-nested-include" title="Permalink to this headline">
@@ -40,17 +40,19 @@
      <p>
       This relative path will refer to the importing file:
      </p>
-     <div class="figure align-default" id="id1">
+     <figure class="align-default" id="id1">
       <img alt="_images/example1.jpg" src="_images/example1.jpg"/>
-      <p class="caption">
-       <span class="caption-text">
-        Caption
-       </span>
-       <a class="headerlink" href="#id1" title="Permalink to this image">
-        ¶
-       </a>
-      </p>
-     </div>
+      <figcaption>
+       <p>
+        <span class="caption-text">
+         Caption
+        </span>
+        <a class="headerlink" href="#id1" title="Permalink to this image">
+         ¶
+        </a>
+       </p>
+      </figcaption>
+     </figure>
      <p>
       This absolute path will refer to the project root (where the
       <code class="docutils literal notranslate">
@@ -60,17 +62,19 @@
       </code>
       is):
      </p>
-     <div class="figure align-default" id="id2">
+     <figure class="align-default" id="id2">
       <img alt="_images/example2.jpg" src="_images/example2.jpg"/>
-      <p class="caption">
-       <span class="caption-text">
-        Caption
-       </span>
-       <a class="headerlink" href="#id2" title="Permalink to this image">
-        ¶
-       </a>
-      </p>
-     </div>
+      <figcaption>
+       <p>
+        <span class="caption-text">
+         Caption
+        </span>
+        <a class="headerlink" href="#id2" title="Permalink to this image">
+         ¶
+        </a>
+       </p>
+      </figcaption>
+     </figure>
      <p>
       <img alt="alt" src="_images/example2.jpg"/>
      </p>
@@ -98,8 +102,8 @@
 </pre>
       </div>
      </div>
-     <pre class="code python literal-block"><code><span class="ln">0 </span><span class="keyword">def</span> <span class="name function">a_func</span><span class="punctuation">(</span><span class="name">param</span><span class="punctuation">):</span>
-<span class="ln">1 </span>    <span class="name builtin">print</span><span class="punctuation">(</span><span class="name">param</span><span class="punctuation">)</span></code></pre>
+     <pre class="code python literal-block"><small class="ln">0 </small><code data-lineno="0 "><span class="keyword">def</span> <span class="name function">a_func</span><span class="punctuation">(</span><span class="name">param</span><span class="punctuation">):</span>
+</code><small class="ln">1 </small><code data-lineno="1 ">    <span class="name builtin">print</span><span class="punctuation">(</span><span class="name">param</span><span class="punctuation">)</span></code></pre>
      <div class="highlight-default notranslate">
       <div class="highlight">
        <pre><span></span><span class="n">This</span> <span class="n">should</span> <span class="n">be</span> <span class="o">*</span><span class="n">literal</span><span class="o">*</span>
@@ -113,7 +117,7 @@
      </div>
      <pre class="literal-block" id="literal-ref"><span class="ln">0 </span>Lots
 <span class="ln">1 </span>of</pre>
-     <div class="section" id="a-sub-sub-heading">
+     <section id="a-sub-sub-heading">
       <h3>
        A Sub-sub-Heading
        <a class="headerlink" href="#a-sub-sub-heading" title="Permalink to this headline">
@@ -123,9 +127,9 @@
       <p>
        some more text
       </p>
-     </div>
-    </div>
-   </div>
+     </section>
+    </section>
+   </section>
   </div>
  </div>
 </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_references.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.html
@@ -1,7 +1,7 @@
 <div class="documentwrapper">
  <div class="bodywrapper">
   <div class="body" role="main">
-   <div class="section" id="title-with-nested-a-1">
+   <section id="title-with-nested-a-1">
     <span id="title">
     </span>
     <h1>
@@ -106,7 +106,7 @@
       </span>
      </a>
     </p>
-    <div class="section" id="title-anchors">
+    <section id="title-anchors">
      <h2>
       Title
       <em>
@@ -171,8 +171,8 @@
        </span>
       </a>
      </p>
-    </div>
-   </div>
+    </section>
+   </section>
   </div>
  </div>
 </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_references_singlehtml.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_references_singlehtml.html
@@ -1,7 +1,7 @@
 <div class="documentwrapper">
  <div class="bodywrapper">
   <div class="body" role="main">
-   <div class="section" id="title">
+   <section id="title">
     <h1>
      Title
      <a class="headerlink" href="#title" title="Permalink to this headline">
@@ -11,7 +11,7 @@
     <div class="toctree-wrapper compound">
      <span id="document-other/index">
      </span>
-     <div class="section" id="other-index">
+     <section id="other-index">
       <h2>
        Other Index
        <a class="headerlink" href="#other-index" title="Permalink to this headline">
@@ -21,7 +21,7 @@
       <div class="toctree-wrapper compound">
        <span id="document-other/other">
        </span>
-       <div class="section" id="other-title">
+       <section id="other-title">
         <h3>
          Other Title
          <a class="headerlink" href="#other-title" title="Permalink to this headline">
@@ -56,19 +56,19 @@
           </span>
          </a>
         </p>
-       </div>
+       </section>
        <span id="document-other/other2">
        </span>
-       <div class="section" id="other-2-title">
+       <section id="other-2-title">
         <h3>
          Other 2 Title
          <a class="headerlink" href="#other-2-title" title="Permalink to this headline">
           ¶
          </a>
         </h3>
-       </div>
+       </section>
       </div>
-     </div>
+     </section>
     </div>
     <p>
      <a class="reference internal" href="index.html#document-other/other">
@@ -105,7 +105,7 @@
       </span>
      </a>
     </p>
-   </div>
+   </section>
   </div>
  </div>
 </div>


### PR DESCRIPTION
This adds the missing setting that has been added to the RST parser in docutils v0.17.
Although, perhaps it is better to not have `settings_spec` copy/pasted here, but just inherit it