### PR TITLE
📚 DOCS: Fix date of  0.17.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.17.0 - 2021-02-11
+## 0.17.0 - 2022-02-11
 
 This release contains a number of breaking improvements.
 


### PR DESCRIPTION
2022 is the new 2021 (date typo in CHANGELOG)