### PR TITLE
⬆️ UPGRADE: Drop python 3.6, support 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
         sphinx: [">=4,<5"]
         os: [ubuntu-latest]
         include:

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,10 +16,10 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Software Development :: Libraries :: Python Modules
@@ -43,7 +43,7 @@ install_requires =
     mdit-py-plugins~=0.3.0
     pyyaml
     sphinx>=3.1,<5
-python_requires = >=3.6
+python_requires = >=3.7
 include_package_data = True
 zip_safe = True
 
@@ -75,7 +75,7 @@ testing =
     beautifulsoup4
     coverage
     docutils~=0.17.0  # this version changes some HTML tags
-    pytest>=3.6,<4
+    pytest>=6,<7
     pytest-cov
     pytest-regressions
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ envlist = py37-sphinx4
 [testenv]
 usedevelop = true
 
-[testenv:py{36,37,38,39}-sphinx{3,4}]
+[testenv:py{37,38,39,310}-sphinx{3,4}]
 deps =
     black
     flake8


### PR DESCRIPTION
Python 3.6 end-of-life was 23 Dec 2021