### PR TITLE
🐛 FIX: Source line reporting for nested parsing

### DIFF
--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -114,14 +114,14 @@ class MockState:
         if option_presets:
             raise MockingError("parse_directive_block: option_presets not implemented")
         # TODO should argument_str always be ""?
-        arguments, options, body_lines = parse_directive_text(
+        arguments, options, body_lines, content_offset = parse_directive_text(
             directive, "", "\n".join(content)
         )
         return (
             arguments,
             options,
             StringList(body_lines, source=content.source),
-            line_offset + len(content) - len(body_lines),
+            line_offset + content_offset,
         )
 
     def nested_parse(

--- a/tests/test_renderers/fixtures/mock_include_errors.md
+++ b/tests/test_renderers/fixtures/mock_include_errors.md
@@ -20,5 +20,5 @@ Error in include file:
 ```{include} bad.md
 ```
 .
-tmpdir/bad.md:1: (ERROR/3) Unknown interpreted text role "a".
+tmpdir/bad.md:2: (ERROR/3) Unknown interpreted text role "a".
 .

--- a/tests/test_renderers/fixtures/reporter_warnings.md
+++ b/tests/test_renderers/fixtures/reporter_warnings.md
@@ -136,5 +136,19 @@ header nested in admonition
 # Header
 ```
 .
-<string>:1: (WARNING/2) Header nested in this element can lead to unexpected outcomes
+<string>:2: (WARNING/2) Header nested in this element can lead to unexpected outcomes
+.
+
+nested parse warning
+.
+Paragraph
+
+```{note}
+:class: abc
+:name: xyz
+
+{unknown}`a`
+```
+.
+<string>:7: (ERROR/3) Unknown interpreted text role "unknown".
 .

--- a/tests/test_renderers/test_parse_directives.py
+++ b/tests/test_renderers/test_parse_directives.py
@@ -6,11 +6,21 @@ from docutils.parsers.rst.directives.body import Rubric
 from myst_parser.parse_directives import DirectiveParsingError, parse_directive_text
 
 
-@pytest.mark.parametrize("klass,arguments,content", [(Note, "", "a"), (Note, "a", "")])
+@pytest.mark.parametrize(
+    "klass,arguments,content",
+    [(Note, "", "a"), (Note, "a", ""), (Note, "", ":class: name\n\na")],
+)
 def test_parsing(klass, arguments, content, data_regression):
-    arguments, options, body_lines = parse_directive_text(klass, arguments, content)
+    arguments, options, body_lines, content_offset = parse_directive_text(
+        klass, arguments, content
+    )
     data_regression.check(
-        {"arguments": arguments, "options": options, "body": body_lines}
+        {
+            "arguments": arguments,
+            "options": options,
+            "body": body_lines,
+            "content_offset": content_offset,
+        }
     )
 
 

--- a/tests/test_renderers/test_parse_directives/test_parsing_Note___class__name_n_na_.yml
+++ b/tests/test_renderers/test_parse_directives/test_parsing_Note___class__name_n_na_.yml
@@ -1,0 +1,7 @@
+arguments: []
+body:
+- a
+content_offset: 2
+options:
+  class:
+  - name

--- a/tests/test_renderers/test_parse_directives/test_parsing_Note__a_.yml
+++ b/tests/test_renderers/test_parse_directives/test_parsing_Note__a_.yml
@@ -1,4 +1,5 @@
 arguments: []
 body:
 - a
+content_offset: 0
 options: {}

--- a/tests/test_renderers/test_parse_directives/test_parsing_Note_a__.yml
+++ b/tests/test_renderers/test_parse_directives/test_parsing_Note_a__.yml
@@ -1,4 +1,5 @@
 arguments: []
 body:
 - a
+content_offset: 0
 options: {}


### PR DESCRIPTION
Previously, nested parsing of content within directives
would not correctly propagate the starting line number
of the content.

For example:

````markdown
Paragraph

```{note}
:class: abc
:name: xyz

{unknown}`a`
```
````

Would incorrectly report the error on line 1:

```
<string>:1: (ERROR/3) Unknown interpreted text role "unknown".
```

but now correctly reports on line 7:

```
<string>:7: (ERROR/3) Unknown interpreted text role "unknown".
```
