### PR TITLE
Test on sphinx 5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,13 +26,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        sphinx: [">=4,<5"]
+        sphinx: [">=4,<5", "==5.0.0.b1"]
         os: [ubuntu-latest]
         include:
-          # fails because of: https://github.com/sphinx-doc/sphinx/issues/10291
-          # - os: ubuntu-latest
-          #   python-version: "3.8"
-          #   sphinx: ">=3,<4"
           - os: windows-latest
             python-version: "3.8"
             sphinx: ">=4,<5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "markdown-it-py>=1.0.0,<3.0.0",
     "mdit-py-plugins~=0.3.0",
     "pyyaml",
-    "sphinx>=3.1,<5",
+    "sphinx>=3.1,<6",
     "typing-extensions",
 ]
 


### PR DESCRIPTION
According to the 5.0.0 release plan, Sphinx 5 should be released in a few weeks:
- https://github.com/sphinx-doc/sphinx/issues/10312

I would like to make this change to make it easier for projects that depend on MyST-Parser to test on Sphinx 5.

Would it be acceptable to change `"sphinx>=3.1,<6"` to  `"sphinx>=4,<6"`, since you don't test on Sphinx 3? If not, should I a test to verify that this should work on `sphinx==3.1`?