### PR TITLE
🔧 MAINTAIN: Add publishing job for `myst-docutils`

### DIFF
--- a/.github/workflows/docutils_setup.py
+++ b/.github/workflows/docutils_setup.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Script to convert package setup to myst-docutils."""
+import configparser
+import io
+import sys
+
+
+def modify_setup_cfg(content: str) -> str:
+    """Modify setup.cfg."""
+    cfg = configparser.ConfigParser()
+    cfg.read_string(content)
+    # change name of package
+    cfg.set("metadata", "name", "myst-docutils")
+    # move dependency on docutils and sphinx to extra
+    install_requires = []
+    sphinx_extra = [""]
+    for line in cfg.get("options", "install_requires").splitlines():
+        if line.startswith("docutils"):
+            sphinx_extra.append(line)
+        elif line.startswith("sphinx"):
+            sphinx_extra.append(line)
+        else:
+            install_requires.append(line)
+    cfg.set("options", "install_requires", "\n".join(install_requires))
+    cfg.set("options.extras_require", "sphinx", "\n".join(sphinx_extra))
+
+    stream = io.StringIO()
+    cfg.write(stream)
+    return stream.getvalue()
+
+
+def modify_readme(content: str) -> str:
+    """Modify README.md."""
+    content = content.replace(
+        "# MyST-Parser",
+        "# MyST-Parser\n\nNote: myst-docutils is identical to myst-parser, "
+        "but without installation requirements on sphinx",
+    )
+    content = content.replace("myst-parser", "myst-docutils")
+    content = content.replace("myst-docutils.readthedocs", "myst-parser.readthedocs")
+    content = content.replace(
+        "readthedocs.org/projects/myst-docutils", "readthedocs.org/projects/myst-parser"
+    )
+    return content
+
+
+if __name__ == "__main__":
+    setup_path = sys.argv[1]
+    readme_path = sys.argv[2]
+    with open(setup_path, "r") as f:
+        content = f.read()
+    content = modify_setup_cfg(content)
+    with open(setup_path, "w") as f:
+        f.write(content)
+    with open(readme_path, "r") as f:
+        content = f.read()
+    content = modify_readme(content)
+    with open(readme_path, "w") as f:
+        f.write(content)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
         pip install .
         pip install docutils==${{ matrix.docutils-version }}
     - name: Run CLI
-      run: python -m myst_parser.docutils_ --help
+      run: echo "test" | python -m myst_parser.docutils_
 
 
   publish:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,9 +84,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install .
         pip install docutils==${{ matrix.docutils-version }}
-    - name: Run CLI
-      run: echo "test" | python -m myst_parser.docutils_
-
+    - name: Run docutils CLI
+      run: echo "test" | myst-docutils-html
 
   publish:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,10 +61,32 @@ jobs:
         file: ./coverage.xml
         fail_ci_if_error: true
 
+  check-myst-docutils:
+
+    name: Check myst-docutils install
+
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Modify setup
+      run: python .github/workflows/docutils_setup.py setup.cfg README.md
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install .
+    - name: Run CLI
+      run: python -m myst_docutils.docutils_ --help
+
+
   publish:
 
     name: Publish myst-parser to PyPi
-    needs: [pre-commit, tests]
+    needs: [pre-commit, tests, check-myst-docutils]
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,22 +17,22 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: "3.8"
     - uses: pre-commit/action@v2.0.0
 
   tests:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
         sphinx: [">=4,<5"]
         os: [ubuntu-latest]
         include:
           - os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.8"
             sphinx: ">=3,<4"
           - os: windows-latest
-            python-version: 3.8
+            python-version: "3.8"
             sphinx: ">=4,<5"
 
     runs-on: ${{ matrix.os }}
@@ -64,21 +64,26 @@ jobs:
   check-myst-docutils:
 
     name: Check myst-docutils install
-
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        docutils-version: ["0.16", "0.17", "0.18"]
+
     steps:
     - name: Checkout source
       uses: actions/checkout@v2
     - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: "3.8"
     - name: Modify setup
       run: python .github/workflows/docutils_setup.py setup.cfg README.md
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install .
+        pip install docutils==${{ matrix.docutils-version }}
     - name: Run CLI
       run: python -m myst_parser.docutils_ --help
 
@@ -95,7 +100,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: "3.8"
     - name: Build package
       run: |
         pip install build
@@ -118,7 +123,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: "3.8"
     - name: Modify setup
       run: python .github/workflows/docutils_setup.py setup.cfg README.md
     - name: Build package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [master]
     tags:
-      - 'v*'
+      - "v[0-9]+.[0-9]+.[0-9]+*"
   pull_request:
 
 jobs:
@@ -63,7 +63,7 @@ jobs:
 
   publish:
 
-    name: Publish to PyPi
+    name: Publish myst-parser to PyPi
     needs: [pre-commit, tests]
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
@@ -76,10 +76,35 @@ jobs:
         python-version: 3.8
     - name: Build package
       run: |
-        pip install wheel
-        python setup.py sdist bdist_wheel
+        pip install build
+        python -m build
     - name: Publish
       uses: pypa/gh-action-pypi-publish@v1.3.1
       with:
         user: __token__
         password: ${{ secrets.PYPI_KEY }}
+
+  publish-docutils:
+
+    name: Publish myst-docutils to PyPi
+    needs: [publish]
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Modify setup
+      run: python .github/workflows/docutils_setup.py setup.cfg README.md
+    - name: Build package
+      run: |
+        pip install build
+        python -m build
+    - name: Publish
+      uses: pypa/gh-action-pypi-publish@v1.3.1
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_KEY_DOCUTILS }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -80,7 +80,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install .
     - name: Run CLI
-      run: python -m myst_docutils.docutils_ --help
+      run: python -m myst_parser.docutils_ --help
 
 
   publish:

--- a/myst_parser/docutils_.py
+++ b/myst_parser/docutils_.py
@@ -53,3 +53,14 @@ class Parser(RstParser):
             # specified in the sphinx configuration
             tokens = [Token("front_matter", "", 0, content="{}", map=[0, 0])] + tokens
         parser.renderer.render(tokens, parser.options, env)
+
+
+if __name__ == "__main__":
+    from docutils.core import default_description, publish_cmdline
+
+    publish_cmdline(
+        parser=Parser(),
+        writer_name="html",
+        description="Generates (X)HTML documents from standalone MyST sources.  "
+        + default_description,
+    )


### PR DESCRIPTION
This PR adds a workflow for releasing an additional package `myst-docutils`, which does not include install requirements on docutils or sphinx, to close #347 and allow docutils to utilise it in their package with no cyclic dependencies.
It does this by simply modifying the `setup.cfg` and `README.md` before the build.
The build is also tested against a range of docutils versions (e.g. to ensure it does not fail due to missing sphinx install)