### PR TITLE
📚 DOCS: literalinclude instead of include-literal

### DIFF
--- a/docs/using/howto.md
+++ b/docs/using/howto.md
@@ -45,7 +45,7 @@ You can now use for example:
 
 ````md
 Source:
-```{include-literal} ../../example.md
+```{literalinclude} ../../example.md
 :language: md
 ```
 Included:


### PR DESCRIPTION
When following the instructions as written, I got the error:

`WARNING: Unknown directive type "literal-include".`

But it worked as expected when I replaced `{include-literal}` with the Spinx directive `{literalinclude}`. (Also, I notice that `{literalinclude}` is the directive being used in this file to include `example-include.md`.)

Using:
* sphinx                             3.4.3
* jupyter-book                  0.10.0
* myst-parser                   0.13.3