### PR TITLE
✨ NEW: Add `dmath_double_inline` configuration option

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,7 @@ myst_enable_extensions = [
 myst_url_schemes = ("http", "https", "mailto")
 myst_heading_anchors = 2
 myst_footnote_transition = True
+myst_dmath_double_inline = True
 panels_add_bootstrap_css = False
 bibtex_bibfiles = ["examples/references.bib"]
 

--- a/docs/using/intro.md
+++ b/docs/using/intro.md
@@ -281,9 +281,12 @@ Math specific, when `"dollarmath"` activated, see the [Math syntax](syntax/math)
 * - Option
   - Default
   - Description
+* - `myst_dmath_double_inline`
+  - `False`
+  - Allow display math (i.e. `$$`) within an inline context
 * - `myst_dmath_allow_labels`
   - `True`
-  - Parse `$$...$$ (label)` syntax (if dmath enabled)
+  - Parse `$$...$$ (label)` syntax
 * - `myst_dmath_allow_space`
   - `True`
   - If False then inline math will only be parsed if there are no initial/final spaces,

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -763,6 +763,27 @@ There are a few other options available to control dollar math parsing:
 
 These options can both be useful if you also wish to use `$` as a unit of currency.
 
+```{versionadded} 0.14.0
+`myst_dmath_double_inline` option
+```
+
+To allow display math (i.e. `$$`) within an inline context, set `myst_dmath_double_inline = True` (`False` by default).
+This allows for example:
+
+```latex
+Hence, for $\alpha \in (0, 1)$,
+$$
+  \mathbb P (\alpha \bar{X} \ge \mu) \le \alpha;
+$$
+i.e., $[\alpha \bar{X}, \infty)$ is a lower 1-sided $1-\alpha$ confidence bound for $\mu$.
+```
+
+Hence, for $\alpha \in (0, 1)$,
+$$
+  \mathbb P (\alpha \bar{X} \ge \mu) \le \alpha;
+$$
+i.e., $[\alpha \bar{X}, \infty)$ is a lower 1-sided $1-\alpha$ confidence bound for $\mu$.
+
 ### Math in other block elements
 
 Math will also work when nested in other block elements, like lists or quotes:

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -761,7 +761,11 @@ class DocutilsRenderer(RendererProtocol):
 
     def render_math_inline(self, token: SyntaxTreeNode) -> None:
         content = token.content
-        node = nodes.math(content, content)
+        if token.markup == "$$":
+            # available when dmath_double_inline is True
+            node = nodes.math_block(content, content, nowrap=False, number=None)
+        else:
+            node = nodes.math(content, content)
         self.add_line_and_source_path(node, token)
         self.current_node.append(node)
 

--- a/myst_parser/main.py
+++ b/myst_parser/main.py
@@ -33,6 +33,7 @@ class MdParserConfig:
     dmath_allow_labels: bool = attr.ib(default=True, validator=instance_of(bool))
     dmath_allow_space: bool = attr.ib(default=True, validator=instance_of(bool))
     dmath_allow_digits: bool = attr.ib(default=True, validator=instance_of(bool))
+    dmath_double_inline: bool = attr.ib(default=False, validator=instance_of(bool))
 
     update_mathjax: bool = attr.ib(default=True, validator=instance_of(bool))
 
@@ -162,6 +163,7 @@ def default_parser(config: MdParserConfig) -> MarkdownIt:
             allow_labels=config.dmath_allow_labels,
             allow_space=config.dmath_allow_space,
             allow_digits=config.dmath_allow_digits,
+            double_inline=config.dmath_double_inline,
         )
     if "colon_fence" in config.enable_extensions:
         md.use(colon_fence_plugin)

--- a/tests/test_sphinx/sourcedirs/extended_syntaxes/conf.py
+++ b/tests/test_sphinx/sourcedirs/extended_syntaxes/conf.py
@@ -3,6 +3,7 @@ language = "en"
 exclude_patterns = ["_build"]
 myst_disable_syntax = ["emphasis"]
 myst_dmath_allow_space = False
+myst_dmath_double_inline = True
 mathjax_config = {}
 myst_enable_extensions = ["dollarmath", "amsmath", "deflist", "colon_fence", "linkify"]
 myst_html_meta = {

--- a/tests/test_sphinx/sourcedirs/extended_syntaxes/index.md
+++ b/tests/test_sphinx/sourcedirs/extended_syntaxes/index.md
@@ -10,6 +10,8 @@ $$x=5$$ (2)
 
 $ a=1 $
 
+a $$c=3$$ b
+
 \begin{equation}
 b=2
 \end{equation}

--- a/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.html
@@ -31,6 +31,13 @@
     <p>
      $ a=1 $
     </p>
+    <p>
+     a
+     <div class="math notranslate nohighlight">
+      \[c=3\]
+     </div>
+     b
+    </p>
     <div class="amsmath math notranslate nohighlight" id="equation-mock-uuid">
      <span class="eqno">
       (2)

--- a/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.xml
@@ -16,6 +16,11 @@
             x=5
         <paragraph>
             $ a=1 $
+        <paragraph>
+            a 
+            <math_block nowrap="False" number="True" xml:space="preserve">
+                c=3
+             b
         <target refid="equation-mock-uuid">
         <math_block classes="amsmath" docname="index" ids="equation-mock-uuid" label="mock-uuid" nowrap="True" number="2" xml:space="preserve">
             \begin{equation}


### PR DESCRIPTION
Allow display math (i.e. `$$`) within an inline context.
Exposes functionality added in: https://github.com/executablebooks/mdit-py-plugins/pull/19