### PR TITLE
🧪 TESTS: Fix regression output on 32-bit systems to match 64-bit systems

### DIFF
--- a/tests/test_renderers/test_fixtures_sphinx.py
+++ b/tests/test_renderers/test_fixtures_sphinx.py
@@ -3,6 +3,7 @@
 Note, the output AST is before any transforms are applied.
 """
 import re
+import sys
 from pathlib import Path
 
 import pytest
@@ -50,6 +51,9 @@ def test_sphinx_directives(file_params):
     document = to_docutils(file_params.content, in_sphinx_env=True).pformat()
     # see https://github.com/sphinx-doc/sphinx/issues/9827
     document = document.replace('<glossary sorted="False">', "<glossary>")
+    # see https://github.com/executablebooks/MyST-Parser/issues/522
+    if sys.maxsize == 2147483647:
+        document = document.replace('"2147483647"', '"9223372036854775807"')
     file_params.assert_expected(document, rstrip_lines=True)
 
 


### PR DESCRIPTION
Fixes `test_sphinx_directives[35-highlight (sphinx.directives.code.Highlight):]` which was failing on 32-bit platforms due to `linenothreshold` defaulting to `sys.maxsize`.

Fixes: #522