### PR TITLE
👌 IMPROVE: Table rendering

### DIFF
--- a/docs/syntax/syntax.md
+++ b/docs/syntax/syntax.md
@@ -577,6 +577,50 @@ leave the "text" section of the markdown link empty. For example, this
 markdown: `[](syntax.md)` will result in: [](syntax.md).
 ```
 
+## Tables
+
+Tables can be written using the standard [Github Flavoured Markdown syntax](https://github.github.com/gfm/#tables-extension-):
+
+```md
+| foo | bar |
+| --- | --- |
+| baz | bim |
+```
+
+| foo | bar |
+| --- | --- |
+| baz | bim |
+
+Cells in a column can be aligned using the `:` character:
+
+```md
+| left | center | right |
+| :--- | :----: | ----: |
+| a    | b      | c     |
+```
+
+| left | center | right |
+| :--- | :----: | ----: |
+| a    | b      | c     |
+
+:::{note}
+
+Text is aligned by assigning `text-left`, `text-center`, or `text-right` to the cell.
+It is then necessary for the theme you are using to include the appropriate css styling.
+
+```html
+<table class="colwidths-auto table">
+  <thead>
+    <tr><th class="text-left head"><p>left</p></th></tr>
+  </thead>
+  <tbody>
+    <tr><td class="text-left"><p>a</p></td></tr>
+  </tbody>
+</table>
+```
+
+:::
+
 ## Images
 
 MyST provides a few different syntaxes for including images in your documentation.

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -15,6 +15,7 @@ from typing import (
     MutableMapping,
     Optional,
     Sequence,
+    Tuple,
     Union,
     cast,
 )
@@ -729,11 +730,9 @@ class DocutilsRenderer(RendererProtocol):
 
     def render_table(self, token: SyntaxTreeNode) -> None:
 
-        assert token.children and len(token.children) > 1
-
-        # markdown-it table always contains two elements:
+        # markdown-it table always contains at least a header:
+        assert token.children
         header = token.children[0]
-        body = token.children[1]
         # with one header row
         assert header.children
         header_row = header.children[0]
@@ -761,11 +760,13 @@ class DocutilsRenderer(RendererProtocol):
             self.render_table_row(header_row)
 
         # body
-        tbody = nodes.tbody()
-        tgroup += tbody
-        with self.current_node_context(tbody):
-            for body_row in body.children or []:
-                self.render_table_row(body_row)
+        if len(token.children) > 1:
+            body = token.children[1]
+            tbody = nodes.tbody()
+            tgroup += tbody
+            with self.current_node_context(tbody):
+                for body_row in body.children or []:
+                    self.render_table_row(body_row)
 
     def render_table_row(self, token: SyntaxTreeNode) -> None:
         row = nodes.row()
@@ -776,8 +777,12 @@ class DocutilsRenderer(RendererProtocol):
                     child.children[0].content if child.children else ""
                 )
                 style = child.attrGet("style")  # i.e. the alignment when using e.g. :--
-                if style:
-                    entry["classes"].append(style)
+                if style and style in (
+                    "text-align:left",
+                    "text-align:right",
+                    "text-align:center",
+                ):
+                    entry["classes"].append(f"text-{cast(str, style).split(':')[1]}")
                 with self.current_node_context(entry, append=True):
                     with self.current_node_context(para, append=True):
                         self.render_children(child)
@@ -963,9 +968,10 @@ class DocutilsRenderer(RendererProtocol):
         self.document.current_line = position
 
         # get directive class
-        directive_class, messages = directives.directive(
+        output: Tuple[Directive, list] = directives.directive(
             name, self.language_module_rst, self.document
-        )  # type: (Directive, list)
+        )
+        directive_class, messages = output
         if not directive_class:
             error = self.reporter.error(
                 'Unknown directive type "{}".\n'.format(name),

--- a/tests/test_renderers/fixtures/tables.md
+++ b/tests/test_renderers/fixtures/tables.md
@@ -29,6 +29,27 @@ a|b
 .
 
 --------------------------
+Header only:
+.
+| abc | def |
+| --- | --- |
+.
+<document source="notset">
+    <table classes="colwidths-auto">
+        <tgroup cols="2">
+            <colspec colwidth="50.0">
+            <colspec colwidth="50.0">
+            <thead>
+                <row>
+                    <entry>
+                        <paragraph>
+                            abc
+                    <entry>
+                        <paragraph>
+                            def
+.
+
+--------------------------
 Aligned:
 .
 a | b | c
@@ -43,24 +64,24 @@ a | b | c
             <colspec colwidth="33.33">
             <thead>
                 <row>
-                    <entry classes="text-align:left">
+                    <entry classes="text-left">
                         <paragraph>
                             a
-                    <entry classes="text-align:center">
+                    <entry classes="text-center">
                         <paragraph>
                             b
-                    <entry classes="text-align:right">
+                    <entry classes="text-right">
                         <paragraph>
                             c
             <tbody>
                 <row>
-                    <entry classes="text-align:left">
+                    <entry classes="text-left">
                         <paragraph>
                             1
-                    <entry classes="text-align:center">
+                    <entry classes="text-center">
                         <paragraph>
                             2
-                    <entry classes="text-align:right">
+                    <entry classes="text-right">
                         <paragraph>
                             3
 .

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.resolved.sphinx3.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.resolved.sphinx3.xml
@@ -74,7 +74,7 @@
                         <entry>
                             <paragraph>
                                 a
-                        <entry classes="text-align:right">
+                        <entry classes="text-right">
                             <paragraph>
                                 b
                 <tbody>
@@ -83,7 +83,7 @@
                             <paragraph>
                                 <emphasis>
                                     a
-                        <entry classes="text-align:right">
+                        <entry classes="text-right">
                             <paragraph>
                                 2
                     <row>
@@ -91,7 +91,7 @@
                             <paragraph>
                                 <reference refuri="https://google.com">
                                     link-a
-                        <entry classes="text-align:right">
+                        <entry classes="text-right">
                             <paragraph>
                                 <reference refuri="https://python.org">
                                     link-b

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.resolved.sphinx4.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.resolved.sphinx4.xml
@@ -74,7 +74,7 @@
                         <entry>
                             <paragraph>
                                 a
-                        <entry classes="text-align:right">
+                        <entry classes="text-right">
                             <paragraph>
                                 b
                 <tbody>
@@ -83,7 +83,7 @@
                             <paragraph>
                                 <emphasis>
                                     a
-                        <entry classes="text-align:right">
+                        <entry classes="text-right">
                             <paragraph>
                                 2
                     <row>
@@ -91,7 +91,7 @@
                             <paragraph>
                                 <reference refuri="https://google.com">
                                     link-a
-                        <entry classes="text-align:right">
+                        <entry classes="text-right">
                             <paragraph>
                                 <reference refuri="https://python.org">
                                     link-b

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx3.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx3.html
@@ -131,7 +131,7 @@
          a
         </p>
        </th>
-       <th class="text-align:right head">
+       <th class="text-right head">
         <p>
          b
         </p>
@@ -147,7 +147,7 @@
          </em>
         </p>
        </td>
-       <td class="text-align:right">
+       <td class="text-right">
         <p>
          2
         </p>
@@ -161,7 +161,7 @@
          </a>
         </p>
        </td>
-       <td class="text-align:right">
+       <td class="text-right">
         <p>
          <a class="reference external" href="https://python.org">
           link-b

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx3.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx3.xml
@@ -75,7 +75,7 @@
                         <entry>
                             <paragraph>
                                 a
-                        <entry classes="text-align:right">
+                        <entry classes="text-right">
                             <paragraph>
                                 b
                 <tbody>
@@ -84,7 +84,7 @@
                             <paragraph>
                                 <emphasis>
                                     a
-                        <entry classes="text-align:right">
+                        <entry classes="text-right">
                             <paragraph>
                                 2
                     <row>
@@ -92,7 +92,7 @@
                             <paragraph>
                                 <reference refuri="https://google.com">
                                     link-a
-                        <entry classes="text-align:right">
+                        <entry classes="text-right">
                             <paragraph>
                                 <reference refuri="https://python.org">
                                     link-b

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx4.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx4.html
@@ -133,7 +133,7 @@
          a
         </p>
        </th>
-       <th class="text-align:right head">
+       <th class="text-right head">
         <p>
          b
         </p>
@@ -149,7 +149,7 @@
          </em>
         </p>
        </td>
-       <td class="text-align:right">
+       <td class="text-right">
         <p>
          2
         </p>
@@ -163,7 +163,7 @@
          </a>
         </p>
        </td>
-       <td class="text-align:right">
+       <td class="text-right">
         <p>
          <a class="reference external" href="https://python.org">
           link-b

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx4.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx4.xml
@@ -75,7 +75,7 @@
                         <entry>
                             <paragraph>
                                 a
-                        <entry classes="text-align:right">
+                        <entry classes="text-right">
                             <paragraph>
                                 b
                 <tbody>
@@ -84,7 +84,7 @@
                             <paragraph>
                                 <emphasis>
                                     a
-                        <entry classes="text-align:right">
+                        <entry classes="text-right">
                             <paragraph>
                                 2
                     <row>
@@ -92,7 +92,7 @@
                             <paragraph>
                                 <reference refuri="https://google.com">
                                     link-a
-                        <entry classes="text-align:right">
+                        <entry classes="text-right">
                             <paragraph>
                                 <reference refuri="https://python.org">
                                     link-b

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,7 @@
 envlist = py37-sphinx4
 
 [testenv]
-# only recreate the environment when we use `tox -r`
-recreate = false
+usedevelop = true
 
 [testenv:py{36,37,38,39}-sphinx{3,4}]
 deps =


### PR DESCRIPTION
Change cell alignment classes to `text-left`, `text-center`, or `text-right`,
and allow tables with no body.

closes #412, closes #430 