### PR TITLE
🐛 FIX: Heading anchor resolution for parallel builds

### DIFF
--- a/myst_parser/myst_refs.py
+++ b/myst_parser/myst_refs.py
@@ -202,8 +202,11 @@ class MystReferenceResolver(ReferencesResolver):
         self, node: pending_xref, fromdocname: str
     ) -> Optional[Element]:
         """Resolve doc with anchor."""
+        if self.env.config.myst_heading_anchors is None:
+            # no target anchors will have been created, so we don't look for them
+            return None
         target = node["reftarget"]  # type: str
-        if not ("#" in target and hasattr(self.env, "myst_anchors")):
+        if "#" not in target:
             return None
         # the link may be a heading anchor; we need to first get the relative path
         rel_path, anchor = target.rsplit("#", 1)

--- a/myst_parser/sphinx_renderer.py
+++ b/myst_parser/sphinx_renderer.py
@@ -164,9 +164,7 @@ class SphinxRenderer(DocutilsRenderer):
             clean_astext(section[0]),
         )
 
-        # for debugging
-        if not hasattr(self.doc_env, "myst_anchors"):
-            self.doc_env.myst_anchors = True  # type: ignore[attr-defined]
+        self.doc_env.metadata[self.doc_env.docname]["myst_anchors"] = True
         section["myst-anchor"] = doc_slug
 
     def render_math_block_label(self, token: SyntaxTreeNode) -> None:


### PR DESCRIPTION
For sphinx parallel builds, `env.myst_anchors` will be discarded when merging environments from the parallel jobs.
So we no longer use this to check whether to look for heading anchors

closes #411