### PR TITLE
👌 IMPROVE: `DocutilsRenderer.create_highlighted_code_block`

### DIFF
--- a/tests/test_renderers/fixtures/docutil_syntax_elements.md
+++ b/tests/test_renderers/fixtures/docutil_syntax_elements.md
@@ -127,7 +127,7 @@ Block Code:
     foo
 .
 <document source="notset">
-    <literal_block classes="code none" xml:space="preserve">
+    <literal_block classes="code" xml:space="preserve">
         foo
 .
 


### PR DESCRIPTION
Minor improvement, to handle null lexer_name,
and allow for the use of an alternative node class.