### PR TITLE
⬆️ UPGRADE: sphinx v4 (& drop sphinx v2, change mathjax override)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,15 +25,15 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
-        sphinx: [">=3,<4"]
+        sphinx: [">=4,<5"]
         os: [ubuntu-latest]
         include:
           - os: ubuntu-latest
             python-version: 3.8
-            sphinx: ">=2,<3"
+            sphinx: ">=3,<4"
           - os: windows-latest
             python-version: 3.8
-            sphinx: ">=3,<4"
+            sphinx: ">=4,<5"
 
     runs-on: ${{ matrix.os }}
 
@@ -46,8 +46,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install "sphinx${{ matrix.sphinx }}"
         pip install -e .[linkify,testing]
+        pip install --upgrade-strategy "only-if-needed" "sphinx${{ matrix.sphinx }}"
     - name: Run pytest
       run: pytest
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,5 +6,5 @@ coverage:
         threshold: 0.5%
     patch:
       default:
-        target: 79%
+        target: 75%
         threshold: 0.5%

--- a/docs/using/intro.md
+++ b/docs/using/intro.md
@@ -299,14 +299,12 @@ Math specific, when `"dollarmath"` activated, see the [Math syntax](syntax/math)
   - `True`
   - If False then inline math will only be parsed if there are no initial/final digits,
     e.g. `$a$` but not `1$a$` or `$a$2` (this is useful for using `$` as currency)
