### PR TITLE
👌 IMPROVE: Propagate enumerated list suffix

### DIFF
--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -377,7 +377,8 @@ class DocutilsRenderer(RendererProtocol):
             self.render_children(token)
 
     def render_ordered_list(self, token: SyntaxTreeNode) -> None:
-        list_node = nodes.enumerated_list(enumtype="arabic", prefix="", suffix=".")
+        list_node = nodes.enumerated_list(enumtype="arabic", prefix="")
+        list_node["suffix"] = token.markup  # for CommonMark, this should be "." or ")"
         if "start" in token.attrs:  # starting number
             list_node["start"] = token.attrs["start"]
         self.add_line_and_source_path(list_node, token)

--- a/tests/test_renderers/fixtures/docutil_syntax_elements.md
+++ b/tests/test_renderers/fixtures/docutil_syntax_elements.md
@@ -258,6 +258,8 @@ Enumerated List:
 .
 1. *foo*
 
+1) bar
+
 para
 
 10. starting
@@ -269,6 +271,10 @@ para
             <paragraph>
                 <emphasis>
                     foo
+    <enumerated_list enumtype="arabic" prefix="" suffix=")">
+        <list_item>
+            <paragraph>
+                bar
     <paragraph>
         para
     <enumerated_list enumtype="arabic" prefix="" start="10" suffix=".">

--- a/tests/test_renderers/fixtures/sphinx_syntax_elements.md
+++ b/tests/test_renderers/fixtures/sphinx_syntax_elements.md
@@ -258,6 +258,8 @@ Enumerated List:
 .
 1. *foo*
 
+1) bar
+
 para
 
 10. starting
@@ -269,6 +271,10 @@ para
             <paragraph>
                 <emphasis>
                     foo
+    <enumerated_list enumtype="arabic" prefix="" suffix=")">
+        <list_item>
+            <paragraph>
+                bar
     <paragraph>
         para
     <enumerated_list enumtype="arabic" prefix="" start="10" suffix=".">


### PR DESCRIPTION
i.e. "." for `1. a` and ")" for `1) a`