### PR TITLE
[draft] Remove option mathjax_classes

### DIFF
--- a/myst_parser/main.py
+++ b/myst_parser/main.py
@@ -47,11 +47,6 @@ class MdParserConfig:
 
     update_mathjax: bool = attr.ib(default=True, validator=instance_of(bool))
 
-    mathjax_classes: str = attr.ib(
-        default="tex2jax_process|mathjax_process|math|output_area",
-        validator=instance_of(str),
-    )
-
     @enable_extensions.validator
     def check_extensions(self, attribute, value):
         if not isinstance(value, Iterable):

--- a/myst_parser/mathjax.py
+++ b/myst_parser/mathjax.py
@@ -19,22 +19,6 @@ from sphinx.writers.html import HTMLTranslator
 logger = logging.getLogger(__name__)
 
 
-def log_override_warning(app: Sphinx, version: int, current: str, new: str) -> None:
-    """Log a warning if MathJax configuration being overriden."""
-    if logging.is_suppressed_warning("myst", "mathjax", app.config.suppress_warnings):
-        return
-    config_name = (
-        "mathjax3_config['options']['processHtmlClass']"
-        if version == 3
-        else "mathjax_config['tex2jax']['processClass']"
-    )
-    logger.warning(
-        f"`{config_name}` is being overridden by myst-parser: '{current}' -> '{new}'. "
-        "Set `suppress_warnings=['myst.mathjax']` to ignore this warning, or "
-        "`myst_update_mathjax=False` if this is undesirable."
-    )
-
-
 def override_mathjax(app: Sphinx):
     """Override aspects of the mathjax extension.
 
@@ -50,43 +34,6 @@ def override_mathjax(app: Sphinx):
             html_visit_displaymath,  # type: ignore[assignment]
             None,
         )
-
-    if not app.env.myst_config.update_mathjax:  # type: ignore[attr-defined]
-        return
-
-    mjax_classes = app.env.myst_config.mathjax_classes  # type: ignore[attr-defined]
-
-    if "mathjax3_config" in app.config:
-        # sphinx 4 + mathjax 3
-        app.config.mathjax3_config = app.config.mathjax3_config or {}  # type: ignore[attr-defined]
-        app.config.mathjax3_config.setdefault("options", {})
-        if (
-            "processHtmlClass" in app.config.mathjax3_config["options"]
-            and app.config.mathjax3_config["options"]["processHtmlClass"]
-            != mjax_classes
-        ):
-            log_override_warning(
-                app,
-                3,
-                app.config.mathjax3_config["options"]["processHtmlClass"],
-                mjax_classes,
-            )
-        app.config.mathjax3_config["options"]["processHtmlClass"] = mjax_classes
-    elif "mathjax_config" in app.config:
-        # sphinx 3 + mathjax 2
-        app.config.mathjax_config = app.config.mathjax_config or {}  # type: ignore[attr-defined]
-        app.config.mathjax_config.setdefault("tex2jax", {})
-        if (
-            "processClass" in app.config.mathjax_config["tex2jax"]
-            and app.config.mathjax_config["tex2jax"]["processClass"] != mjax_classes
-        ):
-            log_override_warning(
-                app,
-                2,
-                app.config.mathjax_config["tex2jax"]["processClass"],
-                mjax_classes,
-            )
-        app.config.mathjax_config["tex2jax"]["processClass"] = mjax_classes
 
 
 def html_visit_displaymath(self: HTMLTranslator, node: nodes.math_block) -> None:


### PR DESCRIPTION
The global approach in #395 isn't really sustainable: it requires all-ways cooperation between all projects that want to customize MathJax.  Additionally, when processing a MyST document without Sphinx, the MathJax configuration changes are not performed (part of #347).  And, of course, this approach of overriding the MathJax object causes issues down the line for projects that need to customize MathJax (the setting in Sphinx isn't sufficient, see https://github.com/sphinx-doc/sphinx/issues/9450)

@chrisjsewell you wrote:

> Its not really ideal that either package has to override the (global) configuration

I think the following two approaches would not require overriding the global config:

1. Add a custom script instead of touching the mathjax3_config variable; something like this, essentially:

   ```js
   app.add_js_file(None, priority=0, body="""
      var MathJax = window.MathJax || MathJax;
      MathJax.options = MathJax.options || {};
      MathJax.options.processHtmlClass = (MathJax.options.processHtmlClass || "")
      + "|math";
   """)
   ```

2. Don't touch MathJax_config at all; instead, add an explicit `mathjax_process`  class on all math nodes, either by changing `docutils_renderer` (this PR) or by  adding a Docutils transform to processes all math nodes:

  ```python
  class ActivateMathJaxTransform(Transform):
      default_priority = 800

      @staticmethod
      def is_math(node):
          return isinstance(node, (math, math_block))

      def apply(self, **kwargs):
          for node in self.document.traverse(self.is_math):
              node.attributes.setdefault("classes", []).append("mathjax_process")
  ```

This PR isn't ready for merging; it's just to start a discussion.