### PR TITLE
🐛 FIX: `parse_directive_text` when body followed by options

### DIFF
--- a/myst_parser/parse_directives.py
+++ b/myst_parser/parse_directives.py
@@ -76,13 +76,8 @@ def parse_directive_text(
         body_lines = content.splitlines()
         content_offset = 0
 
-    if not (
-        directive_class.required_arguments
-        or directive_class.optional_arguments
-        or options
-    ):
-        # If there are no possible arguments and no option block,
-        # then the body starts on the argument line
+    if not (directive_class.required_arguments or directive_class.optional_arguments):
+        # If there are no possible arguments, then the body starts on the argument line
         if first_line:
             body_lines.insert(0, first_line)
         arguments = []


### PR DESCRIPTION
This was uncovered in https://github.com/executablebooks/markdown-it-docutils/pull/28

The change does not break any existing tests, but I should add a test that would break without this change