### PR TITLE
🐛 FIX: Ordered list starting number

### DIFF
--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -377,9 +377,9 @@ class DocutilsRenderer(RendererProtocol):
             self.render_children(token)
 
     def render_ordered_list(self, token: SyntaxTreeNode) -> None:
-        list_node = nodes.enumerated_list()
-        list_node["enumtype"] = "arabic"
-        list_node["suffix"] = "."
+        list_node = nodes.enumerated_list(enumtype="arabic", prefix="", suffix=".")
+        if "start" in token.attrs:  # starting number
+            list_node["start"] = token.attrs["start"]
         self.add_line_and_source_path(list_node, token)
         with self.current_node_context(list_node, append=True):
             self.render_children(token)

--- a/tests/test_renderers/fixtures/docutil_syntax_elements.md
+++ b/tests/test_renderers/fixtures/docutil_syntax_elements.md
@@ -257,13 +257,27 @@ Nested Bullets
 Enumerated List:
 .
 1. *foo*
+
+para
+
+10. starting
+11. enumerator
 .
 <document source="notset">
-    <enumerated_list enumtype="arabic" suffix=".">
+    <enumerated_list enumtype="arabic" prefix="" suffix=".">
         <list_item>
             <paragraph>
                 <emphasis>
                     foo
+    <paragraph>
+        para
+    <enumerated_list enumtype="arabic" prefix="" start="10" suffix=".">
+        <list_item>
+            <paragraph>
+                starting
+        <list_item>
+            <paragraph>
+                enumerator
 .
 
 --------------------------
@@ -274,14 +288,14 @@ Nested Enumrated List:
     1. c
 .
 <document source="notset">
-    <enumerated_list enumtype="arabic" suffix=".">
+    <enumerated_list enumtype="arabic" prefix="" suffix=".">
         <list_item>
             <paragraph>
                 a
         <list_item>
             <paragraph>
                 b
-            <enumerated_list enumtype="arabic" suffix=".">
+            <enumerated_list enumtype="arabic" prefix="" suffix=".">
                 <list_item>
                     <paragraph>
                         c

--- a/tests/test_renderers/fixtures/sphinx_syntax_elements.md
+++ b/tests/test_renderers/fixtures/sphinx_syntax_elements.md
@@ -257,13 +257,27 @@ Nested Bullets
 Enumerated List:
 .
 1. *foo*
+
+para
+
+10. starting
+11. enumerator
 .
 <document source="notset">
-    <enumerated_list enumtype="arabic" suffix=".">
+    <enumerated_list enumtype="arabic" prefix="" suffix=".">
         <list_item>
             <paragraph>
                 <emphasis>
                     foo
+    <paragraph>
+        para
+    <enumerated_list enumtype="arabic" prefix="" start="10" suffix=".">
+        <list_item>
+            <paragraph>
+                starting
+        <list_item>
+            <paragraph>
+                enumerator
 .
 
 --------------------------
@@ -274,14 +288,14 @@ Nested Enumrated List:
     1. c
 .
 <document source="notset">
-    <enumerated_list enumtype="arabic" suffix=".">
+    <enumerated_list enumtype="arabic" prefix="" suffix=".">
         <list_item>
             <paragraph>
                 a
         <list_item>
             <paragraph>
                 b
-            <enumerated_list enumtype="arabic" suffix=".">
+            <enumerated_list enumtype="arabic" prefix="" suffix=".">
                 <list_item>
                     <paragraph>
                         c

--- a/tests/test_sphinx/conftest.py
+++ b/tests/test_sphinx/conftest.py
@@ -78,6 +78,9 @@ def get_sphinx_app_output(file_regression):
             # only regress the inner body, since other sections are non-deterministic
             soup = BeautifulSoup(content, "html.parser")
             doc_div = soup.findAll("div", {"class": "documentwrapper"})[0]
+            # pygments 2.11.0 introduces a whitespace tag
+            for pygment_whitespace in doc_div.select("pre > span.w"):
+                pygment_whitespace.replace_with(pygment_whitespace.text)
             text = doc_div.prettify()
             for find, rep in (replace or {}).items():
                 text = text.replace(find, rep)

--- a/tests/test_sphinx/test_sphinx_builds/test_gettext_html.resolved.sphinx3.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_gettext_html.resolved.sphinx3.xml
@@ -24,7 +24,7 @@
                     texte 5 en 
                     <strong>
                         gras
-        <enumerated_list enumtype="arabic" suffix=".">
+        <enumerated_list enumtype="arabic" prefix="" suffix=".">
             <list_item>
                 <paragraph>
                     texte 6 en 

--- a/tests/test_sphinx/test_sphinx_builds/test_gettext_html.resolved.sphinx4.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_gettext_html.resolved.sphinx4.xml
@@ -24,7 +24,7 @@
                     texte 5 en 
                     <strong>
                         gras
-        <enumerated_list enumtype="arabic" suffix=".">
+        <enumerated_list enumtype="arabic" prefix="" suffix=".">
             <list_item>
                 <paragraph>
                     texte 6 en 

--- a/tests/test_sphinx/test_sphinx_builds/test_gettext_html.sphinx3.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_gettext_html.sphinx3.xml
@@ -24,7 +24,7 @@
                     texte 5 en 
                     <strong>
                         gras
-        <enumerated_list enumtype="arabic" suffix=".">
+        <enumerated_list enumtype="arabic" prefix="" suffix=".">
             <list_item>
                 <paragraph>
                     texte 6 en 

--- a/tests/test_sphinx/test_sphinx_builds/test_gettext_html.sphinx4.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_gettext_html.sphinx4.xml
@@ -24,7 +24,7 @@
                     texte 5 en 
                     <strong>
                         gras
-        <enumerated_list enumtype="arabic" suffix=".">
+        <enumerated_list enumtype="arabic" prefix="" suffix=".">
             <list_item>
                 <paragraph>
                     texte 6 en 


### PR DESCRIPTION
Propagate the starting number of ordered lists to the docutils AST.

fixes #482

Equivalency with RST can now be seen with:

`test.txt`:

```
5. foo
6. bar
```

```console
$ rst2pseudoxml.py test.txt
<document source="test.txt">
    <enumerated_list enumtype="arabic" prefix="" start="5" suffix=".">
        <list_item>
            <paragraph>
                foo
        <list_item>
            <paragraph>
                bar
$ myst-docutils-pseudoxml test.txt
<document source="test.txt">
    <enumerated_list enumtype="arabic" prefix="" start="5" suffix=".">
        <list_item>
            <paragraph>
                foo
        <list_item>
            <paragraph>
                bar
```