### PR TITLE
FIX: Add mandatory attributes on enumerated_list

### DIFF
--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -373,6 +373,8 @@ class DocutilsRenderer(RendererProtocol):
 
     def render_ordered_list(self, token: SyntaxTreeNode) -> None:
         list_node = nodes.enumerated_list()
+        list_node["enumtype"] = "arabic"
+        list_node["suffix"] = "."
         self.add_line_and_source_path(list_node, token)
         with self.current_node_context(list_node, append=True):
             self.render_children(token)

--- a/tests/test_renderers/fixtures/syntax_elements.md
+++ b/tests/test_renderers/fixtures/syntax_elements.md
@@ -238,7 +238,7 @@ Enumerated List:
 1. *foo*
 .
 <document source="notset">
-    <enumerated_list>
+    <enumerated_list enumtype="arabic" suffix=".">
         <list_item>
             <paragraph>
                 <emphasis>
@@ -253,14 +253,14 @@ Nested Enumrated List:
     1. c
 .
 <document source="notset">
-    <enumerated_list>
+    <enumerated_list enumtype="arabic" suffix=".">
         <list_item>
             <paragraph>
                 a
         <list_item>
             <paragraph>
                 b
-            <enumerated_list>
+            <enumerated_list enumtype="arabic" suffix=".">
                 <list_item>
                     <paragraph>
                         c


### PR DESCRIPTION
The doctrees that MyST generates are compatible with Sphinx but not with the normal Docutils pipeline.  This PR fixes one of the incompatibilities.  The [first example](https://myst-parser.readthedocs.io/en/latest/api/renderers.html#the-docutils-renderer) of the API docs is enough to demonstrate the issue:

````python
from myst_parser.main import to_docutils

document = to_docutils("""
Here's some *text*

1. a list

> a quote

{emphasis}`content`

```{sidebar} my sidebar
content
```
""")

from docutils.core import publish_from_doctree
print(publish_from_doctree(document, writer_name="latex").decode("utf-8"))
````

````
Traceback (most recent call last):
  File "./minimal.py", line 19, in <module>
    print(publish_from_doctree(document, writer_name="latex").decode("utf-8"))
  File "…/docutils/core.py", line 522, in publish_from_doctree
    return pub.publish(enable_exit_status=enable_exit_status)
  File "…/docutils/core.py", line 220, in publish
    output = self.writer.write(self.document, self.destination)
  File "…/docutils/writers/__init__.py", line 78, in write
    self.translate()
  File "…/docutils/writers/latex2e/__init__.py", line 251, in translate
    self.document.walkabout(visitor)
  File "…/docutils/nodes.py", line 214, in walkabout
    if child.walkabout(visitor):
  File "…/docutils/nodes.py", line 206, in walkabout
    visitor.dispatch_visit(self)
  File "…/docutils/nodes.py", line 1995, in dispatch_visit
    return method(node)
  File "…/docutils/writers/latex2e/__init__.py", line 2161, in visit_enumerated_list
    enumtype = types[node.get('enumtype' '')]
KeyError: None
````

The exact backtrace that docutils generates comes from a separate bug (https://sourceforge.net/p/docutils/patches/184/), but even with that fixed the LaTeX that gets generated is invalid, so it's probably worth fixing this here.


