### PR TITLE
👌 IMPROVE: Convert nested headings to rubrics

### DIFF
--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -133,7 +133,16 @@ class MockState:
         state_machine_class=None,
         state_machine_kwargs=None,
     ) -> None:
-        """Perform a nested parse of the input block, with ``node`` as the parent."""
+        """Perform a nested parse of the input block, with ``node`` as the parent.
+
+        :param block: The block of lines to parse.
+        :param input_offset: The offset of the first line of block,
+            to the starting line of the state (i.e. directive).
+        :param node: The parent node to attach the parsed content to.
+        :param match_titles: Whether to to allow the parsing of headings
+            (normally this is false,
+            since nested heading would break the document structure)
+        """
         sm_match_titles = self.state_machine.match_titles
         render_match_titles = self._renderer.md_env.get("match_titles", None)
         self.state_machine.match_titles = self._renderer.md_env[

--- a/myst_parser/sphinx_renderer.py
+++ b/myst_parser/sphinx_renderer.py
@@ -135,6 +135,11 @@ class SphinxRenderer(DocutilsRenderer):
         The approach is similar to ``sphinx.ext.autosectionlabel``
         """
         super().render_heading(token)
+
+        if not isinstance(self.current_node, nodes.section):
+            return
+
+        # create the slug string
         slug = cast(str, token.attrGet("id"))
         if slug is None:
             return

--- a/tests/test_renderers/fixtures/reporter_warnings.md
+++ b/tests/test_renderers/fixtures/reporter_warnings.md
@@ -136,7 +136,7 @@ header nested in admonition
 # Header
 ```
 .
-<string>:2: (WARNING/2) Header nested in this element can lead to unexpected outcomes
+<string>:2: (WARNING/2) Disallowed nested header found, converting to rubric
 .
 
 nested parse warning


### PR DESCRIPTION
Handle disallowed nested headings, by converting them to `rubric` nodes

closes #494