-* - `myst_amsmath_enable`
-  - `False`
-  - Enable direct parsing of [amsmath LaTeX environments](https://ctan.org/pkg/amsmath)
 * - `myst_update_mathjax`
   - `True`
-  - If using [sphinx.ext.mathjax](https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.mathjax) (the default) then `mathjax_config` will be updated,
-  to ignore `$` delimiters and LaTeX environments, which should instead be handled by
-  `myst_dmath_enable` and `myst_amsmath_enable` respectively.
+  - If using [sphinx.ext.mathjax](https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.mathjax) (the default) then `mathjax_config` will be updated to only process specific HTML classes.
+* - `myst_mathjax_classes`
+  - `"tex2jax_process|mathjax_process|math"`
+  - A regex for the HTML classes that MathJax will process
 `````
 
 ## Disable markdown syntax for the parser

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -810,22 +810,24 @@ See [the extended syntax option](syntax/amsmath).
 (syntax/mathjax)=
 ### Mathjax and math parsing
 
-When building HTML using the [sphinx.ext.mathjax](https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.mathjax) extension (enabled by default), its default configuration is to also search for `$` delimiters and LaTeX environments (see [the tex2jax preprocessor](https://docs.mathjax.org/en/v2.7-latest/options/preprocessors/tex2jax.html#configure-tex2jax)).
+When building HTML using the [sphinx.ext.mathjax](https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.mathjax) extension (enabled by default),
+Myst-Parser injects the `tex2jax_ignore` (MathJax v2) and  `mathjax_ignore` (MathJax v3) classes in to the top-level section of each MyST document, and adds the following default MathJax configuration:
 
-Since such parsing is already covered by the plugins above, MyST-Parser disables this behaviour by overriding the `mathjax_config['tex2jax']` option with:
+MathJax v2 (see [the tex2jax preprocessor](https://docs.mathjax.org/en/v2.7-latest/options/preprocessors/tex2jax.html#configure-tex2jax):
 
-```python
-mathjax_config["tex2jax"] = {
-  "inlineMath": [["\\(", "\\)"]],
-  "displayMath": [["\\[", "\\]"]],
-  "processRefs": False,
-  "processEnvironments": False,
-}
+```javascript
+MathJax.Hub.Config({"tex2jax": {"processClass": "tex2jax_process|mathjax_process|math"}})
 ```
 
-Since these delimiters are how `sphinx.ext.mathjax` wraps the math content in the built HTML documents.
+MathJax v3 (see [the document options](https://docs.mathjax.org/en/latest/options/document.html?highlight=ignoreHtmlClass#the-configuration-block)):
 
-To inhibit this override, set `myst_update_mathjax=False`.
+```javascript
+window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math"}}
+```
+
+This is to ensure that MathJax processes only math, identified by the `dollarmath` and `amsmath` extensions, or specified in `math` directives.
+
+To change this behaviour, set a custom regex like `myst_mathjax_classes="math|myclass"`, or `update_mathjax=False` to inhibit the override and process all HTML elements.
 
 (syntax/frontmatter)=
 

--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -813,21 +813,21 @@ See [the extended syntax option](syntax/amsmath).
 When building HTML using the [sphinx.ext.mathjax](https://www.sphinx-doc.org/en/master/usage/extensions/math.html#module-sphinx.ext.mathjax) extension (enabled by default),
 Myst-Parser injects the `tex2jax_ignore` (MathJax v2) and  `mathjax_ignore` (MathJax v3) classes in to the top-level section of each MyST document, and adds the following default MathJax configuration:
 
-MathJax v2 (see [the tex2jax preprocessor](https://docs.mathjax.org/en/v2.7-latest/options/preprocessors/tex2jax.html#configure-tex2jax):
+MathJax version 2 (see [the tex2jax preprocessor](https://docs.mathjax.org/en/v2.7-latest/options/preprocessors/tex2jax.html#configure-tex2jax):
 
 ```javascript
 MathJax.Hub.Config({"tex2jax": {"processClass": "tex2jax_process|mathjax_process|math"}})
 ```
 
-MathJax v3 (see [the document options](https://docs.mathjax.org/en/latest/options/document.html?highlight=ignoreHtmlClass#the-configuration-block)):
+MathJax version 3 (see [the document options](https://docs.mathjax.org/en/latest/options/document.html?highlight=ignoreHtmlClass#the-configuration-block)):
 
 ```javascript
 window.MathJax = {"options": {"processHtmlClass": "tex2jax_process|mathjax_process|math"}}
 ```
 
-This is to ensure that MathJax processes only math, identified by the `dollarmath` and `amsmath` extensions, or specified in `math` directives.
+This ensurea that MathJax processes only math, identified by the `dollarmath` and `amsmath` extensions, or specified in `math` directives.
 
-To change this behaviour, set a custom regex like `myst_mathjax_classes="math|myclass"`, or `update_mathjax=False` to inhibit the override and process all HTML elements.
+To change this behaviour, set a custom regex, for identifying HTML classes to process, like `myst_mathjax_classes="math|myclass"`, or set `update_mathjax=False` to inhibit this override and process all HTML elements.
 
 (syntax/frontmatter)=
 

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -104,6 +104,14 @@ class DocutilsRenderer(RendererProtocol):
         )
         self._level_to_elem: Dict[int, nodes.Element] = {0: self.document}
 
+    @property
+    def sphinx_env(self) -> Optional[Any]:
+        """Return the sphinx env, if using Sphinx."""
+        try:
+            return self.document.settings.env
+        except AttributeError:
+            return None
+
     def create_warning(
         self,
         message: str,
@@ -232,12 +240,8 @@ class DocutilsRenderer(RendererProtocol):
             return
 
         # save the wordcount to the sphinx BuildEnvironment metadata
-        try:
-            sphinx_env = self.document.settings.env
-        except AttributeError:
-            pass  # if not sphinx renderer
-        else:
-            meta = sphinx_env.metadata.setdefault(sphinx_env.docname, {})
+        if self.sphinx_env is not None:
+            meta = self.sphinx_env.metadata.setdefault(self.sphinx_env.docname, {})
             meta["wordcount"] = wordcount_metadata
 
         # now add the wordcount as substitution definitions,
@@ -455,13 +459,11 @@ class DocutilsRenderer(RendererProtocol):
             return self.render_directive(token)
 
         if not language:
-            try:
-                sphinx_env = self.document.settings.env
-                language = sphinx_env.temp_data.get(
-                    "highlight_language", sphinx_env.config.highlight_language
+            if self.sphinx_env is not None:
+                language = self.sphinx_env.temp_data.get(
+                    "highlight_language", self.sphinx_env.config.highlight_language
                 )
-            except AttributeError:
-                pass
+
         if not language:
             language = self.config.get("highlight_language", "")
         node = nodes.literal_block(text, text, language=language)
@@ -488,6 +490,14 @@ class DocutilsRenderer(RendererProtocol):
         self.add_line_and_source_path(title_node, token)
 
         new_section = nodes.section()
+        if level == 1 and (
+            self.sphinx_env is None
+            or (
+                "myst_update_mathjax" in self.sphinx_env.config
+                and self.sphinx_env.config.myst_update_mathjax
+            )
+        ):
+            new_section["classes"].extend(["tex2jax_ignore", "mathjax_ignore"])
         self.add_line_and_source_path(new_section, token)
         new_section.append(title_node)
 
@@ -1060,10 +1070,8 @@ class DocutilsRenderer(RendererProtocol):
             **self.config.get("myst_substitutions", {}),
             **getattr(self.document, "fm_substitutions", {}),
         }
-        try:
-            variable_context["env"] = self.document.settings.env
-        except AttributeError:
-            pass  # if not sphinx renderer
+        if self.sphinx_env is not None:
+            variable_context["env"] = self.sphinx_env
 
         # fail on undefined variables
         env = jinja2.Environment(undefined=jinja2.StrictUndefined)

--- a/myst_parser/main.py
+++ b/myst_parser/main.py
@@ -38,6 +38,8 @@ class MdParserConfig:
         default="sphinx", validator=in_(["sphinx", "html", "docutils"])
     )
     commonmark_only: bool = attr.ib(default=False, validator=instance_of(bool))
+    enable_extensions: Iterable[str] = attr.ib(factory=lambda: ["dollarmath"])
+
     dmath_allow_labels: bool = attr.ib(default=True, validator=instance_of(bool))
     dmath_allow_space: bool = attr.ib(default=True, validator=instance_of(bool))
     dmath_allow_digits: bool = attr.ib(default=True, validator=instance_of(bool))
@@ -45,7 +47,10 @@ class MdParserConfig:
 
     update_mathjax: bool = attr.ib(default=True, validator=instance_of(bool))
 
-    enable_extensions: Iterable[str] = attr.ib(factory=lambda: ["dollarmath"])
+    mathjax_classes: str = attr.ib(
+        default="tex2jax_process|mathjax_process|math",
+        validator=instance_of(str),
+    )
 
     @enable_extensions.validator
     def check_extensions(self, attribute, value):
@@ -117,6 +122,10 @@ class MdParserConfig:
                 raise TypeError(
                     f"myst_sub_delimiters does not contain strings of length 1: {value}"
                 )
+
+    @classmethod
+    def get_fields(cls) -> Tuple[attr.Attribute, ...]:
+        return attr.fields(cls)
 
     def as_dict(self, dict_factory=dict) -> dict:
         return attr.asdict(self, dict_factory=dict_factory)

--- a/myst_parser/mathjax.py
+++ b/myst_parser/mathjax.py
@@ -20,8 +20,12 @@ logger = logging.getLogger(__name__)
 
 
 def override_mathjax(app: Sphinx):
-    """Override aspects of the mathjax extension, but only if necessary."""
+    """Override aspects of the mathjax extension.
 
+    MyST-Parser parses dollar and latex math, via markdown-it plugins.
+    Therefore, we tell Mathjax to only render these HTML elements.
+    This is accompanied by setting the `ignoreClass` on the top-level section of each MyST document.
+    """
     if (
         "amsmath" in app.config["myst_enable_extensions"]
         and "mathjax" in app.registry.html_block_math_renderers
@@ -30,32 +34,34 @@ def override_mathjax(app: Sphinx):
             html_visit_displaymath,  # type: ignore[assignment]
             None,
         )
-    # https://docs.mathjax.org/en/v2.7-latest/options/preprocessors/tex2jax.html#configure-tex2jax
-    if (
-        app.config.mathjax_config is None
-        and app.env.myst_config.update_mathjax  # type: ignore[attr-defined]
-    ):
-        app.config.mathjax_config = {  # type: ignore[attr-defined]
-            "tex2jax": {
-                "inlineMath": [["\\(", "\\)"]],
-                "displayMath": [["\\[", "\\]"]],
-                "processRefs": False,
-                "processEnvironments": False,
-            }
-        }
-    elif app.env.myst_config.update_mathjax:  # type: ignore[attr-defined]
-        if "tex2jax" in app.config.mathjax_config:
+
+    if not app.env.myst_config.update_mathjax:  # type: ignore[attr-defined]
+        return
+
+    mjax_classes = app.env.myst_config.mathjax_classes  # type: ignore[attr-defined]
+
+    if "mathjax3_config" in app.config:
+        # sphinx 4 + mathjax 3
+        app.config.mathjax3_config = app.config.mathjax3_config or {}  # type: ignore[attr-defined]
+        app.config.mathjax3_config.setdefault("options", {})
+        if "processHtmlClass" in app.config.mathjax3_config["options"]:
             logger.warning(
-                "`mathjax_config['tex2jax']` is set, but `myst_update_mathjax = True`, "
-                "and so this will be overridden. "
-                "Set `myst_update_mathjax = False` if you wish to use your own config"
+                "`mathjax3_config['options']['processHtmlClass']` is being overridden "
+                f"by myst-parser to {mjax_classes}. "
+                "Set `myst_mathjax_classes = None` if this is undesirable."
             )
-        app.config.mathjax_config["tex2jax"] = {
-            "inlineMath": [["\\(", "\\)"]],
-            "displayMath": [["\\[", "\\]"]],
-            "processRefs": False,
-            "processEnvironments": False,
-        }
+        app.config.mathjax3_config["options"]["processHtmlClass"] = mjax_classes
+    else:
+        # sphinx 3 + mathjax 2
+        app.config.mathjax_config = app.config.mathjax_config or {}  # type: ignore[attr-defined]
+        app.config.mathjax_config.setdefault("tex2jax", {})
+        if "processClass" in app.config.mathjax_config["tex2jax"]:
+            logger.warning(
+                "`mathjax_config['tex2jax']['processClass']` is being overridden by "
+                f"myst-parser to {mjax_classes}. "
+                "Set `myst_mathjax_classes = None` if this is undesirable."
+            )
+        app.config.mathjax_config["tex2jax"]["processClass"] = mjax_classes
 
 
 def html_visit_displaymath(self: HTMLTranslator, node: nodes.math_block) -> None:

--- a/myst_parser/mathjax.py
+++ b/myst_parser/mathjax.py
@@ -51,7 +51,7 @@ def override_mathjax(app: Sphinx):
                 "Set `myst_mathjax_classes = None` if this is undesirable."
             )
         app.config.mathjax3_config["options"]["processHtmlClass"] = mjax_classes
-    else:
+    elif "mathjax_config" in app.config:
         # sphinx 3 + mathjax 2
         app.config.mathjax_config = app.config.mathjax_config or {}  # type: ignore[attr-defined]
         app.config.mathjax_config.setdefault("tex2jax", {})

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ install_requires =
     markdown-it-py>=1.0.0,<2.0.0
     mdit-py-plugins~=0.2.8
     pyyaml
-    sphinx>=2.1,<4
+    sphinx>=3,<5
 python_requires = >=3.6
 include_package_data = True
 zip_safe = True

--- a/tests/test_renderers/fixtures/sphinx_directives.md
+++ b/tests/test_renderers/fixtures/sphinx_directives.md
@@ -17,16 +17,16 @@ default-domain (`sphinx.directives.DefaultDomain`):
 .
 
 --------------------------------
-SPHINX3 object (`sphinx.directives.ObjectDescription`):
+SPHINX4 object (`sphinx.directives.ObjectDescription`):
 .
 ```{object} something
 ```
 .
 <document source="notset">
     <index entries="">
-    <desc desctype="object" domain="" noindex="False" objtype="object">
-        <desc_signature>
-            <desc_name xml:space="preserve">
+    <desc classes="object" desctype="object" domain="" noindex="False" objtype="object">
+        <desc_signature classes="sig sig-object">
+            <desc_name classes="sig-name descname" xml:space="preserve">
                 something
         <desc_content>
 .
@@ -178,7 +178,7 @@ acks (`sphinx.directives.other.Acks`):
 .
 
 --------------------------------
-SPHINX3.5 hlist (`sphinx.directives.other.HList`):
+SPHINX4 hlist (`sphinx.directives.other.HList`):
 .
 ```{hlist}
 
@@ -430,47 +430,47 @@ SPHINX3 productionlist (`sphinx.domains.std.ProductionList`):
 .
 
 --------------------------------
-SPHINX3 cmdoption (`sphinx.domains.std.Cmdoption`):
+SPHINX4 cmdoption (`sphinx.domains.std.Cmdoption`):
 .
 ```{cmdoption} a
 ```
 .
 <document source="notset">
     <index entries="('pair',\ 'command\ line\ option;\ a',\ 'cmdoption-arg-a',\ '',\ None)">
-    <desc classes="std" desctype="cmdoption" domain="std" noindex="False" objtype="cmdoption">
-        <desc_signature allnames="a" ids="cmdoption-arg-a">
-            <desc_name xml:space="preserve">
+    <desc classes="std cmdoption" desctype="cmdoption" domain="std" noindex="False" objtype="cmdoption">
+        <desc_signature allnames="a" classes="sig sig-object" ids="cmdoption-arg-a">
+            <desc_name classes="sig-name descname" xml:space="preserve">
                 a
-            <desc_addname xml:space="preserve">
+            <desc_addname classes="sig-prename descclassname" xml:space="preserve">
         <desc_content>
 .
 
 --------------------------------
-SPHINX3 rst:directive (`sphinx.domains.rst.ReSTDirective`):
+SPHINX4 rst:directive (`sphinx.domains.rst.ReSTDirective`):
 .
 ```{rst:directive} a
 ```
 .
 <document source="notset">
     <index entries="('single',\ 'a\ (directive)',\ 'directive-a',\ '',\ None)">
-    <desc classes="rst" desctype="directive" domain="rst" noindex="False" objtype="directive">
-        <desc_signature ids="directive-a">
-            <desc_name xml:space="preserve">
+    <desc classes="rst directive" desctype="directive" domain="rst" noindex="False" objtype="directive">
+        <desc_signature classes="sig sig-object" ids="directive-a">
+            <desc_name classes="sig-name descname" xml:space="preserve">
                 .. a::
         <desc_content>
 .
 
 --------------------------------
-SPHINX3 rst:directive:option (`sphinx.domains.rst.ReSTDirectiveOption`):
+SPHINX4 rst:directive:option (`sphinx.domains.rst.ReSTDirectiveOption`):
 .
 ```{rst:directive:option} a
 ```
 .
 <document source="notset">
     <index entries="('single',\ ':a:\ (directive\ option)',\ 'directive-option-a',\ '',\ 'A')">
-    <desc classes="rst" desctype="directive:option" domain="rst" noindex="False" objtype="directive:option">
-        <desc_signature ids="directive-option-a directive:option--a">
-            <desc_name xml:space="preserve">
+    <desc classes="rst directive:option" desctype="directive:option" domain="rst" noindex="False" objtype="directive:option">
+        <desc_signature classes="sig sig-object" ids="directive-option-a directive:option--a">
+            <desc_name classes="sig-name descname" xml:space="preserve">
                 :a:
         <desc_content>
 .

--- a/tests/test_renderers/fixtures/sphinx_roles.md
+++ b/tests/test_renderers/fixtures/sphinx_roles.md
@@ -191,27 +191,29 @@ cpp:enumerator (`sphinx.domains.cpp.CPPEnumeratorObject`):
 .
 
 --------------------------------
-cpp:expr (`sphinx.domains.cpp.CPPExprRole`):
+SKIP cpp:expr (`sphinx.domains.cpp.CPPExprRole`):
 .
 {cpp:expr}`a`
 .
 <document source="notset">
     <paragraph>
-        <literal classes="xref cpp cpp-expr">
-            <pending_xref classname="True" cpp:parent_key="" modname="True" refdomain="cpp" reftarget="a" reftype="identifier">
-                a
+        <desc_inline classes="cpp-expr sig sig-inline cpp">
+            <pending_xref classname="True" cpp:parent_key="<sphinx.domains.cpp.LookupKey object at 0x7f948a6a73d0>" modname="True" refdomain="cpp" reftarget="a" reftype="identifier">
+                <desc_sig_name classes="n">
+                    a
 .
 
 --------------------------------
-cpp:texpr (`sphinx.domains.cpp.CPPExprRole`):
+SKIP cpp:texpr (`sphinx.domains.cpp.CPPExprRole`):
 .
 {cpp:texpr}`a`
 .
 <document source="notset">
     <paragraph>
-        <inline classes="xref cpp cpp-texpr">
-            <pending_xref classname="True" cpp:parent_key="" modname="True" refdomain="cpp" reftarget="a" reftype="identifier">
-                a
+        <desc_inline classes="cpp-texpr sig sig-inline cpp">
+            <pending_xref classname="True" cpp:parent_key="<sphinx.domains.cpp.LookupKey object at 0x7fac40b5f950>" modname="True" refdomain="cpp" reftarget="a" reftype="identifier">
+                <desc_sig_name classes="n">
+                    a
 .
 
 --------------------------------

--- a/tests/test_renderers/test_fixtures.py
+++ b/tests/test_renderers/test_fixtures.py
@@ -110,6 +110,8 @@ def test_sphinx_directives(line, title, input, expected):
         pytest.skip(title)
     elif title.startswith("SPHINX3") and sphinx.version_info[0] < 3:
         pytest.skip(title)
+    elif title.startswith("SPHINX4") and sphinx.version_info[0] < 4:
+        pytest.skip(title)
     document = to_docutils(input, in_sphinx_env=True)
     _actual, _expected = [
         "\n".join([ll.rstrip() for ll in text.splitlines()])
@@ -129,6 +131,8 @@ def test_sphinx_directives(line, title, input, expected):
 )
 def test_sphinx_roles(line, title, input, expected):
     if title.startswith("SKIP"):
+        pytest.skip(title)
+    elif title.startswith("SPHINX4") and sphinx.version_info[0] < 4:
         pytest.skip(title)
     document = to_docutils(input, in_sphinx_env=True)
     print(document.pformat())

--- a/tests/test_renderers/test_myst_refs/duplicate.xml
+++ b/tests/test_renderers/test_myst_refs/duplicate.xml
@@ -1,4 +1,4 @@
-<document ids="title index" names="title index" source="root/index.md" title="Title">
+<document classes="tex2jax_ignore mathjax_ignore" ids="title index" names="title index" source="root/index.md" title="Title">
     <title>
         Title
     <target refid="index">

--- a/tests/test_renderers/test_myst_refs/ref.xml
+++ b/tests/test_renderers/test_myst_refs/ref.xml
@@ -1,4 +1,4 @@
-<document ids="title ref" names="title ref" source="root/index.md" title="Title">
+<document classes="tex2jax_ignore mathjax_ignore" ids="title ref" names="title ref" source="root/index.md" title="Title">
     <title>
         Title
     <target refid="ref">

--- a/tests/test_renderers/test_myst_refs/ref_nested.xml
+++ b/tests/test_renderers/test_myst_refs/ref_nested.xml
@@ -1,4 +1,4 @@
-<document ids="title ref" names="title ref" source="root/index.md" title="Title">
+<document classes="tex2jax_ignore mathjax_ignore" ids="title ref" names="title ref" source="root/index.md" title="Title">
     <title>
         Title
     <target refid="ref">

--- a/tests/test_sphinx/conftest.py
+++ b/tests/test_sphinx/conftest.py
@@ -65,6 +65,7 @@ def get_sphinx_app_output(file_regression):
         extract_body=False,
         remove_scripts=False,
         regress_html=False,
+        regress_ext=".html",
         replace=None,
     ):
 
@@ -85,7 +86,7 @@ def get_sphinx_app_output(file_regression):
             text = doc_div.prettify()
             for find, rep in (replace or {}).items():
                 text = text.replace(find, rep)
-            file_regression.check(text, extension=".html", encoding="utf8")
+            file_regression.check(text, extension=regress_ext, encoding="utf8")
 
         return content
 
@@ -94,13 +95,20 @@ def get_sphinx_app_output(file_regression):
 
 @pytest.fixture
 def get_sphinx_app_doctree(file_regression):
-    def read(app, docname="index", resolve=False, regress=False, replace=None):
+    def read(
+        app,
+        docname="index",
+        resolve=False,
+        regress=False,
+        replace=None,
+        regress_ext=".xml",
+    ):
         if resolve:
             doctree = app.env.get_and_resolve_doctree(docname, app.builder)
-            extension = ".resolved.xml"
+            extension = f".resolved{regress_ext}"
         else:
             doctree = app.env.get_doctree(docname)
-            extension = ".xml"
+            extension = regress_ext
 
         # convert absolute filenames
         for node in doctree.traverse(

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -1,6 +1,11 @@
 """Uses sphinx's pytest fixture to run builds.
 
 see conftest.py for fixture usage
+
+NOTE: sphinx 3 & 4 regress against different output files,
+the major difference being sphinx 4 uses docutils 0.17,
+which uses semantic HTML tags
+(e.g. converting `<div class="section">` to `<section>`)
 """
 import os
 import re

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -6,6 +6,7 @@ import os
 import re
 
 import pytest
+import sphinx
 
 SOURCE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "sourcedirs"))
 
@@ -28,9 +29,25 @@ def test_basic(
     warnings = warning.getvalue().strip()
     assert warnings == ""
 
-    get_sphinx_app_doctree(app, docname="content", regress=True)
-    get_sphinx_app_doctree(app, docname="content", resolve=True, regress=True)
-    get_sphinx_app_output(app, filename="content.html", regress_html=True)
+    get_sphinx_app_doctree(
+        app,
+        docname="content",
+        regress=True,
+        regress_ext=f".sphinx{sphinx.version_info[0]}.xml",
+    )
+    get_sphinx_app_doctree(
+        app,
+        docname="content",
+        resolve=True,
+        regress=True,
+        regress_ext=f".sphinx{sphinx.version_info[0]}.xml",
+    )
+    get_sphinx_app_output(
+        app,
+        filename="content.html",
+        regress_html=True,
+        regress_ext=f".sphinx{sphinx.version_info[0]}.html",
+    )
 
     assert app.env.metadata["content"] == {
         "author": "Chris Sewell",
@@ -72,7 +89,12 @@ def test_references(
         get_sphinx_app_doctree(app, docname="index", regress=True)
     finally:
         get_sphinx_app_doctree(app, docname="index", resolve=True, regress=True)
-    get_sphinx_app_output(app, filename="index.html", regress_html=True)
+    get_sphinx_app_output(
+        app,
+        filename="index.html",
+        regress_html=True,
+        regress_ext=f".sphinx{sphinx.version_info[0]}.html",
+    )
 
 
 @pytest.mark.sphinx(
@@ -118,7 +140,11 @@ def test_references_singlehtml(
         )
 
     get_sphinx_app_output(
-        app, filename="index.html", buildername="singlehtml", regress_html=True
+        app,
+        filename="index.html",
+        buildername="singlehtml",
+        regress_html=True,
+        regress_ext=f".sphinx{sphinx.version_info[0]}.html",
     )
 
 
@@ -146,7 +172,12 @@ def test_heading_slug_func(
         get_sphinx_app_doctree(app, docname="index", regress=True)
     finally:
         get_sphinx_app_doctree(app, docname="index", resolve=True, regress=True)
-    get_sphinx_app_output(app, filename="index.html", regress_html=True)
+    get_sphinx_app_output(
+        app,
+        filename="index.html",
+        regress_html=True,
+        regress_ext=f".sphinx{sphinx.version_info[0]}.html",
+    )
 
 
 @pytest.mark.sphinx(
@@ -173,9 +204,19 @@ def test_extended_syntaxes(
     assert warnings == ""
 
     try:
-        get_sphinx_app_doctree(app, docname="index", regress=True)
+        get_sphinx_app_doctree(
+            app,
+            docname="index",
+            regress=True,
+            regress_ext=f".sphinx{sphinx.version_info[0]}.xml",
+        )
     finally:
-        get_sphinx_app_output(app, filename="index.html", regress_html=True)
+        get_sphinx_app_output(
+            app,
+            filename="index.html",
+            regress_html=True,
+            regress_ext=f".sphinx{sphinx.version_info[0]}.html",
+        )
 
 
 @pytest.mark.sphinx(
@@ -201,6 +242,7 @@ def test_includes(
             app,
             docname="index",
             regress=True,
+            regress_ext=f".sphinx{sphinx.version_info[0]}.xml",
             # fix for Windows CI
             replace={
                 r"subfolder\example2.jpg": "subfolder/example2.jpg",
@@ -213,6 +255,7 @@ def test_includes(
             app,
             filename="index.html",
             regress_html=True,
+            regress_ext=f".sphinx{sphinx.version_info[0]}.html",
             replace={
                 r"'subfolder\\example2'": "'subfolder/example2'",
                 r'uri="subfolder\\example2"': 'uri="subfolder/example2"',
@@ -242,7 +285,12 @@ def test_footnotes(
     try:
         get_sphinx_app_doctree(app, docname="footnote_md", regress=True)
     finally:
-        get_sphinx_app_output(app, filename="footnote_md.html", regress_html=True)
+        get_sphinx_app_output(
+            app,
+            filename="footnote_md.html",
+            regress_html=True,
+            regress_ext=f".sphinx{sphinx.version_info[0]}.html",
+        )
 
 
 @pytest.mark.sphinx(
@@ -267,7 +315,12 @@ def test_commonmark_only(
     try:
         get_sphinx_app_doctree(app, docname="index", regress=True)
     finally:
-        get_sphinx_app_output(app, filename="index.html", regress_html=True)
+        get_sphinx_app_output(
+            app,
+            filename="index.html",
+            regress_html=True,
+            regress_ext=f".sphinx{sphinx.version_info[0]}.html",
+        )
 
 
 @pytest.mark.sphinx(

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.resolved.sphinx3.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.resolved.sphinx3.xml
@@ -1,0 +1,146 @@
+<document source="content.md">
+    <topic classes="dedication">
+        <title>
+            Dedication
+        <paragraph>
+            To my 
+            <emphasis>
+                homies
+            
+    <topic classes="abstract">
+        <title>
+            Abstract
+        <paragraph>
+            Something something 
+            <strong>
+                dark
+             side
+    <target refid="target">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="header target" names="header target">
+        <title>
+            Header
+        <comment xml:space="preserve">
+            comment
+        <note>
+            <paragraph>
+                abcd 
+                <emphasis>
+                    abc
+                 
+                <reference refuri="https://www.google.com">
+                    google
+            <warning>
+                <paragraph>
+                    xyz
+        <target refid="target2">
+        <figure align="default" ids="id1 target2" names="target2">
+            <reference refuri="https://www.google.com">
+                <image candidates="{'*': 'example.jpg'}" height="40px" uri="example.jpg">
+            <caption>
+                Caption
+        <paragraph>
+            <image alt="alternative text" candidates="{'*': 'example.jpg'}" uri="example.jpg">
+        <paragraph>
+            <reference refuri="https://www.google.com">
+                https://www.google.com
+        <paragraph>
+            <strong>
+                <literal classes="code">
+                     a=1{`} 
+        <paragraph>
+            <math>
+                sdfds
+        <paragraph>
+            <strong>
+                <math>
+                    a=1
+        <math_block nowrap="False" number="True" xml:space="preserve">
+            b=2
+        <target refid="equation-eq-label">
+        <math_block docname="content" ids="equation-eq-label" label="eq:label" nowrap="False" number="1" xml:space="preserve">
+            c=2
+        <paragraph>
+            <reference internal="True" refid="equation-eq-label">
+                (1)
+        <paragraph>
+            <literal>
+                a=1{`}
+        <table align="default" classes="colwidths-auto">
+            <tgroup cols="2">
+                <colspec colwidth="50.0">
+                <colspec colwidth="50.0">
+                <thead>
+                    <row>
+                        <entry>
+                            <paragraph>
+                                a
+                        <entry classes="text-align:right">
+                            <paragraph>
+                                b
+                <tbody>
+                    <row>
+                        <entry>
+                            <paragraph>
+                                <emphasis>
+                                    a
+                        <entry classes="text-align:right">
+                            <paragraph>
+                                2
+                    <row>
+                        <entry>
+                            <paragraph>
+                                <reference refuri="https://google.com">
+                                    link-a
+                        <entry classes="text-align:right">
+                            <paragraph>
+                                <reference refuri="https://python.org">
+                                    link-b
+        <paragraph>
+            this
+            
+            is
+            
+            a
+            
+            paragraph
+        <comment xml:space="preserve">
+            a comment 2
+        <paragraph>
+            this is a second paragraph
+        <bullet_list>
+            <list_item>
+                <paragraph>
+                    a list
+                <bullet_list>
+                    <list_item>
+                        <paragraph>
+                            a sub list
+        <comment xml:space="preserve">
+            a comment 3
+        <bullet_list>
+            <list_item>
+                <paragraph>
+                    new list?
+        <paragraph>
+            <reference internal="True" refid="target">
+                <inline classes="std std-ref">
+                    Header
+              
+            <reference internal="True" refid="target2">
+                <inline classes="std std-ref">
+                    Caption
+        <comment classes="block_break" xml:space="preserve">
+            a block break
+        <paragraph>
+            <reference refuri="https://www.google.com" title="a title">
+                name
+        <literal_block language="default" linenos="False" xml:space="preserve">
+            def func(a, b=1):
+                print(a)
+        <paragraph>
+            Special substitution references:
+        <paragraph>
+            53
+             words | 
+            0
+             min read

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.resolved.sphinx4.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.resolved.sphinx4.xml
@@ -1,0 +1,146 @@
+<document source="content.md">
+    <topic classes="dedication">
+        <title>
+            Dedication
+        <paragraph>
+            To my 
+            <emphasis>
+                homies
+            
+    <topic classes="abstract">
+        <title>
+            Abstract
+        <paragraph>
+            Something something 
+            <strong>
+                dark
+             side
+    <target refid="target">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="header target" names="header target">
+        <title>
+            Header
+        <comment xml:space="preserve">
+            comment
+        <note>
+            <paragraph>
+                abcd 
+                <emphasis>
+                    abc
+                 
+                <reference refuri="https://www.google.com">
+                    google
+            <warning>
+                <paragraph>
+                    xyz
+        <target refid="target2">
+        <figure ids="id1 target2" names="target2">
+            <reference refuri="https://www.google.com">
+                <image candidates="{'*': 'example.jpg'}" height="40px" uri="example.jpg">
+            <caption>
+                Caption
+        <paragraph>
+            <image alt="alternative text" candidates="{'*': 'example.jpg'}" uri="example.jpg">
+        <paragraph>
+            <reference refuri="https://www.google.com">
+                https://www.google.com
+        <paragraph>
+            <strong>
+                <literal classes="code">
+                     a=1{`} 
+        <paragraph>
+            <math>
+                sdfds
+        <paragraph>
+            <strong>
+                <math>
+                    a=1
+        <math_block nowrap="False" number="True" xml:space="preserve">
+            b=2
+        <target refid="equation-eq-label">
+        <math_block docname="content" ids="equation-eq-label" label="eq:label" nowrap="False" number="1" xml:space="preserve">
+            c=2
+        <paragraph>
+            <reference internal="True" refid="equation-eq-label">
+                (1)
+        <paragraph>
+            <literal>
+                a=1{`}
+        <table classes="colwidths-auto">
+            <tgroup cols="2">
+                <colspec colwidth="50.0">
+                <colspec colwidth="50.0">
+                <thead>
+                    <row>
+                        <entry>
+                            <paragraph>
+                                a
+                        <entry classes="text-align:right">
+                            <paragraph>
+                                b
+                <tbody>
+                    <row>
+                        <entry>
+                            <paragraph>
+                                <emphasis>
+                                    a
+                        <entry classes="text-align:right">
+                            <paragraph>
+                                2
+                    <row>
+                        <entry>
+                            <paragraph>
+                                <reference refuri="https://google.com">
+                                    link-a
+                        <entry classes="text-align:right">
+                            <paragraph>
+                                <reference refuri="https://python.org">
+                                    link-b
+        <paragraph>
+            this
+            
+            is
+            
+            a
+            
+            paragraph
+        <comment xml:space="preserve">
+            a comment 2
+        <paragraph>
+            this is a second paragraph
+        <bullet_list>
+            <list_item>
+                <paragraph>
+                    a list
+                <bullet_list>
+                    <list_item>
+                        <paragraph>
+                            a sub list
+        <comment xml:space="preserve">
+            a comment 3
+        <bullet_list>
+            <list_item>
+                <paragraph>
+                    new list?
+        <paragraph>
+            <reference internal="True" refid="target">
+                <inline classes="std std-ref">
+                    Header
+              
+            <reference internal="True" refid="target2">
+                <inline classes="std std-ref">
+                    Caption
+        <comment classes="block_break" xml:space="preserve">
+            a block break
+        <paragraph>
+            <reference refuri="https://www.google.com" title="a title">
+                name
+        <literal_block language="default" linenos="False" xml:space="preserve">
+            def func(a, b=1):
+                print(a)
+        <paragraph>
+            Special substitution references:
+        <paragraph>
+            53
+             words | 
+            0
+             min read

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx3.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx3.html
@@ -24,7 +24,7 @@
      side
     </p>
    </div>
-   <section id="header">
+   <div class="tex2jax_ignore mathjax_ignore section" id="header">
     <span id="target">
     </span>
     <h1>
@@ -55,23 +55,21 @@
       </p>
      </div>
     </div>
-    <figure class="align-default" id="id1">
+    <div class="figure align-default" id="id1">
      <span id="target2">
      </span>
      <a class="reference external image-reference" href="https://www.google.com">
       <img alt="_images/example.jpg" src="_images/example.jpg" style="height: 40px;"/>
      </a>
-     <figcaption>
-      <p>
-       <span class="caption-text">
-        Caption
-       </span>
-       <a class="headerlink" href="#id1" title="Permalink to this image">
-        ¶
-       </a>
-      </p>
-     </figcaption>
-    </figure>
+     <p class="caption">
+      <span class="caption-text">
+       Caption
+      </span>
+      <a class="headerlink" href="#id1" title="Permalink to this image">
+       ¶
+      </a>
+     </p>
+    </div>
     <p>
      <img alt="alternative text" src="_images/example.jpg"/>
     </p>
@@ -233,7 +231,7 @@ paragraph
     <p>
      53 words | 0 min read
     </p>
-   </section>
+   </div>
   </div>
  </div>
 </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx3.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx3.xml
@@ -16,7 +16,7 @@
                 dark
              side
     <target refid="target">
-    <section ids="header target" names="header target">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="header target" names="header target">
         <title>
             Header
         <comment xml:space="preserve">
@@ -60,8 +60,9 @@
         <math_block docname="content" ids="equation-eq-label" label="eq:label" nowrap="False" number="1" xml:space="preserve">
             c=2
         <paragraph>
-            <reference internal="True" refid="equation-eq-label">
-                (1)
+            <pending_xref refdoc="content" refdomain="math" refexplicit="False" reftarget="eq:label" reftype="eq" refwarn="True">
+                <literal classes="xref eq">
+                    eq:label
         <paragraph>
             <literal>
                 a=1{`}
@@ -122,19 +123,19 @@
                 <paragraph>
                     new list?
         <paragraph>
-            <reference internal="True" refid="target">
-                <inline classes="std std-ref">
-                    Header
+            <pending_xref refdoc="content" refdomain="std" refexplicit="False" reftarget="target" reftype="ref" refwarn="True">
+                <inline classes="xref std std-ref">
+                    target
               
-            <reference internal="True" refid="target2">
-                <inline classes="std std-ref">
-                    Caption
+            <pending_xref refdoc="content" refdomain="std" refexplicit="False" reftarget="target2" reftype="ref" refwarn="True">
+                <inline classes="xref std std-ref">
+                    target2
         <comment classes="block_break" xml:space="preserve">
             a block break
         <paragraph>
             <reference refuri="https://www.google.com" title="a title">
                 name
-        <literal_block language="default" linenos="False" xml:space="preserve">
+        <literal_block language="default" xml:space="preserve">
             def func(a, b=1):
                 print(a)
         <paragraph>

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx4.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx4.html
@@ -1,0 +1,239 @@
+<div class="documentwrapper">
+ <div class="bodywrapper">
+  <div class="body" role="main">
+   <div class="dedication topic">
+    <p class="topic-title">
+     Dedication
+    </p>
+    <p>
+     To my
+     <em>
+      homies
+     </em>
+    </p>
+   </div>
+   <div class="abstract topic">
+    <p class="topic-title">
+     Abstract
+    </p>
+    <p>
+     Something something
+     <strong>
+      dark
+     </strong>
+     side
+    </p>
+   </div>
+   <section class="tex2jax_ignore mathjax_ignore" id="header">
+    <span id="target">
+    </span>
+    <h1>
+     Header
+     <a class="headerlink" href="#header" title="Permalink to this headline">
+      ¶
+     </a>
+    </h1>
+    <div class="admonition note">
+     <p class="admonition-title">
+      Note
+     </p>
+     <p>
+      abcd
+      <em>
+       abc
+      </em>
+      <a class="reference external" href="https://www.google.com">
+       google
+      </a>
+     </p>
+     <div class="admonition warning">
+      <p class="admonition-title">
+       Warning
+      </p>
+      <p>
+       xyz
+      </p>
+     </div>
+    </div>
+    <figure class="align-default" id="id1">
+     <span id="target2">
+     </span>
+     <a class="reference external image-reference" href="https://www.google.com">
+      <img alt="_images/example.jpg" src="_images/example.jpg" style="height: 40px;"/>
+     </a>
+     <figcaption>
+      <p>
+       <span class="caption-text">
+        Caption
+       </span>
+       <a class="headerlink" href="#id1" title="Permalink to this image">
+        ¶
+       </a>
+      </p>
+     </figcaption>
+    </figure>
+    <p>
+     <img alt="alternative text" src="_images/example.jpg"/>
+    </p>
+    <p>
+     <a class="reference external" href="https://www.google.com">
+      https://www.google.com
+     </a>
+    </p>
+    <p>
+     <strong>
+      <code class="code docutils literal notranslate">
+       <span class="pre">
+        a=1{`}
+       </span>
+      </code>
+     </strong>
+    </p>
+    <p>
+     <span class="math notranslate nohighlight">
+      \(sdfds\)
+     </span>
+    </p>
+    <p>
+     <strong>
+      <span class="math notranslate nohighlight">
+       \(a=1\)
+      </span>
+     </strong>
+    </p>
+    <div class="math notranslate nohighlight">
+     \[b=2\]
+    </div>
+    <div class="math notranslate nohighlight" id="equation-eq-label">
+     <span class="eqno">
+      (1)
+      <a class="headerlink" href="#equation-eq-label" title="Permalink to this equation">
+       ¶
+      </a>
+     </span>
+     \[c=2\]
+    </div>
+    <p>
+     <a class="reference internal" href="#equation-eq-label">
+      (1)
+     </a>
+    </p>
+    <p>
+     <code class="docutils literal notranslate">
+      <span class="pre">
+       a=1{`}
+      </span>
+     </code>
+    </p>
+    <table class="colwidths-auto docutils align-default">
+     <thead>
+      <tr class="row-odd">
+       <th class="head">
+        <p>
+         a
+        </p>
+       </th>
+       <th class="text-align:right head">
+        <p>
+         b
+        </p>
+       </th>
+      </tr>
+     </thead>
+     <tbody>
+      <tr class="row-even">
+       <td>
+        <p>
+         <em>
+          a
+         </em>
+        </p>
+       </td>
+       <td class="text-align:right">
+        <p>
+         2
+        </p>
+       </td>
+      </tr>
+      <tr class="row-odd">
+       <td>
+        <p>
+         <a class="reference external" href="https://google.com">
+          link-a
+         </a>
+        </p>
+       </td>
+       <td class="text-align:right">
+        <p>
+         <a class="reference external" href="https://python.org">
+          link-b
+         </a>
+        </p>
+       </td>
+      </tr>
+     </tbody>
+    </table>
+    <p>
+     this
+is
+a
+paragraph
+    </p>
+    <p>
+     this is a second paragraph
+    </p>
+    <ul class="simple">
+     <li>
+      <p>
+       a list
+      </p>
+      <ul>
+       <li>
+        <p>
+         a sub list
+        </p>
+       </li>
+      </ul>
+     </li>
+    </ul>
+    <ul class="simple">
+     <li>
+      <p>
+       new list?
+      </p>
+     </li>
+    </ul>
+    <p>
+     <a class="reference internal" href="#target">
+      <span class="std std-ref">
+       Header
+      </span>
+     </a>
+     <a class="reference internal" href="#target2">
+      <span class="std std-ref">
+       Caption
+      </span>
+     </a>
+    </p>
+    <p>
+     <a class="reference external" href="https://www.google.com">
+      name
+     </a>
+    </p>
+    <div class="highlight-default notranslate">
+     <div class="highlight">
+      <pre><span></span><span class="k">def</span> <span class="nf">func</span><span class="p">(</span><span class="n">a</span><span class="p">,</span> <span class="n">b</span><span class="o">=</span><span class="mi">1</span><span class="p">):</span>
+    <span class="nb">print</span><span class="p">(</span><span class="n">a</span><span class="p">)</span>
+</pre>
+     </div>
+    </div>
+    <p>
+     Special substitution references:
+    </p>
+    <p>
+     53 words | 0 min read
+    </p>
+   </section>
+  </div>
+ </div>
+</div>

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx4.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx4.xml
@@ -16,7 +16,7 @@
                 dark
              side
     <target refid="target">
-    <section ids="header target" names="header target">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="header target" names="header target">
         <title>
             Header
         <comment xml:space="preserve">
@@ -33,7 +33,7 @@
                 <paragraph>
                     xyz
         <target refid="target2">
-        <figure align="default" ids="id1 target2" names="target2">
+        <figure ids="id1 target2" names="target2">
             <reference refuri="https://www.google.com">
                 <image candidates="{'*': 'example.jpg'}" height="40px" uri="example.jpg">
             <caption>
@@ -66,7 +66,7 @@
         <paragraph>
             <literal>
                 a=1{`}
-        <table align="default" classes="colwidths-auto">
+        <table classes="colwidths-auto">
             <tgroup cols="2">
                 <colspec colwidth="50.0">
                 <colspec colwidth="50.0">

--- a/tests/test_sphinx/test_sphinx_builds/test_commonmark_only.sphinx3.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_commonmark_only.sphinx3.html
@@ -1,7 +1,7 @@
 <div class="documentwrapper">
  <div class="bodywrapper">
   <div class="body" role="main">
-   <section id="test">
+   <div class="tex2jax_ignore mathjax_ignore section" id="test">
     <h1>
      Test
      <a class="headerlink" href="#test" title="Permalink to this headline">
@@ -22,7 +22,7 @@
       </span>
      </code>
     </p>
-   </section>
+   </div>
   </div>
  </div>
 </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_commonmark_only.sphinx4.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_commonmark_only.sphinx4.html
@@ -1,0 +1,28 @@
+<div class="documentwrapper">
+ <div class="bodywrapper">
+  <div class="body" role="main">
+   <section class="tex2jax_ignore mathjax_ignore" id="test">
+    <h1>
+     Test
+     <a class="headerlink" href="#test" title="Permalink to this headline">
+      ¶
+     </a>
+    </h1>
+    <div class="highlight-{note} notranslate">
+     <div class="highlight">
+      <pre><span></span>hallo
+</pre>
+     </div>
+    </div>
+    <p>
+     {a}
+     <code class="docutils literal notranslate">
+      <span class="pre">
+       b
+      </span>
+     </code>
+    </p>
+   </section>
+  </div>
+ </div>
+</div>

--- a/tests/test_sphinx/test_sphinx_builds/test_commonmark_only.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_commonmark_only.xml
@@ -1,5 +1,5 @@
 <document source="index.md">
-    <section ids="test" names="test">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="test" names="test">
         <title>
             Test
         <literal_block language="{note}" xml:space="preserve">

--- a/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.sphinx3.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.sphinx3.html
@@ -1,0 +1,153 @@
+<div class="documentwrapper">
+ <div class="bodywrapper">
+  <div class="body" role="main">
+   <div class="tex2jax_ignore mathjax_ignore section" id="test">
+    <h1>
+     Test
+     <a class="headerlink" href="#test" title="Permalink to this headline">
+      ¶
+     </a>
+    </h1>
+    <p>
+     *disabled*
+    </p>
+    <p>
+     <span class="math notranslate nohighlight">
+      \(a=1\)
+     </span>
+    </p>
+    <div class="math notranslate nohighlight">
+     \[x=5\]
+    </div>
+    <div class="math notranslate nohighlight" id="equation-2">
+     <span class="eqno">
+      (1)
+      <a class="headerlink" href="#equation-2" title="Permalink to this equation">
+       ¶
+      </a>
+     </span>
+     \[x=5\]
+    </div>
+    <p>
+     $ a=1 $
+    </p>
+    <p>
+     a
+     <div class="math notranslate nohighlight">
+      \[c=3\]
+     </div>
+     b
+    </p>
+    <div class="amsmath math notranslate nohighlight" id="equation-mock-uuid">
+     <span class="eqno">
+      (2)
+      <a class="headerlink" href="#equation-mock-uuid" title="Permalink to this equation">
+       ¶
+      </a>
+     </span>
+     \[\begin{equation}
+b=2
+\end{equation}\]
+    </div>
+    <div class="math notranslate nohighlight">
+     \[ \begin{align}\begin{aligned}c=3\\d=4\end{aligned}\end{align} \]
+    </div>
+    <dl class="simple myst">
+     <dt>
+      Term **1**
+     </dt>
+     <dd>
+      <p>
+       Definition *1*
+      </p>
+      <p>
+       second paragraph
+      </p>
+     </dd>
+     <dt>
+      Term 2
+     </dt>
+     <dd>
+      <p>
+       Definition 2a
+      </p>
+     </dd>
+     <dd>
+      <p>
+       Definition 2b
+      </p>
+     </dd>
+     <dt>
+      Term 3
+     </dt>
+     <dd>
+      <div class="highlight-none notranslate">
+       <div class="highlight">
+        <pre><span></span>code block
+</pre>
+       </div>
+      </div>
+     </dd>
+     <dd>
+      <blockquote>
+       <div>
+        <p>
+         quote
+        </p>
+       </div>
+      </blockquote>
+     </dd>
+     <dd>
+      <p>
+       other
+      </p>
+     </dd>
+    </dl>
+    <div class="other figure align-default" id="target">
+     <img alt="fun-fish" src="_images/fun-fish.png"/>
+     <p class="caption">
+      <span class="caption-text">
+       This is a caption in **Markdown**
+      </span>
+      <a class="headerlink" href="#target" title="Permalink to this image">
+       ¶
+      </a>
+     </p>
+    </div>
+    <div class="other figure align-default" id="other-target">
+     <a class="bg-primary mb-1 reference internal image-reference" href="_images/fun-fish.png">
+      <img alt="fishy" class="bg-primary mb-1" src="_images/fun-fish.png" style="width: 200px;"/>
+     </a>
+     <p class="caption">
+      <span class="caption-text">
+       This is a caption in **Markdown**
+      </span>
+      <a class="headerlink" href="#other-target" title="Permalink to this image">
+       ¶
+      </a>
+     </p>
+    </div>
+    <p>
+     linkify URL:
+     <a class="reference external" href="http://www.example.com">
+      www.example.com
+     </a>
+    </p>
+    <ul class="contains-task-list simple">
+     <li class="task-list-item">
+      <p>
+       <input class="task-list-item-checkbox" disabled="disabled" type="checkbox"/>
+       hallo
+      </p>
+     </li>
+     <li class="task-list-item">
+      <p>
+       <input checked="checked" class="task-list-item-checkbox" disabled="disabled" type="checkbox"/>
+       there
+      </p>
+     </li>
+    </ul>
+   </div>
+  </div>
+ </div>
+</div>

--- a/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.sphinx3.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.sphinx3.xml
@@ -1,7 +1,7 @@
 <document source="index.md">
     <meta content="meta description" lang="en" name="description">
     <meta content="en_US" property="og:locale">
-    <section ids="test" names="test">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="test" names="test">
         <title>
             Test
         <paragraph>

--- a/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.sphinx4.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.sphinx4.html
@@ -1,7 +1,7 @@
 <div class="documentwrapper">
  <div class="bodywrapper">
   <div class="body" role="main">
-   <section id="test">
+   <section class="tex2jax_ignore mathjax_ignore" id="test">
     <h1>
      Test
      <a class="headerlink" href="#test" title="Permalink to this headline">

--- a/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.sphinx4.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.sphinx4.xml
@@ -1,0 +1,86 @@
+<document source="index.md">
+    <meta content="meta description" lang="en" name="description">
+    <meta content="en_US" property="og:locale">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="test" names="test">
+        <title>
+            Test
+        <paragraph>
+            *disabled*
+        <paragraph>
+            <math>
+                a=1
+        <math_block nowrap="False" number="True" xml:space="preserve">
+            x=5
+        <target refid="equation-2">
+        <math_block docname="index" ids="equation-2" label="2" nowrap="False" number="1" xml:space="preserve">
+            x=5
+        <paragraph>
+            $ a=1 $
+        <paragraph>
+            a 
+            <math_block nowrap="False" number="True" xml:space="preserve">
+                c=3
+             b
+        <target refid="equation-mock-uuid">
+        <math_block classes="amsmath" docname="index" ids="equation-mock-uuid" label="mock-uuid" nowrap="True" number="2" xml:space="preserve">
+            \begin{equation}
+            b=2
+            \end{equation}
+        <math_block docname="index" label="True" nowrap="False" number="True" xml:space="preserve">
+            c=3
+            
+            d=4
+        <definition_list classes="simple myst">
+            <definition_list_item>
+                <term>
+                    Term **1**
+                <definition>
+                    <paragraph>
+                        Definition *1*
+                    <paragraph>
+                        second paragraph
+            <definition_list_item>
+                <term>
+                    Term 2
+                <definition>
+                    <paragraph>
+                        Definition 2a
+                <definition>
+                    <paragraph>
+                        Definition 2b
+            <definition_list_item>
+                <term>
+                    Term 3
+                <definition>
+                    <literal_block language="none" xml:space="preserve">
+                        code block
+                <definition>
+                    <block_quote>
+                        <paragraph>
+                            quote
+                <definition>
+                    <paragraph>
+                        other
+        <figure classes="other" ids="target" names="target">
+            <image alt="fun-fish" candidates="{'*': 'fun-fish.png'}" uri="fun-fish.png">
+            <caption>
+                This is a caption in **Markdown**
+        <figure classes="other" ids="other-target" names="other-target">
+            <image alt="fishy" candidates="{'*': 'fun-fish.png'}" classes="bg-primary mb-1" uri="fun-fish.png" width="200px">
+            <caption>
+                This is a caption in **Markdown**
+        <paragraph>
+            linkify URL: 
+            <reference refuri="http://www.example.com">
+                www.example.com
+        <bullet_list classes="contains-task-list">
+            <list_item classes="task-list-item">
+                <paragraph>
+                    <raw format="html" xml:space="preserve">
+                        <input class="task-list-item-checkbox" disabled="disabled" type="checkbox">
+                     hallo
+            <list_item classes="task-list-item">
+                <paragraph>
+                    <raw format="html" xml:space="preserve">
+                        <input class="task-list-item-checkbox" checked="checked" disabled="disabled" type="checkbox">
+                     there

--- a/tests/test_sphinx/test_sphinx_builds/test_footnotes.sphinx3.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_footnotes.sphinx3.html
@@ -1,0 +1,147 @@
+<div class="documentwrapper">
+ <div class="bodywrapper">
+  <div class="body" role="main">
+   <div class="tex2jax_ignore mathjax_ignore section" id="footnotes-with-markdown">
+    <h1>
+     Footnotes with Markdown
+     <a class="headerlink" href="#footnotes-with-markdown" title="Permalink to this headline">
+      ¶
+     </a>
+    </h1>
+    <p>
+     <a class="footnote-reference brackets" href="#c" id="id1">
+      1
+     </a>
+    </p>
+    <div class="admonition note">
+     <p class="admonition-title">
+      Note
+     </p>
+     <p>
+      <a class="footnote-reference brackets" href="#d" id="id2">
+       2
+      </a>
+     </p>
+    </div>
+    <p>
+     <a class="footnote-reference brackets" href="#a" id="id3">
+      3
+     </a>
+    </p>
+    <p>
+     <a class="footnote-reference brackets" href="#b" id="id4">
+      4
+     </a>
+    </p>
+    <p>
+     <a class="footnote-reference brackets" href="#id8" id="id5">
+      123
+     </a>
+     <a class="footnote-reference brackets" href="#id8" id="id6">
+      123
+     </a>
+    </p>
+    <p>
+     <a class="footnote-reference brackets" href="#e" id="id7">
+      5
+     </a>
+    </p>
+    <blockquote>
+     <div>
+      <ul class="simple">
+       <li>
+       </li>
+      </ul>
+     </div>
+    </blockquote>
+    <hr class="footnotes docutils"/>
+    <dl class="footnote brackets">
+     <dt class="label" id="c">
+      <span class="brackets">
+       <a class="fn-backref" href="#id1">
+        1
+       </a>
+      </span>
+     </dt>
+     <dd>
+      <p>
+       a footnote referenced first
+      </p>
+     </dd>
+     <dt class="label" id="d">
+      <span class="brackets">
+       <a class="fn-backref" href="#id2">
+        2
+       </a>
+      </span>
+     </dt>
+     <dd>
+      <p>
+       a footnote referenced in a directive
+      </p>
+     </dd>
+     <dt class="label" id="a">
+      <span class="brackets">
+       <a class="fn-backref" href="#id3">
+        3
+       </a>
+      </span>
+     </dt>
+     <dd>
+      <p>
+       some footnote
+       <em>
+        text
+       </em>
+      </p>
+     </dd>
+     <dt class="label" id="b">
+      <span class="brackets">
+       <a class="fn-backref" href="#id4">
+        4
+       </a>
+      </span>
+     </dt>
+     <dd>
+      <p>
+       a footnote before its reference
+      </p>
+     </dd>
+     <dt class="label" id="id8">
+      <span class="brackets">
+       123
+      </span>
+      <span class="fn-backref">
+       (
+       <a href="#id5">
+        1
+       </a>
+       ,
+       <a href="#id6">
+        2
+       </a>
+       )
+      </span>
+     </dt>
+     <dd>
+      <p>
+       multiple references footnote
+      </p>
+     </dd>
+     <dt class="label" id="e">
+      <span class="brackets">
+       <a class="fn-backref" href="#id7">
+        5
+       </a>
+      </span>
+     </dt>
+     <dd>
+      <p>
+       footnote definition in a block element
+      </p>
+     </dd>
+    </dl>
+   </div>
+  </div>
+ </div>
+</div>

--- a/tests/test_sphinx/test_sphinx_builds/test_footnotes.sphinx4.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_footnotes.sphinx4.html
@@ -1,7 +1,7 @@
 <div class="documentwrapper">
  <div class="bodywrapper">
   <div class="body" role="main">
-   <section id="footnotes-with-markdown">
+   <section class="tex2jax_ignore mathjax_ignore" id="footnotes-with-markdown">
     <h1>
      Footnotes with Markdown
      <a class="headerlink" href="#footnotes-with-markdown" title="Permalink to this headline">

--- a/tests/test_sphinx/test_sphinx_builds/test_footnotes.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_footnotes.xml
@@ -1,5 +1,5 @@
 <document source="footnote_md.md">
-    <section ids="footnotes-with-markdown" names="footnotes\ with\ markdown">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="footnotes-with-markdown" names="footnotes\ with\ markdown">
         <title>
             Footnotes with Markdown
         <paragraph>

--- a/tests/test_sphinx/test_sphinx_builds/test_heading_slug_func.resolved.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_heading_slug_func.resolved.xml
@@ -1,5 +1,5 @@
 <document source="index.md">
-    <section ids="hyphen-1" myst-anchor="index.md#hyphen-1" names="hyphen\ -\ 1">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="hyphen-1" myst-anchor="index.md#hyphen-1" names="hyphen\ -\ 1">
         <title>
             Hyphen - 1
         <section ids="dot-1-1" myst-anchor="index.md#dot-1-1" names="dot\ 1.1">

--- a/tests/test_sphinx/test_sphinx_builds/test_heading_slug_func.sphinx3.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_heading_slug_func.sphinx3.html
@@ -1,22 +1,22 @@
 <div class="documentwrapper">
  <div class="bodywrapper">
   <div class="body" role="main">
-   <section id="hyphen-1">
+   <div class="tex2jax_ignore mathjax_ignore section" id="hyphen-1">
     <h1>
      Hyphen - 1
      <a class="headerlink" href="#hyphen-1" title="Permalink to this headline">
       ¶
      </a>
     </h1>
-    <section id="dot-1-1">
+    <div class="section" id="dot-1-1">
      <h2>
       Dot 1.1
       <a class="headerlink" href="#dot-1-1" title="Permalink to this headline">
        ¶
       </a>
      </h2>
-    </section>
-   </section>
+    </div>
+   </div>
   </div>
  </div>
 </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_heading_slug_func.sphinx4.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_heading_slug_func.sphinx4.html
@@ -1,0 +1,22 @@
+<div class="documentwrapper">
+ <div class="bodywrapper">
+  <div class="body" role="main">
+   <section class="tex2jax_ignore mathjax_ignore" id="hyphen-1">
+    <h1>
+     Hyphen - 1
+     <a class="headerlink" href="#hyphen-1" title="Permalink to this headline">
+      ¶
+     </a>
+    </h1>
+    <section id="dot-1-1">
+     <h2>
+      Dot 1.1
+      <a class="headerlink" href="#dot-1-1" title="Permalink to this headline">
+       ¶
+      </a>
+     </h2>
+    </section>
+   </section>
+  </div>
+ </div>
+</div>

--- a/tests/test_sphinx/test_sphinx_builds/test_heading_slug_func.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_heading_slug_func.xml
@@ -1,5 +1,5 @@
 <document source="index.md">
-    <section ids="hyphen-1" myst-anchor="index.md#hyphen-1" names="hyphen\ -\ 1">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="hyphen-1" myst-anchor="index.md#hyphen-1" names="hyphen\ -\ 1">
         <title>
             Hyphen - 1
         <section ids="dot-1-1" myst-anchor="index.md#dot-1-1" names="dot\ 1.1">

--- a/tests/test_sphinx/test_sphinx_builds/test_includes.sphinx3.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_includes.sphinx3.html
@@ -1,0 +1,131 @@
+<div class="documentwrapper">
+ <div class="bodywrapper">
+  <div class="body" role="main">
+   <div class="tex2jax_ignore mathjax_ignore section" id="main-title">
+    <h1>
+     Main Title
+     <a class="headerlink" href="#main-title" title="Permalink to this headline">
+      ¶
+     </a>
+    </h1>
+    <div class="section" id="a-sub-heading-in-include">
+     <span id="inc-header">
+     </span>
+     <h2>
+      A Sub-Heading in Include
+      <a class="headerlink" href="#a-sub-heading-in-include" title="Permalink to this headline">
+       ¶
+      </a>
+     </h2>
+     <p>
+      Some text with
+      <em>
+       syntax
+      </em>
+     </p>
+    </div>
+    <div class="section" id="a-sub-heading-in-nested-include">
+     <h2>
+      A Sub-Heading in Nested Include
+      <a class="headerlink" href="#a-sub-heading-in-nested-include" title="Permalink to this headline">
+       ¶
+      </a>
+     </h2>
+     <p>
+      Some other text with
+      <strong>
+       syntax
+      </strong>
+     </p>
+     <p>
+      This relative path will refer to the importing file:
+     </p>
+     <div class="figure align-default" id="id1">
+      <img alt="_images/example1.jpg" src="_images/example1.jpg"/>
+      <p class="caption">
+       <span class="caption-text">
+        Caption
+       </span>
+       <a class="headerlink" href="#id1" title="Permalink to this image">
+        ¶
+       </a>
+      </p>
+     </div>
+     <p>
+      This absolute path will refer to the project root (where the
+      <code class="docutils literal notranslate">
+       <span class="pre">
+        conf.py
+       </span>
+      </code>
+      is):
+     </p>
+     <div class="figure align-default" id="id2">
+      <img alt="_images/example2.jpg" src="_images/example2.jpg"/>
+      <p class="caption">
+       <span class="caption-text">
+        Caption
+       </span>
+       <a class="headerlink" href="#id2" title="Permalink to this image">
+        ¶
+       </a>
+      </p>
+     </div>
+     <p>
+      <img alt="alt" src="_images/example2.jpg"/>
+     </p>
+     <p>
+      <img alt="alt" src="https://example.com"/>
+     </p>
+     <p>
+      <a class="reference internal" href="#">
+       <span class="doc std std-doc">
+        text
+       </span>
+      </a>
+     </p>
+     <p>
+      <a class="reference internal" href="#inc-header">
+       <span class="std std-ref">
+        A Sub-Heading in Include
+       </span>
+      </a>
+     </p>
+     <div class="code python highlight-default notranslate">
+      <div class="highlight">
+       <pre><span></span><span class="k">def</span> <span class="nf">a_func</span><span class="p">(</span><span class="n">param</span><span class="p">):</span>
+    <span class="nb">print</span><span class="p">(</span><span class="n">param</span><span class="p">)</span>
+</pre>
+      </div>
+     </div>
+     <pre class="code python literal-block"><code><span class="ln">0 </span><span class="keyword">def</span> <span class="name function">a_func</span><span class="punctuation">(</span><span class="name">param</span><span class="punctuation">):</span>
+<span class="ln">1 </span>    <span class="name builtin">print</span><span class="punctuation">(</span><span class="name">param</span><span class="punctuation">)</span></code></pre>
+     <div class="highlight-default notranslate">
+      <div class="highlight">
+       <pre><span></span><span class="n">This</span> <span class="n">should</span> <span class="n">be</span> <span class="o">*</span><span class="n">literal</span><span class="o">*</span>
+
+<span class="n">Lots</span>
+<span class="n">of</span>
+<span class="n">lines</span>
+<span class="n">so</span> <span class="n">we</span> <span class="n">can</span> <span class="n">select</span> <span class="n">some</span>
+</pre>
+      </div>
+     </div>
+     <pre class="literal-block" id="literal-ref"><span class="ln">0 </span>Lots
+<span class="ln">1 </span>of</pre>
+     <div class="section" id="a-sub-sub-heading">
+      <h3>
+       A Sub-sub-Heading
+       <a class="headerlink" href="#a-sub-sub-heading" title="Permalink to this headline">
+        ¶
+       </a>
+      </h3>
+      <p>
+       some more text
+      </p>
+     </div>
+    </div>
+   </div>
+  </div>
+ </div>
+</div>

--- a/tests/test_sphinx/test_sphinx_builds/test_includes.sphinx3.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_includes.sphinx3.xml
@@ -1,5 +1,5 @@
 <document source="index.md">
-    <section ids="main-title" names="main\ title">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="main-title" names="main\ title">
         <title>
             Main Title
         <target refid="inc-header">

--- a/tests/test_sphinx/test_sphinx_builds/test_includes.sphinx4.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_includes.sphinx4.html
@@ -1,7 +1,7 @@
 <div class="documentwrapper">
  <div class="bodywrapper">
   <div class="body" role="main">
-   <section id="main-title">
+   <section class="tex2jax_ignore mathjax_ignore" id="main-title">
     <h1>
      Main Title
      <a class="headerlink" href="#main-title" title="Permalink to this headline">

--- a/tests/test_sphinx/test_sphinx_builds/test_includes.sphinx4.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_includes.sphinx4.xml
@@ -1,0 +1,113 @@
+<document source="index.md">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="main-title" names="main\ title">
+        <title>
+            Main Title
+        <target refid="inc-header">
+        <section ids="a-sub-heading-in-include inc-header" names="a\ sub-heading\ in\ include inc_header">
+            <title>
+                A Sub-Heading in Include
+            <paragraph>
+                Some text with 
+                <emphasis>
+                    syntax
+        <section ids="a-sub-heading-in-nested-include" names="a\ sub-heading\ in\ nested\ include">
+            <title>
+                A Sub-Heading in Nested Include
+            <paragraph>
+                Some other text with 
+                <strong>
+                    syntax
+            <paragraph>
+                This relative path will refer to the importing file:
+            <figure ids="id1">
+                <image candidates="{'*': 'example1.jpg'}" uri="example1.jpg">
+                <caption>
+                    Caption
+            <paragraph>
+                This absolute path will refer to the project root (where the 
+                <literal>
+                    conf.py
+                 is):
+            <figure ids="id2">
+                <image candidates="{'*': 'subfolder/example2.jpg'}" uri="subfolder/example2.jpg">
+                <caption>
+                    Caption
+            <paragraph>
+                <image alt="alt" candidates="{'*': 'subfolder/example2.jpg'}" uri="subfolder/example2.jpg">
+            <paragraph>
+                <image alt="alt" candidates="{'?': 'https://example.com'}" uri="https://example.com">
+            <paragraph>
+                <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="index.md" reftype="myst" refwarn="True">
+                    <inline classes="xref myst">
+                        text
+            <paragraph>
+                <pending_xref refdoc="index" refdomain="std" refexplicit="False" reftarget="inc_header" reftype="ref" refwarn="True">
+                    <inline classes="xref std std-ref">
+                        inc_header
+            <literal_block classes="code python" source="include_code.py" xml:space="preserve">
+                <inline classes="keyword">
+                    def
+                 
+                <inline classes="name function">
+                    a_func
+                <inline classes="punctuation">
+                    (
+                <inline classes="name">
+                    param
+                <inline classes="punctuation">
+                    ):
+                
+                    
+                <inline classes="name builtin">
+                    print
+                <inline classes="punctuation">
+                    (
+                <inline classes="name">
+                    param
+                <inline classes="punctuation">
+                    )
+            <literal_block classes="code python" source="include_code.py" xml:space="preserve">
+                <inline classes="ln">
+                    0 
+                <inline classes="keyword">
+                    def
+                 
+                <inline classes="name function">
+                    a_func
+                <inline classes="punctuation">
+                    (
+                <inline classes="name">
+                    param
+                <inline classes="punctuation">
+                    ):
+                
+                <inline classes="ln">
+                    1 
+                    
+                <inline classes="name builtin">
+                    print
+                <inline classes="punctuation">
+                    (
+                <inline classes="name">
+                    param
+                <inline classes="punctuation">
+                    )
+            <literal_block source="include_literal.txt" xml:space="preserve">
+                This should be *literal*
+                
+                Lots
+                of
+                lines
+                so we can select some
+            <literal_block ids="literal-ref" names="literal_ref" source="include_literal.txt" xml:space="preserve">
+                <inline classes="ln">
+                    0 
+                Lots
+                <inline classes="ln">
+                    1 
+                of
+            <section ids="a-sub-sub-heading" names="a\ sub-sub-heading">
+                <title>
+                    A Sub-sub-Heading
+                <paragraph>
+                    some more text

--- a/tests/test_sphinx/test_sphinx_builds/test_references.resolved.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.resolved.xml
@@ -1,6 +1,6 @@
 <document source="index.md">
     <target refid="title">
-    <section ids="title-with-nested-a-1 title" myst-anchor="index.md#title-with-nested" names="title\ with\ nested\ a=1 title">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="title-with-nested-a-1 title" myst-anchor="index.md#title-with-nested" names="title\ with\ nested\ a=1 title">
         <title>
             Title with 
             <strong>

--- a/tests/test_sphinx/test_sphinx_builds/test_references.sphinx3.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.sphinx3.html
@@ -1,7 +1,7 @@
 <div class="documentwrapper">
  <div class="bodywrapper">
   <div class="body" role="main">
-   <section id="title-with-nested-a-1">
+   <div class="tex2jax_ignore mathjax_ignore section" id="title-with-nested-a-1">
     <span id="title">
     </span>
     <h1>
@@ -106,7 +106,7 @@
       </span>
      </a>
     </p>
-    <section id="title-anchors">
+    <div class="section" id="title-anchors">
      <h2>
       Title
       <em>
@@ -171,8 +171,8 @@
        </span>
       </a>
      </p>
-    </section>
-   </section>
+    </div>
+   </div>
   </div>
  </div>
 </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_references.sphinx4.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.sphinx4.html
@@ -1,0 +1,178 @@
+<div class="documentwrapper">
+ <div class="bodywrapper">
+  <div class="body" role="main">
+   <section class="tex2jax_ignore mathjax_ignore" id="title-with-nested-a-1">
+    <span id="title">
+    </span>
+    <h1>
+     Title with
+     <strong>
+      nested
+     </strong>
+     <span class="math notranslate nohighlight">
+      \(a=1\)
+     </span>
+     <a class="headerlink" href="#title-with-nested-a-1" title="Permalink to this headline">
+      ¶
+     </a>
+    </h1>
+    <p>
+     <a class="reference external" href="https://example.com">
+     </a>
+    </p>
+    <p>
+     <a class="reference external" href="https://example.com">
+      plain text
+     </a>
+    </p>
+    <p>
+     <a class="reference external" href="https://example.com">
+      nested
+      <em>
+       syntax
+      </em>
+     </a>
+    </p>
+    <p>
+     <a class="reference internal" href="#title">
+      <span class="std std-ref">
+       Title with nested a=1
+      </span>
+     </a>
+    </p>
+    <p>
+     <a class="reference internal" href="#title">
+      <span class="std std-ref">
+       plain text
+      </span>
+     </a>
+    </p>
+    <p>
+     <a class="reference internal" href="#title">
+      <span class="std std-ref">
+       nested
+       <em>
+        syntax
+       </em>
+      </span>
+     </a>
+    </p>
+    <p>
+     <a class="reference internal" href="#">
+      <span class="doc std std-doc">
+       Title with nested a=1
+      </span>
+     </a>
+    </p>
+    <p>
+     <a class="reference internal" href="#">
+      <span class="doc std std-doc">
+       plain text
+      </span>
+     </a>
+    </p>
+    <p>
+     <a class="reference internal" href="#">
+      <span class="doc std std-doc">
+       nested
+       <em>
+        syntax
+       </em>
+      </span>
+     </a>
+    </p>
+    <p id="insidecodeblock">
+     I am inside the eval-rst fence
+    </p>
+    <p>
+     Referencing the
+     <a class="reference internal" href="#title">
+      <span class="std std-ref">
+       Title with nested a=1
+      </span>
+     </a>
+    </p>
+    <p>
+     Still inside the codeblock
+     <a class="reference internal" href="#insidecodeblock">
+      insidecodeblock
+     </a>
+    </p>
+    <p>
+     I am outside the
+     <a class="reference internal" href="#insidecodeblock">
+      <span class="std std-ref">
+       fence
+      </span>
+     </a>
+    </p>
+    <section id="title-anchors">
+     <h2>
+      Title
+      <em>
+       anchors
+      </em>
+      <a class="headerlink" href="#title-anchors" title="Permalink to this headline">
+       ¶
+      </a>
+     </h2>
+     <div class="toctree-wrapper compound">
+      <ul>
+       <li class="toctree-l1">
+        <a class="reference internal" href="other.html">
+         Title
+         <em>
+          anchors
+         </em>
+        </a>
+       </li>
+       <li class="toctree-l1">
+        <a class="reference internal" href="subfolder/other2.html">
+         Title
+         <em>
+          anchors
+         </em>
+        </a>
+       </li>
+      </ul>
+     </div>
+     <p>
+      <a class="reference internal" href="#title-anchors">
+       <span class="std std-doc">
+        Title anchors
+       </span>
+      </a>
+     </p>
+     <p>
+      <a class="reference internal" href="#title-anchors">
+       <span class="std std-doc">
+        Title anchors
+       </span>
+      </a>
+     </p>
+     <p>
+      <a class="reference internal" href="other.html#title-anchors">
+       <span class="std std-doc">
+        Title anchors
+       </span>
+      </a>
+     </p>
+     <p>
+      <a class="reference internal" href="other.html#title-anchors">
+       <span class="std std-doc">
+        Title anchors
+       </span>
+      </a>
+     </p>
+     <p>
+      <a class="reference internal" href="subfolder/other2.html#title-anchors">
+       <span class="std std-doc">
+        Title anchors
+       </span>
+      </a>
+     </p>
+    </section>
+   </section>
+  </div>
+ </div>
+</div>

--- a/tests/test_sphinx/test_sphinx_builds/test_references.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.xml
@@ -1,6 +1,6 @@
 <document source="index.md">
     <target refid="title">
-    <section ids="title-with-nested-a-1 title" myst-anchor="index.md#title-with-nested" names="title\ with\ nested\ a=1 title">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="title-with-nested-a-1 title" myst-anchor="index.md#title-with-nested" names="title\ with\ nested\ a=1 title">
         <title>
             Title with 
             <strong>

--- a/tests/test_sphinx/test_sphinx_builds/test_references_singlehtml.resolved.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references_singlehtml.resolved.xml
@@ -1,5 +1,5 @@
 <document source="other.md">
-    <section ids="other-title" myst-anchor="other/other.md#other-title" names="other\ title">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="other-title" myst-anchor="other/other.md#other-title" names="other\ title">
         <title>
             Other Title
         <paragraph>

--- a/tests/test_sphinx/test_sphinx_builds/test_references_singlehtml.sphinx3.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_references_singlehtml.sphinx3.html
@@ -1,0 +1,111 @@
+<div class="documentwrapper">
+ <div class="bodywrapper">
+  <div class="body" role="main">
+   <div class="tex2jax_ignore mathjax_ignore section" id="title">
+    <h1>
+     Title
+     <a class="headerlink" href="#title" title="Permalink to this headline">
+      ¶
+     </a>
+    </h1>
+    <div class="toctree-wrapper compound">
+     <span id="document-other/index">
+     </span>
+     <div class="tex2jax_ignore mathjax_ignore section" id="other-index">
+      <h2>
+       Other Index
+       <a class="headerlink" href="#other-index" title="Permalink to this headline">
+        ¶
+       </a>
+      </h2>
+      <div class="toctree-wrapper compound">
+       <span id="document-other/other">
+       </span>
+       <div class="tex2jax_ignore mathjax_ignore section" id="other-title">
+        <h3>
+         Other Title
+         <a class="headerlink" href="#other-title" title="Permalink to this headline">
+          ¶
+         </a>
+        </h3>
+        <p>
+         <a class="reference internal" href="index.html#document-other/other2">
+          <span class="doc">
+           Other 2 Title
+          </span>
+         </a>
+        </p>
+        <p>
+         <a class="reference internal" href="index.html#document-other/other2">
+          <span class="doc">
+           Other 2 Title
+          </span>
+         </a>
+        </p>
+        <p>
+         <a class="reference internal" href="index.html#document-other/other2">
+          <span class="doc std std-doc">
+           Other 2 Title
+          </span>
+         </a>
+        </p>
+        <p>
+         <a class="reference internal" href="index.html#title">
+          <span class="std std-doc">
+           Title
+          </span>
+         </a>
+        </p>
+       </div>
+       <span id="document-other/other2">
+       </span>
+       <div class="tex2jax_ignore mathjax_ignore section" id="other-2-title">
+        <h3>
+         Other 2 Title
+         <a class="headerlink" href="#other-2-title" title="Permalink to this headline">
+          ¶
+         </a>
+        </h3>
+       </div>
+      </div>
+     </div>
+    </div>
+    <p>
+     <a class="reference internal" href="index.html#document-other/other">
+      <span class="doc">
+       Other Title
+      </span>
+     </a>
+    </p>
+    <p>
+     <a class="reference internal" href="index.html#document-other/other">
+      <span class="doc">
+       Other Title
+      </span>
+     </a>
+    </p>
+    <p>
+     <a class="reference internal" href="index.html#document-other/other">
+      <span class="doc std std-doc">
+       Other Title
+      </span>
+     </a>
+    </p>
+    <p>
+     <a class="reference internal" href="#title">
+      <span class="std std-doc">
+       Title
+      </span>
+     </a>
+    </p>
+    <p>
+     <a class="reference internal" href="index.html#other-title">
+      <span class="std std-doc">
+       Other Title
+      </span>
+     </a>
+    </p>
+   </div>
+  </div>
+ </div>
+</div>

--- a/tests/test_sphinx/test_sphinx_builds/test_references_singlehtml.sphinx4.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_references_singlehtml.sphinx4.html
@@ -1,7 +1,7 @@
 <div class="documentwrapper">
  <div class="bodywrapper">
   <div class="body" role="main">
-   <section id="title">
+   <section class="tex2jax_ignore mathjax_ignore" id="title">
     <h1>
      Title
      <a class="headerlink" href="#title" title="Permalink to this headline">
@@ -11,7 +11,7 @@
     <div class="toctree-wrapper compound">
      <span id="document-other/index">
      </span>
-     <section id="other-index">
+     <section class="tex2jax_ignore mathjax_ignore" id="other-index">
       <h2>
        Other Index
        <a class="headerlink" href="#other-index" title="Permalink to this headline">
@@ -21,7 +21,7 @@
       <div class="toctree-wrapper compound">
        <span id="document-other/other">
        </span>
-       <section id="other-title">
+       <section class="tex2jax_ignore mathjax_ignore" id="other-title">
         <h3>
          Other Title
          <a class="headerlink" href="#other-title" title="Permalink to this headline">
@@ -59,7 +59,7 @@
        </section>
        <span id="document-other/other2">
        </span>
-       <section id="other-2-title">
+       <section class="tex2jax_ignore mathjax_ignore" id="other-2-title">
         <h3>
          Other 2 Title
          <a class="headerlink" href="#other-2-title" title="Permalink to this headline">

--- a/tests/test_sphinx/test_sphinx_builds/test_references_singlehtml.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references_singlehtml.xml
@@ -1,5 +1,5 @@
 <document source="other.md">
-    <section ids="other-title" myst-anchor="other/other.md#other-title" names="other\ title">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="other-title" myst-anchor="other/other.md#other-title" names="other\ title">
         <title>
             Other Title
         <paragraph>

--- a/tests/test_sphinx/test_sphinx_builds/test_substitutions.other.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_substitutions.other.xml
@@ -1,5 +1,5 @@
 <document source="other.md">
-    <section ids="other" names="other">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="other" names="other">
         <title>
             Other
         <paragraph>

--- a/tox.ini
+++ b/tox.ini
@@ -11,19 +11,21 @@
 # then then deleting compiled files has been found to fix it: `find . -name \*.pyc -delete`
 
 [tox]
-envlist = py37-sphinx3
+envlist = py37-sphinx4
 
 [testenv]
 # only recreate the environment when we use `tox -r`
 recreate = false
 
-[testenv:py{36,37,38,39}-sphinx{2,3}]
+[testenv:py{36,37,38,39}-sphinx{3,4}]
+deps =
+    black
+    flake8
 extras =
     linkify
     testing
-deps =
-    sphinx2: sphinx>=2,<3
-    sphinx3: sphinx>=3,<4
+commands_pre =
+    sphinx3: pip install --quiet --upgrade-strategy "only-if-needed" "sphinx==3.5.4"
 commands = pytest {posargs}
 
 [testenv:docs-{update,clean}]
@@ -55,3 +57,5 @@ commands =
 addopts = --ignore=setup.py
 markers =
     sphinx: set parameters for the sphinx `app` fixture (see ipypublish/sphinx/tests/conftest.py)
+filterwarnings =
+    ignore::DeprecationWarning:sphinx.jinja2glue.*


### PR DESCRIPTION
The main change is with mathjax. It's still a bit of a faff, but I think the approach is a little better: 
`tex2jax_process` and `mathjax_process` classes are added to the top-level sections of myst documents (this "fixes" having to override setting for RST documents), this tells mathjax not to render for any math under this section (i.e. the entire document) by default. The `math` class is then added to the process list, which overrides the default, and so tells mathjax to render elements (and child elements) with this class.
So basically it constricts mathjax to only rendering the elements we want.
This is also explained at; https://myst-parser--390.org.readthedocs.build/en/390/using/syntax.html#mathjax-and-math-parsing

As well as this, most of the sphinx test regression files have been split into sphinx3 (docutils<0.17) and sphinx4 (docutil 0.17) variants.

closes https://github.com/executablebooks/MyST-Parser/issues/378