### PR TITLE
📚 DOCS: Fix typo - "to use write Sphinx"

### DIFF
--- a/docs/sphinx/index.md
+++ b/docs/sphinx/index.md
@@ -2,7 +2,7 @@
 
 # MyST with Sphinx
 
-The MyST Parser comes bundled with a Sphinx extension that allows you to use write Sphinx documentation entirely in MyST (or, in a combination of rST and MyST).
+The MyST Parser comes bundled with a Sphinx extension that allows you to write Sphinx documentation entirely in MyST (or, in a combination of rST and MyST).
 The following sections cover some major functionality of the Sphinx extension.
 
 :::{seealso}


### PR DESCRIPTION
The phrase "allows you to use write Sphinx documentation" includes an extra word because of an editing oversight. I think the writer means "allows you to write Sphinx documentation" etc. My guess is that in a previous draft, the writer had "allows you to use MyST to write Sphinx documentation," and didn't fully complete the revision.