### PR TITLE
♻️ REFACTOR: `default_parser` -> `create_md_parser`

### DIFF
--- a/docs/api/parsers.md
+++ b/docs/api/parsers.md
@@ -96,13 +96,14 @@ See the documentation of these tools for more information.
 
 ### Load a parser
 
-To load one of these parsers for your own use, use the `default_parser` function.
+To load one of these parsers for your own use, use the `create_md_parser` function.
 Below we'll create such a parser and show that it is an instance of a `markdown-it-py` parser:
 
 ```python
-from myst_parser.main import default_parser, MdParserConfig
-config = MdParserConfig(renderer="html")
-parser = default_parser(config)
+from markdown_it.renderer import RendererHTML
+from myst_parser.main import create_md_parser, MdParserConfig
+config = MdParserConfig()
+parser = create_md_parser(config, RendererHTML)
 parser
 ```
 

--- a/myst_parser/__init__.py
+++ b/myst_parser/__init__.py
@@ -34,9 +34,8 @@ def setup_sphinx(app: "Sphinx"):
     app.add_post_transform(MystReferenceResolver)
 
     for name, default in MdParserConfig().as_dict().items():
-        if not name == "renderer":
-            # TODO add types?
-            app.add_config_value(f"myst_{name}", default, "env")
+        # TODO add types?
+        app.add_config_value(f"myst_{name}", default, "env")
 
     app.connect("builder-inited", create_myst_config)
     app.connect("builder-inited", override_mathjax)

--- a/myst_parser/cli.py
+++ b/myst_parser/cli.py
@@ -1,7 +1,9 @@
 import argparse
 import sys
 
-from myst_parser.main import MdParserConfig, default_parser
+from markdown_it.renderer import RendererHTML
+
+from myst_parser.main import MdParserConfig, create_md_parser
 
 
 def print_anchors(args=None):
@@ -25,7 +27,7 @@ def print_anchors(args=None):
         "-l", "--level", type=int, default=2, help="Maximum heading level."
     )
     args = arg_parser.parse_args(args)
-    parser = default_parser(MdParserConfig(renderer="html", heading_anchors=args.level))
+    parser = create_md_parser(MdParserConfig(heading_anchors=args.level), RendererHTML)
 
     def _filter_plugin(state):
         state.tokens = [

--- a/myst_parser/directives.py
+++ b/myst_parser/directives.py
@@ -61,8 +61,6 @@ class FigureMarkdown(SphinxDirective):
         figclasses = self.options.pop("class", None)
         align = self.options.pop("align", None)
 
-        # parser = default_parser(self.env.myst_config)
-
         node = nodes.Element()
         # TODO test that we are using myst parser
         # ensure html image enabled

--- a/myst_parser/docutils_.py
+++ b/myst_parser/docutils_.py
@@ -11,7 +11,8 @@ from docutils.core import default_description, publish_cmdline
 from docutils.parsers.rst import Parser as RstParser
 from markdown_it.token import Token
 
-from myst_parser.main import MdParserConfig, default_parser
+from myst_parser.docutils_renderer import DocutilsRenderer
+from myst_parser.main import MdParserConfig, create_md_parser
 
 
 def _validate_int(
@@ -63,8 +64,6 @@ DOCUTILS_EXCLUDED_ARGS = (
     "ref_domains",
     "update_mathjax",
     "mathjax_classes",
-    # We don't want to set the renderer from docutils.conf
-    "renderer",
 )
 """Names of settings that cannot be set in docutils.conf."""
 
@@ -139,7 +138,6 @@ def create_myst_config(settings: frontend.Values):
         val = getattr(settings, setting, DOCUTILS_UNSET)
         if val is not DOCUTILS_UNSET:
             values[attribute.name] = val
-    values["renderer"] = "docutils"
     return MdParserConfig(**values)
 
 
@@ -171,8 +169,8 @@ class Parser(RstParser):
             config = create_myst_config(document.settings)
         except (TypeError, ValueError) as error:
             document.reporter.error(f"myst configuration invalid: {error.args[0]}")
-            config = MdParserConfig(renderer="docutils")
-        parser = default_parser(config)
+            config = MdParserConfig()
+        parser = create_md_parser(config, DocutilsRenderer)
         parser.options["document"] = document
         env: dict = {}
         tokens = parser.parse(inputstring, env)

--- a/myst_parser/sphinx_parser.py
+++ b/myst_parser/sphinx_parser.py
@@ -12,7 +12,8 @@ from sphinx.parsers import Parser as SphinxParser
 from sphinx.util import logging
 from sphinx.util.docutils import sphinx_domains
 
-from myst_parser.main import default_parser
+from myst_parser.main import create_md_parser
+from myst_parser.sphinx_renderer import SphinxRenderer
 
 SPHINX_LOGGER = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ class MystParser(SphinxParser):
 
         """
         config = document.settings.env.myst_config
-        parser = default_parser(config)
+        parser = create_md_parser(config, SphinxRenderer)
         parser.options["document"] = document
         env: dict = {}
         tokens = parser.parse(inputstring, env)


### PR DESCRIPTION
The `renderer` option has been removed from `MdParserConfig`,
since it is not a configuration for the parser.
Then the `default_parser` function has been replaced with `create_md_parser`,
which directly takes the renderer class as a 2nd argument.