### PR TITLE
👌 IMPROVE: Add `\\` for hard-breaks in latex

### DIFF
--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -400,6 +400,7 @@ class DocutilsRenderer(RendererProtocol):
 
     def render_hardbreak(self, token: SyntaxTreeNode) -> None:
         self.current_node.append(nodes.raw("", "<br />\n", format="html"))
+        self.current_node.append(nodes.raw("", "\\\\\n", format="latex"))
 
     def render_strong(self, token: SyntaxTreeNode) -> None:
         node = nodes.strong()

--- a/tests/test_renderers/fixtures/syntax_elements.md
+++ b/tests/test_renderers/fixtures/syntax_elements.md
@@ -9,6 +9,22 @@ foo
 .
 
 ---------------------------
+Hard-break
+.
+foo\
+bar
+.
+<document source="notset">
+    <paragraph>
+        foo
+        <raw format="html" xml:space="preserve">
+            <br />
+        <raw format="latex" xml:space="preserve">
+            \\
+        bar
+.
+
+---------------------------
 Strong:
 .
 **foo**


### PR DESCRIPTION
closes #408