### PR TITLE
🐛 FIX: Front matter -> sphinx metadata regression

### DIFF
--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -818,7 +818,7 @@ class DocutilsRenderer(RendererProtocol):
             if key in bibliofields:
                 para_nodes, _ = state.inline_text(value, line)
             else:
-                para_nodes = [nodes.Text(value, value)]
+                para_nodes = [nodes.literal(value, value)]
 
             body_children = [nodes.paragraph("", "", *para_nodes)]
             body_children[0].source = self.document["source"]

--- a/tests/test_renderers/fixtures/docutil_syntax_elements.md
+++ b/tests/test_renderers/fixtures/docutil_syntax_elements.md
@@ -595,19 +595,22 @@ c:
                 a
             <field_body>
                 <paragraph>
-                    1
+                    <literal>
+                        1
         <field>
             <field_name>
                 b
             <field_body>
                 <paragraph>
-                    foo
+                    <literal>
+                        foo
         <field>
             <field_name>
                 c
             <field_body>
                 <paragraph>
-                    {"d": 2}
+                    <literal>
+                        {"d": 2}
 .
 
 --------------------------
@@ -725,7 +728,8 @@ other: Something else
                 other
             <field_body>
                 <paragraph>
-                    Something else
+                    <literal>
+                        Something else
 .
 
 --------------------------
@@ -827,7 +831,8 @@ a = 1
                 a
             <field_body>
                 <paragraph>
-                    1
+                    <literal>
+                        1
     <target ids="target" names="target">
     <section ids="header-1" names="header\ 1">
         <title>

--- a/tests/test_renderers/fixtures/sphinx_syntax_elements.md
+++ b/tests/test_renderers/fixtures/sphinx_syntax_elements.md
@@ -632,19 +632,22 @@ c:
                 a
             <field_body>
                 <paragraph>
-                    1
+                    <literal>
+                        1
         <field>
             <field_name>
                 b
             <field_body>
                 <paragraph>
-                    foo
+                    <literal>
+                        foo
         <field>
             <field_name>
                 c
             <field_body>
                 <paragraph>
-                    {"d": 2}
+                    <literal>
+                        {"d": 2}
 .
 
 --------------------------
@@ -762,7 +765,8 @@ other: Something else
                 other
             <field_body>
                 <paragraph>
-                    Something else
+                    <literal>
+                        Something else
 .
 
 --------------------------
@@ -864,7 +868,8 @@ a = 1
                 a
             <field_body>
                 <paragraph>
-                    1
+                    <literal>
+                        1
     <target ids="target" names="target">
     <section ids="header-1" names="header\ 1">
         <title>

--- a/tests/test_sphinx/sourcedirs/basic/content.md
+++ b/tests/test_sphinx/sourcedirs/basic/content.md
@@ -17,6 +17,8 @@ dedication: |
 abstract:
     Something something **dark** side
 other: Something else
+other_dict:
+  key: value
 ---
 
 (target)=

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -66,6 +66,7 @@ def test_basic(
         "date": "2/12/1985",
         "copyright": "MIT",
         "other": "Something else",
+        "other_dict": '{"key": "value"}',
         "wordcount": {"minutes": 0, "words": 57},
     }
 


### PR DESCRIPTION
After PR #477, I noted that the `SmartQuote` transform was being applied to  the front-matter values,
before they were extracted to the document metadata (see also issue #479).
Therefore, we now add them as a `literal` to stop this happening.