### PR TITLE
👌 IMPROVE: Add warning for nested headers

### DIFF
--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -463,8 +463,16 @@ class DocutilsRenderer:
         self.current_node.append(node)
 
     def render_heading_open(self, token: NestedTokens):
-        # Test if we're replacing a section level first
 
+        if self.env.get("match_titles", None) is False:
+            self.create_warning(
+                "Header nested in this element can lead to unexpected outcomes",
+                line=token_line(token, default=0),
+                subtype="nested_header",
+                append_to=self.current_node,
+            )
+
+        # Test if we're replacing a section level first
         level = int(token.tag[1])
         if isinstance(self.current_node, nodes.section):
             if self.is_section_level(level, self.current_node):

--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -133,13 +133,18 @@ class MockState:
         state_machine_kwargs=None,
     ) -> None:
         """Perform a nested parse of the input block, with ``node`` as the parent."""
-        current_match_titles = self.state_machine.match_titles
-        self.state_machine.match_titles = match_titles
+        sm_match_titles = self.state_machine.match_titles
+        render_match_titles = self._renderer.env.get("match_titles", None)
+        self.state_machine.match_titles = self._renderer.env[
+            "match_titles"
+        ] = match_titles
+
         with self._renderer.current_node_context(node):
             self._renderer.nested_render_text(
                 "\n".join(block), self._lineno + input_offset
             )
-        self.state_machine.match_titles = current_match_titles
+        self.state_machine.match_titles = sm_match_titles
+        self._renderer.env["match_titles"] = render_match_titles
 
     def parse_target(self, block, block_text, lineno: int):
         """

--- a/tests/test_renderers/fixtures/reporter_warnings.md
+++ b/tests/test_renderers/fixtures/reporter_warnings.md
@@ -129,3 +129,12 @@ source/path:1: (ERROR/3) Directive 'note': option "class" value not string (encl
 :class: [1]
 
 .
+
+header nested in admonition
+.
+```{note}
+# Header
+```
+.
+source/path:1: (WARNING/2) Header nested in this element can lead to unexpected outcomes
+.


### PR DESCRIPTION
When a nested parse is performed and `match_titles=False`,
this informs that headers are not supported in this block,
as is the case for example with admonitions:

````markdown
```{note}
# Header
```
````

A warning (of type `myst.nested_header`) is now emitted when this occurs.