### PR TITLE
🔧 MAINTAIN: Directly specify attrs dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ keywords = [
 ]
 requires-python = ">=3.7"
 dependencies = [
+    "attrs>=19",
     "docutils>=0.15,<0.18",
     "jinja2", # required for substitutions, but let sphinx choose version
     "markdown-it-py>=1.0.0,<3.0.0",


### PR DESCRIPTION
This dependency has been removed from markdown-it-py,
so needs to be directly declared here
(https://github.com/executablebooks/markdown-it-py/pull/212)