### PR TITLE
✨ NEW: Add `toclist` extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -87,6 +87,7 @@ myst_enable_extensions = [
     "linkify",
     "substitution",
     "tasklist",
+    "toclist",
 ]
 myst_number_code_blocks = ["typescript"]
 myst_heading_anchors = 2

--- a/docs/sphinx/reference.md
+++ b/docs/sphinx/reference.md
@@ -69,6 +69,7 @@ List of extensions:
 - "smartquotes": automatically convert standard quotations to their opening/closing variants
 - "substitution": substitute keys, see the [substitutions syntax](syntax/substitutions) for details
 - "tasklist": add check-boxes to the start of list items, see the [tasklist syntax](syntax/tasklists) for details
+- "toclist": specify sphinx `toctree` in a Markdown native manner, see the [toclist syntax](syntax/toclists) for details
 
 Math specific, when `"dollarmath"` activated, see the [Math syntax](syntax/math) for more details:
 

--- a/docs/syntax/optional.md
+++ b/docs/syntax/optional.md
@@ -38,6 +38,7 @@ myst_enable_extensions = [
     "smartquotes",
     "substitution",
     "tasklist",
+    "toclist",
 ]
 ```
 
@@ -681,6 +682,42 @@ Send a message to a recipient
 :::{note}
 Currently `sphinx.ext.autodoc` does not support MyST, see [](howto/autodoc).
 :::
+
+(syntax/toclist)=
+## Table of Contents Lists
+
+By adding `"toclist"` to `myst_enable_extensions` (in the sphinx `conf.py` [configuration file](https://www.sphinx-doc.org/en/master/usage/configuration.html)),
+you will be able to specify [sphinx `toctree`](sphinx:toctree-directive) in a Markdown native manner.
+
+`toclist` are identified by bullet lists that use the `+` character as the marker,
+and each item should be a link to another source file or an external hyperlink:
+
+```markdown
++ [Link text](subsection.md)
++ [Link text](https://example.com "Example external link")
+```
+
+is equivalent to:
+
+````markdown
+```{toctree}
+
+subsection.md
+Example external link <https://example.com>
+```
+````
+
++ [Link text](subsection.md)
++ [Link text](https://example.com "Example external link")
+
+Note that the link text is omitted from the output `toctree`, and the title of the link is taken from either the link title, if present, or the title of the source file.
+
+You can also specify the `maxdepth` and `numbered` options for all toclist in your `conf.py`:
+
+```python
+myst_toclist_maxdepth = 2
+myst_toclist_numbered = True
+```
 
 (syntax/images)=
 

--- a/docs/syntax/optional.md
+++ b/docs/syntax/optional.md
@@ -683,7 +683,7 @@ Send a message to a recipient
 Currently `sphinx.ext.autodoc` does not support MyST, see [](howto/autodoc).
 :::
 
-(syntax/toclist)=
+(syntax/toclists)=
 ## Table of Contents Lists
 
 By adding `"toclist"` to `myst_enable_extensions` (in the sphinx `conf.py` [configuration file](https://www.sphinx-doc.org/en/master/usage/configuration.html)),

--- a/docs/syntax/subsection.md
+++ b/docs/syntax/subsection.md
@@ -1,0 +1,3 @@
+# Example subsection
+
+A subsection referenced by the `toclist` example.

--- a/myst_parser/docutils_.py
+++ b/myst_parser/docutils_.py
@@ -65,6 +65,8 @@ DOCUTILS_EXCLUDED_ARGS = (
     "ref_domains",
     "update_mathjax",
     "mathjax_classes",
+    "toclist_maxdepth",
+    "toclist_numbered",
 )
 """Names of settings that cannot be set in docutils.conf."""
 

--- a/myst_parser/main.py
+++ b/myst_parser/main.py
@@ -89,9 +89,9 @@ class MdParserConfig:
             raise TypeError(f"myst_enable_extensions not iterable: {value}")
         diff = set(value).difference(
             [
-                "dollarmath",
                 "amsmath",
                 "deflist",
+                "dollarmath",
                 "fieldlist",
                 "html_admonition",
                 "html_image",
@@ -101,6 +101,7 @@ class MdParserConfig:
                 "linkify",
                 "substitution",
                 "tasklist",
+                "toclist",
             ]
         )
         if diff:
@@ -182,6 +183,18 @@ class MdParserConfig:
 
     sub_delimiters: Tuple[str, str] = attr.ib(
         default=("{", "}"), metadata={"help": "Substitution delimiters"}
+    )
+
+    toclist_maxdepth: Optional[int] = attr.ib(
+        default=None,
+        validator=optional(instance_of(int)),
+        metadata={"help": "Max depth of toctree created from the toclist extension"},
+    )
+
+    toclist_numbered: bool = attr.ib(
+        default=False,
+        validator=instance_of(bool),
+        metadata={"help": "Number toctree entries created from the toclist extension"},
     )
 
     words_per_minute: int = attr.ib(
@@ -307,6 +320,8 @@ def create_md_parser(
             "myst_footnote_transition": config.footnote_transition,
             "myst_number_code_blocks": config.number_code_blocks,
             "myst_highlight_code_blocks": config.highlight_code_blocks,
+            "myst_toclist_maxdepth": config.toclist_maxdepth,
+            "myst_toclist_numbered": config.toclist_numbered,
         }
     )
 

--- a/tests/test_sphinx/sourcedirs/toclist/conf.py
+++ b/tests/test_sphinx/sourcedirs/toclist/conf.py
@@ -1,0 +1,3 @@
+extensions = ["myst_parser"]
+exclude_patterns = ["_build"]
+myst_enable_extensions = ["toclist"]

--- a/tests/test_sphinx/sourcedirs/toclist/conf.py
+++ b/tests/test_sphinx/sourcedirs/toclist/conf.py
@@ -1,3 +1,5 @@
 extensions = ["myst_parser"]
 exclude_patterns = ["_build"]
 myst_enable_extensions = ["toclist"]
+myst_toclist_maxdepth = 2
+myst_toclist_numbered = True

--- a/tests/test_sphinx/sourcedirs/toclist/index.md
+++ b/tests/test_sphinx/sourcedirs/toclist/index.md
@@ -1,0 +1,7 @@
+# Title
+
++ [Some discarded text](page1.md)
++ [](https://example.com)
++ [](https://example.com "title")
+
+- A normal list

--- a/tests/test_sphinx/sourcedirs/toclist/page1.md
+++ b/tests/test_sphinx/sourcedirs/toclist/page1.md
@@ -1,0 +1,1 @@
+# Page 1 Title

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -532,3 +532,28 @@ def test_fieldlist_extension(
             regress_html=True,
             regress_ext=f".sphinx{sphinx.version_info[0]}.html",
         )
+
+
+@pytest.mark.sphinx(
+    buildername="html",
+    srcdir=os.path.join(SOURCE_DIR, "toclist"),
+    freshenv=True,
+)
+def test_toclist_extension(
+    app,
+    status,
+    warning,
+    get_sphinx_app_doctree,
+):
+    """test enabling the toclist extension."""
+    app.build()
+    assert "build succeeded" in status.getvalue()  # Build succeeded
+    warnings = warning.getvalue().strip()
+    assert warnings == ""
+
+    get_sphinx_app_doctree(
+        app,
+        docname="index",
+        regress=True,
+        regress_ext=".xml",
+    )

--- a/tests/test_sphinx/test_sphinx_builds/test_toclist_extension.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_toclist_extension.xml
@@ -3,7 +3,7 @@
         <title>
             Title
         <compound classes="toctree-wrapper">
-            <toctree caption="True" entries="(None,\ 'page1') (None,\ 'https://example.com') ('title',\ 'https://example.com')" glob="False" hidden="False" includefiles="page1" includehidden="False" maxdepth="-1" numbered="0" parent="index" rawentries="title" titlesonly="False">
+            <toctree caption="True" entries="(None,\ 'page1') (None,\ 'https://example.com') ('title',\ 'https://example.com')" glob="False" hidden="False" includefiles="page1" includehidden="False" maxdepth="2" numbered="999" parent="index" rawentries="title" titlesonly="False">
         <bullet_list bullet="-">
             <list_item>
                 <paragraph>

--- a/tests/test_sphinx/test_sphinx_builds/test_toclist_extension.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_toclist_extension.xml
@@ -1,0 +1,10 @@
+<document source="index.md">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="title" names="title">
+        <title>
+            Title
+        <compound classes="toctree-wrapper">
+            <toctree caption="True" entries="(None,\ 'page1') (None,\ 'https://example.com') ('title',\ 'https://example.com')" glob="False" hidden="False" includefiles="page1" includehidden="False" maxdepth="-1" numbered="0" parent="index" rawentries="title" titlesonly="False">
+        <bullet_list bullet="-">
+            <list_item>
+                <paragraph>
+                    A normal list


### PR DESCRIPTION
By adding `"toclist"` to `myst_enable_extensions` (in the sphinx `conf.py` [configuration file](https://www.sphinx-doc.org/en/master/usage/configuration.html)),
you will be able to specify [sphinx `toctree`](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-toctree) in a Markdown native manner.

`toclist` are identified by bullet lists that use the `+` character as the marker,
and each item should be a link to another source file or an external hyperlink:

```markdown
+ [Link text](subsection.md)
+ [Link text](https://example.com "Example external link")
```

is equivalent to:

````markdown
```{toctree}

subsection.md
Example external link <https://example.com>
```
````

Note that the link text is omitted from the output `toctree`, and the title of the link is taken from either the link title, if present, or the title of the source file.

You can also specify the `maxdepth` and `numbered` options for all toclist in your `conf.py`:

```python
myst_toclist_maxdepth = 2
myst_toclist_numbered = True
```

---

Design notes:

- I think the extension could be really useful for offering the possibility to write documentation using only CommonMark syntax; `toctree` is essentially the only directive/role strictly necessary to create multi-page sphinx sites.
  - At present the extension requires quite minimal code to implement, so should not incur much additional code maintenance burden 
- This extension is similar to https://recommonmark.readthedocs.io/en/latest/auto_structify.html#auto-toc-tree
  - Also, to some extent, https://nbsphinx.readthedocs.io/en/0.8.8/subdir/toctree.html 
- I chose the `+` marker since I felt it is the least used of the possible CommonMark bullet markers (`-`, `*`, `+`), so should generally not conflict with "standard" bullet lists
- For specifying entry titles, I use `[](page.md "title")` instead of `[title](page.md)`. A key reason is because the latter is parsed to markdown tokens, and so you would need to convert it back to plain text, which would be tricky.
- `toctree` options can only be set globally, using `myst_toclist_maxdepth`, `myst_toclist_numbered`. Specifying them per `toclist` would mean some kind of bespoke "decorator" syntax, which would complicate the implementation , and I feel is not necessary for most use cases.
  - Although `caption` would be nice to specify, see below...

---

Some way to specify the `caption`, per `toclist` might be nice, preferably with minimal overhead on syntax/implementation code overhead.

Possibly the simplest would be allowing an initial item with the caption:

```markdown
+ `toctree caption`
+ [Link text](subsection.md)
+ [Link text](https://example.com "Example external link")
```

Note, similar to entry titles, we would want to specify them as inline code, so they are not parsed as markdown.

A slightly more complex implementation would be to use nested lists, also allowing multiple toctrees in a single list:


```markdown
+ `toctree 1 caption`
   + [Link text](subsection1.md)
   + [Link text](https://example.com "Example external link")
+ `toctree 2 caption`
   + [Link text](subsection2.md "a title")
```

would be equivalent to:

````markdown
```{toctree}
:caption: toctree 1 caption

subsection1.md
Example external link <https://example.com>
```

```{toctree}
:caption: toctree 2 caption

a title <subsection2.md>
```
````

thoughts @choldgraf, @mmcky, etc?