### PR TITLE
👌 IMPROVE: Use correct renderer for `state.inline_text`

### DIFF
--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -181,9 +181,7 @@ class MockState:
         # so that the nested parse does not effect the current renderer,
         # but we use the same env, so that link references, etc
         # are added to the global parse.
-        from myst_parser.docutils_renderer import DocutilsRenderer
-
-        nested_renderer = DocutilsRenderer(self._renderer.md)
+        nested_renderer = self._renderer.__class__(self._renderer.md)
         options = {k: v for k, v in self._renderer.config.items()}
         options.update(
             {

--- a/tests/test_sphinx/sourcedirs/basic/content.md
+++ b/tests/test_sphinx/sourcedirs/basic/content.md
@@ -34,6 +34,10 @@ abcd *abc* [google](https://www.google.com)
 
 ````
 
+```{admonition} Title with [link](target2)
+Content
+```
+
 (target2)=
 
 ```{figure} example.jpg

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -67,7 +67,7 @@ def test_basic(
         "date": "2/12/1985",
         "copyright": "MIT",
         "other": "Something else",
-        "wordcount": {"minutes": 0, "words": 53},
+        "wordcount": {"minutes": 0, "words": 57},
     }
 
 

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.resolved.sphinx3.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.resolved.sphinx3.xml
@@ -32,6 +32,14 @@
             <warning>
                 <paragraph>
                     xyz
+        <admonition classes="admonition-title-with-link-target2">
+            <title>
+                Title with 
+                <reference internal="True" refid="target2">
+                    <inline classes="std std-ref">
+                        link
+            <paragraph>
+                Content
         <target refid="target2">
         <figure align="default" ids="id1 target2" names="target2">
             <reference refuri="https://www.google.com">
@@ -140,7 +148,7 @@
         <paragraph>
             Special substitution references:
         <paragraph>
-            53
+            57
              words | 
             0
              min read

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.resolved.sphinx4.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.resolved.sphinx4.xml
@@ -32,6 +32,14 @@
             <warning>
                 <paragraph>
                     xyz
+        <admonition classes="admonition-title-with-link-target2">
+            <title>
+                Title with 
+                <reference internal="True" refid="target2">
+                    <inline classes="std std-ref">
+                        link
+            <paragraph>
+                Content
         <target refid="target2">
         <figure ids="id1 target2" names="target2">
             <reference refuri="https://www.google.com">
@@ -140,7 +148,7 @@
         <paragraph>
             Special substitution references:
         <paragraph>
-            53
+            57
              words | 
             0
              min read

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx3.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx3.html
@@ -55,6 +55,19 @@
       </p>
      </div>
     </div>
+    <div class="admonition-title-with-link-target2 admonition">
+     <p class="admonition-title">
+      Title with
+      <a class="reference internal" href="#target2">
+       <span class="std std-ref">
+        link
+       </span>
+      </a>
+     </p>
+     <p>
+      Content
+     </p>
+    </div>
     <div class="figure align-default" id="id1">
      <span id="target2">
      </span>
@@ -229,7 +242,7 @@ paragraph
      Special substitution references:
     </p>
     <p>
-     53 words | 0 min read
+     57 words | 0 min read
     </p>
    </div>
   </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx3.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx3.xml
@@ -32,6 +32,14 @@
             <warning>
                 <paragraph>
                     xyz
+        <admonition classes="admonition-title-with-link-target2">
+            <title>
+                Title with 
+                <pending_xref refdoc="content" refdomain="True" refexplicit="True" reftarget="target2" reftype="myst" refwarn="True">
+                    <inline classes="xref myst">
+                        link
+            <paragraph>
+                Content
         <target refid="target2">
         <figure align="default" ids="id1 target2" names="target2">
             <reference refuri="https://www.google.com">
@@ -141,7 +149,7 @@
         <paragraph>
             Special substitution references:
         <paragraph>
-            53
+            57
              words | 
             0
              min read

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx4.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx4.html
@@ -55,6 +55,19 @@
       </p>
      </div>
     </div>
+    <div class="admonition-title-with-link-target2 admonition">
+     <p class="admonition-title">
+      Title with
+      <a class="reference internal" href="#target2">
+       <span class="std std-ref">
+        link
+       </span>
+      </a>
+     </p>
+     <p>
+      Content
+     </p>
+    </div>
     <figure class="align-default" id="id1">
      <span id="target2">
      </span>
@@ -231,7 +244,7 @@ paragraph
      Special substitution references:
     </p>
     <p>
-     53 words | 0 min read
+     57 words | 0 min read
     </p>
    </section>
   </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx4.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.sphinx4.xml
@@ -32,6 +32,14 @@
             <warning>
                 <paragraph>
                     xyz
+        <admonition classes="admonition-title-with-link-target2">
+            <title>
+                Title with 
+                <pending_xref refdoc="content" refdomain="True" refexplicit="True" reftarget="target2" reftype="myst" refwarn="True">
+                    <inline classes="xref myst">
+                        link
+            <paragraph>
+                Content
         <target refid="target2">
         <figure ids="id1 target2" names="target2">
             <reference refuri="https://www.google.com">
@@ -141,7 +149,7 @@
         <paragraph>
             Special substitution references:
         <paragraph>
-            53
+            57
              words | 
             0
              min read


### PR DESCRIPTION
Previously `state.inline_text()` (used by some directives)
always parsed text with the `DocutilsRenderer`.
Now it will correctly use the `SphinxRenderer`,
when parsing with sphinx,
allowing for cross-document references to be handled.