### PR TITLE
✨ NEW: Add `myst_linkify_fuzzy_links` option

### DIFF
--- a/docs/sphinx/reference.md
+++ b/docs/sphinx/reference.md
@@ -23,6 +23,9 @@ To do so, use the keywords beginning `myst_`.
   - `None`
   - [URI schemes](https://en.wikipedia.org/wiki/List_of_URI_schemes) that will be recognised as external URLs in `[](scheme:loc)` syntax, or set `None` to recognise all.
     Other links will be resolved as internal cross-references.
+* - `myst_linkify_fuzzy_links`
+  - `True`
+  - If `False`, only links that contain a scheme (such as `http`) will be recognised as external links.
 * - `myst_heading_anchors`
   - `None`
   - Enable auto-generated heading anchors, up to a maximum level, [see here](syntax/header-anchors) for details.

--- a/docs/syntax/optional.md
+++ b/docs/syntax/optional.md
@@ -243,6 +243,8 @@ Adding `"linkify"` to `myst_enable_extensions` (in the sphinx `conf.py` [configu
 
 `www.example.com` -> www.example.com
 
+To only match URLs that start with schema, such as `http://example.com`, set `myst_linkify_fuzzy_links=False`.
+
 :::{important}
 This extension requires that [linkify-it-py](https://github.com/tsutsu3/linkify-it-py) is installed.
 Either directly; `pip install linkify-it-py` or *via* `pip install myst-parser[linkify]`.

--- a/myst_parser/main.py
+++ b/myst_parser/main.py
@@ -47,6 +47,12 @@ class MdParserConfig:
         factory=lambda: ["dollarmath"], metadata={"help": "Enable extensions"}
     )
 
+    linkify_fuzzy_links: bool = attr.ib(
+        default=True,
+        validator=instance_of(bool),
+        metadata={"help": "linkify: recognise URLs without schema prefixes"},
+    )
+
     dmath_allow_labels: bool = attr.ib(
         default=True,
         validator=instance_of(bool),
@@ -223,8 +229,9 @@ def default_parser(config: MdParserConfig) -> MarkdownIt:
         md.enable("replacements")
         typographer = True
     if "linkify" in config.enable_extensions:
-        # TODO warn, don't enable, if linkify-it-py not installed
         md.enable("linkify")
+        if md.linkify is not None:
+            md.linkify.set({"fuzzy_link": config.linkify_fuzzy_links})
 
     if "dollarmath" in config.enable_extensions:
         md.use(


### PR DESCRIPTION
If `False`, only links that contain a scheme (such as `http`) will be recognised as external links.