### PR TITLE
⬆️ UPGRADE: markdown-it-py v2, mdit-py-plugins v0.3

### DIFF
--- a/docs/api/parsers.md
+++ b/docs/api/parsers.md
@@ -112,7 +112,7 @@ pprint(parser.get_active_rules())
 {'block': ['front_matter',
            'table',
            'code',
-           'math_block_eqno',
+           'math_block_label',
            'math_block',
            'fence',
            'myst_line_comment',

--- a/docs/api/reference.rst
+++ b/docs/api/reference.rst
@@ -36,7 +36,7 @@ Sphinx
 
 .. autoclass:: myst_parser.sphinx_renderer.SphinxRenderer
     :special-members: __output__
-    :members: handle_cross_reference, render_math_block_eqno
+    :members: handle_cross_reference, render_math_block_label
     :undoc-members:
     :member-order: alphabetical
     :show-inheritance:

--- a/myst_parser/docutils_.py
+++ b/myst_parser/docutils_.py
@@ -8,7 +8,6 @@ from typing import Tuple
 from docutils import nodes
 from docutils.parsers.rst import Parser as RstParser
 from markdown_it.token import Token
-from markdown_it.utils import AttrDict
 
 from myst_parser.main import MdParserConfig, default_parser
 
@@ -47,7 +46,7 @@ class Parser(RstParser):
         config = MdParserConfig(renderer="docutils")
         parser = default_parser(config)
         parser.options["document"] = document
-        env = AttrDict()
+        env: dict = {}
         tokens = parser.parse(inputstring, env)
         if not tokens or tokens[0].type != "front_matter":
             # we always add front matter, so that we can merge it with global keys,

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -784,11 +784,13 @@ class DocutilsRenderer(RendererProtocol):
 
     def render_math_inline(self, token: SyntaxTreeNode) -> None:
         content = token.content
-        if token.markup == "$$":
-            # available when dmath_double_inline is True
-            node = nodes.math_block(content, content, nowrap=False, number=None)
-        else:
-            node = nodes.math(content, content)
+        node = nodes.math(content, content)
+        self.add_line_and_source_path(node, token)
+        self.current_node.append(node)
+
+    def render_math_inline_double(self, token: SyntaxTreeNode) -> None:
+        content = token.content
+        node = nodes.math_block(content, content, nowrap=False, number=None)
         self.add_line_and_source_path(node, token)
         self.current_node.append(node)
 

--- a/myst_parser/sphinx_parser.py
+++ b/myst_parser/sphinx_parser.py
@@ -6,7 +6,6 @@ from docutils import nodes
 from docutils.core import publish_doctree
 from docutils.parsers.rst import Parser as RstParser
 from markdown_it.token import Token
-from markdown_it.utils import AttrDict
 from sphinx.application import Sphinx
 from sphinx.io import SphinxStandaloneReader
 from sphinx.parsers import Parser as SphinxParser
@@ -52,7 +51,7 @@ class MystParser(SphinxParser):
         config = document.settings.env.myst_config
         parser = default_parser(config)
         parser.options["document"] = document
-        env = AttrDict()
+        env: dict = {}
         tokens = parser.parse(inputstring, env)
         if not tokens or tokens[0].type != "front_matter":
             # we always add front matter, so that we can merge it with global keys,

--- a/myst_parser/sphinx_renderer.py
+++ b/myst_parser/sphinx_renderer.py
@@ -122,7 +122,7 @@ class SphinxRenderer(DocutilsRenderer):
             self.doc_env.myst_anchors = True  # type: ignore[attr-defined]
         section["myst-anchor"] = doc_slug
 
-    def render_math_block_eqno(self, token: SyntaxTreeNode) -> None:
+    def render_math_block_label(self, token: SyntaxTreeNode) -> None:
         """Render math with referencable labels, e.g. ``$a=1$ (label)``."""
         label = token.info
         content = token.content

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,8 @@ packages = find:
 install_requires =
     docutils>=0.15,<0.18
     jinja2  # required for substitutions, but let sphinx choose version
-    markdown-it-py>=1.0.0,<2.0.0
-    mdit-py-plugins~=0.2.8
+    markdown-it-py>=1.0.0,<3.0.0
+    mdit-py-plugins~=0.3.0
     pyyaml
     sphinx>=3.1,<5
 python_requires = >=3.6

--- a/tests/test_commonmark/test_commonmark.py
+++ b/tests/test_commonmark/test_commonmark.py
@@ -26,9 +26,6 @@ def test_commonmark(entry):
         pytest.skip(
             "Thematic breaks on the first line conflict with front matter syntax"
         )
-    if entry["example"] == 599:  # <http://example.com/\\[\\>\n
-        # TODO awaiting upstream fix
-        pytest.skip("url backslash escaping")
     test_case = entry["markdown"]
     output = to_html(test_case)
 

--- a/tests/test_renderers/fixtures/sphinx_roles.md
+++ b/tests/test_renderers/fixtures/sphinx_roles.md
@@ -638,6 +638,22 @@ ref (`sphinx.roles.XRefRole`):
 .
 
 --------------------------------
+ref with line breaks (`sphinx.roles.XRefRole`):
+.
+{ref}`some
+text
+<and
+a
+custom reference>`
+.
+<document source="notset">
+    <paragraph>
+        <pending_xref refdoc="mock_docname" refdomain="std" refexplicit="True" reftarget="and a custom reference" reftype="ref" refwarn="True">
+            <inline classes="xref std std-ref">
+                some text
+.
+
+--------------------------------
 numref (`sphinx.roles.XRefRole`):
 .
 {numref}`a`

--- a/tests/test_renderers/fixtures/syntax_elements.md
+++ b/tests/test_renderers/fixtures/syntax_elements.md
@@ -369,6 +369,15 @@ Target:
 .
 
 --------------------------
+Target with whitespace:
+.
+(target with space)=
+.
+<document source="notset">
+    <target ids="target-with-space" names="target\ with\ space">
+.
+
+--------------------------
 Referencing:
 .
 (target)=


### PR DESCRIPTION
See https://github.com/executablebooks/markdown-it-py/releases/tag/v2.0.0,
and https://github.com/executablebooks/mdit-py-plugins/releases/tag/v0.3.0

closes #169