### PR TITLE
Remove duplicate reference label from intro.md

### DIFF
--- a/docs/sphinx/intro.md
+++ b/docs/sphinx/intro.md
@@ -212,14 +212,6 @@ And some more content.
 ````
 
 Because your new section has a label (`section-two`), you can reference it with the `ref` role.
-Add it to your markdown file like so:
-
-
-```md
-(label-name)=
-## Some header
-```
-
 Add this to your markdown file from above, like so:
 
 ````md


### PR DESCRIPTION
at the moment, https://myst-parser.readthedocs.io/en/latest/sphinx/intro.html#reference-a-section-label-with-a-role  unnecessarily mentions the following syntax twice

```
(label-name)=
## Some header
```

this PR removes the second mention