### PR TITLE
✨ NEW: Add `myst_title_to_header` configuration

### DIFF
--- a/docs/sphinx/reference.md
+++ b/docs/sphinx/reference.md
@@ -32,6 +32,9 @@ To do so, use the keywords beginning `myst_`.
 * - `myst_linkify_fuzzy_links`
   - `True`
   - If `False`, only links that contain a scheme (such as `http`) will be recognised as external links.
+* - `myst_title_to_header`
+  - `False`
+  - If `True`, the `title` key of a document front-matter is converted to a header at the top of the document.
 * - `myst_heading_anchors`
   - `None`
   - Enable auto-generated heading anchors, up to a maximum level, [see here](syntax/header-anchors) for details.

--- a/docs/syntax/syntax.md
+++ b/docs/syntax/syntax.md
@@ -398,8 +398,26 @@ This is a YAML block at the start of the document, as used for example in
 
 :::{seealso}
 Top-matter is also used for the [substitution syntax extension](syntax/substitutions),
-and can be used to store information for blog posting (see [ablog's myst-parser support](https://ablog.readthedocs.io/manual/markdown/)).
+and can be used to store information for blog posting (see [ablog's myst-parser support](https://ablog.readthedocs.io/en/latest/manual/markdown/)).
 :::
+
+### Setting a title
+
+If `myst_title_to_header` is set to `True`, and a `title` key is present in the front matter,
+then the title will be used as the document's header (parsed as Markdown.
+For example:
+
+```md
+---
+title: My Title with *emphasis*
+---
+```
+
+would be equivalent to:
+
+```md
+# My Title with *emphasis*
+```
 
 (syntax/html_meta)=
 

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -748,6 +748,9 @@ class DocutilsRenderer(RendererProtocol):
         else:
             data = deepcopy(token.content)
 
+        if data.get("title"):
+            self.nested_render_text(f"# {data.pop('title')}", 0)
+
         substitutions = data.pop("substitutions", {})
         html_meta = data.pop("html_meta", {})
 

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -831,7 +831,7 @@ class DocutilsRenderer(RendererProtocol):
             )
         )
 
-        if data.get("title") and self.config.get("myst_title_to_header", False):
+        if data.get("title") and self.md_config.title_to_header:
             self.nested_render_text(f"# {data['title']}", 0)
 
     def dict_to_fm_field_list(

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -748,9 +748,6 @@ class DocutilsRenderer(RendererProtocol):
         else:
             data = deepcopy(token.content)
 
-        if data.get("title"):
-            self.nested_render_text(f"# {data.pop('title')}", 0)
-
         substitutions = data.pop("substitutions", {})
         html_meta = data.pop("html_meta", {})
 
@@ -787,6 +784,9 @@ class DocutilsRenderer(RendererProtocol):
                 reporter=self.reporter,
             )
         )
+
+        if data.get("title") and self.config.get("myst_title_to_header", False):
+            self.nested_render_text(f"# {data['title']}", 0)
 
     def dict_to_fm_field_list(
         self, data: Dict[str, Any], language_code: str, line: int = 0

--- a/myst_parser/main.py
+++ b/myst_parser/main.py
@@ -1,3 +1,6 @@
+"""This module holds the global configuration for the parser ``MdParserConfig``,
+and the ``create_md_parser`` function, which creates a parser from the config.
+"""
 from typing import Any, Callable, Dict, Iterable, Optional, Sequence, Tuple, Union, cast
 
 import attr
@@ -144,6 +147,12 @@ class MdParserConfig:
         default=(),
         validator=deep_iterable(instance_of(str)),
         metadata={"help": "Add line numbers to code blocks with these languages"},
+    )
+
+    title_to_header: bool = attr.ib(
+        default=False,
+        validator=instance_of(bool),
+        metadata={"help": "Convert a `title` field in the top-matter to a H1 header"},
     )
 
     heading_anchors: Optional[int] = attr.ib(
@@ -307,6 +316,7 @@ def create_md_parser(
             "myst_footnote_transition": config.footnote_transition,
             "myst_number_code_blocks": config.number_code_blocks,
             "myst_highlight_code_blocks": config.highlight_code_blocks,
+            "myst_title_to_header": config.title_to_header,
         }
     )
 

--- a/tests/test_renderers/fixtures/myst-config.txt
+++ b/tests/test_renderers/fixtures/myst-config.txt
@@ -1,0 +1,26 @@
+[title-to-header] --myst-title-to-header="yes"
+.
+---
+title: "The title *nested syntax*"
+---
+
+# Other header
+.
+<document source="<string>">
+    <docinfo>
+        <field classes="title">
+            <field_name>
+                title
+            <field_body>
+                <paragraph>
+                    <literal>
+                        The title *nested syntax*
+    <section ids="the-title-nested-syntax" names="the\ title\ nested\ syntax">
+        <title>
+            The title
+            <emphasis>
+                nested syntax
+    <section ids="other-header" names="other\ header">
+        <title>
+            Other header
+.

--- a/tests/test_renderers/test_error_reporting.py
+++ b/tests/test_renderers/test_error_reporting.py
@@ -1,3 +1,4 @@
+"""Tests of the warning reporting for different MyST Markdown inputs."""
 from io import StringIO
 from pathlib import Path
 

--- a/tests/test_renderers/test_myst_config.py
+++ b/tests/test_renderers/test_myst_config.py
@@ -1,0 +1,34 @@
+"""Test (docutils) parsing with different ``MdParserConfig`` options set."""
+import shlex
+from io import StringIO
+from pathlib import Path
+
+from docutils.core import Publisher, publish_doctree
+from pytest_param_files import with_parameters
+
+from myst_parser.docutils_ import Parser
+
+FIXTURE_PATH = Path(__file__).parent.joinpath("fixtures")
+
+
+@with_parameters(FIXTURE_PATH / "myst-config.txt")
+def test_cmdline(file_params):
+    """The description is parsed as a docutils commandline"""
+    pub = Publisher(parser=Parser())
+    option_parser = pub.setup_option_parser()
+    try:
+        settings = option_parser.parse_args(
+            shlex.split(file_params.description)
+        ).__dict__
+    except Exception as err:
+        raise AssertionError(
+            f"Failed to parse commandline: {file_params.description}\n{err}"
+        )
+    report_stream = StringIO()
+    settings["warning_stream"] = report_stream
+    doctree = publish_doctree(
+        file_params.content,
+        parser=Parser(),
+        settings_overrides=settings,
+    )
+    file_params.assert_expected(doctree.pformat(), rstrip_lines=True)


### PR DESCRIPTION
This is the "simplest" implementation (3 extra lines!).

Basically, it treats this:

```markdown
---
title: "A **title**"
---
```

like this (including parsing nested syntax)

```markdown
# A **title**
```

I'm not sure if this would be the correct/expected implementation though

for example, currently

```markdown
---
title: "A **title**"
---

# Another title
```

would be treated as

```markdown
# A **title**

# Another title
```

but should it instead be treated as

```markdown
# A **title**

## Another title
```

(also, on a technical note, the parsing should be a bit smarter, in only allowing inline syntax,
there should probably also be a config to turn it off/on)
