### PR TITLE
Allow myst_parser to be used as include parser

### DIFF
--- a/myst_parser/__init__.py
+++ b/myst_parser/__init__.py
@@ -1,3 +1,4 @@
+import sys
 from typing import TYPE_CHECKING
 
 __version__ = "0.15.1"
@@ -9,10 +10,16 @@ if TYPE_CHECKING:
 
 def setup(app):
     """Initialize Sphinx extension."""
+    # Avoid circular import referencing __version__
     from myst_parser.sphinx_parser import MystParser
 
     app.add_source_suffix(".md", "markdown")
     app.add_source_parser(MystParser)
+
+    # docutils compatibility: making myst_parser.Parser be a parser allows
+    # `.. ::include:` to specify `:parser: myst_parser`
+    module = sys.modules[__name__]
+    setattr(module, "Parser", MystParser)
 
     setup_sphinx(app)
 


### PR DESCRIPTION
This PR adds `myst_parser.Parser` pointing at `MystParser`.

This is [one of those situations](https://www.youtube.com/watch?v=8fnfeuoh4s8) where a lengthy chain of events has ended up with me changing something quite far removed rom the original problem, so I’m definitely open to other options if there’s an easier way to handle this earlier in the process.

  - In the project I’m working on, Sphinx docs live in a `docs/` folder, using rst `toctree`s to set up the structure but with all the prose content in markdown

  - In the main `toctree`, I want to reference `../blah/README.md`, but sphinx doesn’t allow doing that outside the `docs/` directory

  - [Searching the web](https://stackoverflow.com/questions/10199233/can-sphinx-link-to-documents-that-are-not-located-in-directories-below-the-root) led me to believe I need to have stub files to resolve that, i.e., rst files that do `.. include:: ../blah/README.md`

  - Trying to include markdown from rst results in the markdown being parsed as rst, which is not usable

  - Other web searches [eventually](https://muffinresearch.co.uk/selectively-including-parts-readme-rst-in-your-docs/) resulted in learning that [the `include` directive takes a parser option](https://docutils.sourceforge.io/docs/ref/rst/directives.html#include)

  - Obvious guesses for what might work there (`myst_parser`, `MystParser`, `myst_parser.sphinx_parser.MystParser`) did not work. The debugger showed that [in docutils, when looking up a parser, `get_parser_class()`][get_parser_class] treats the `parser` option as a module name, and looks for `Parser` inside that module.

[get_parser_class]: https://sourceforge.net/p/docutils/code/HEAD/tree/trunk/docutils/docutils/parsers/__init__.py#l76

By exposing `MystParser` as the `Parser` attribute of some module, the following .rst now works as expected:

    .. include:: ../blah/README.md
       :parser: myst_parser
