### PR TITLE
Add support for `hard_wrap`

### DIFF
--- a/myst_parser/config/main.py
+++ b/myst_parser/config/main.py
@@ -75,11 +75,20 @@ class MdParserConfig:
             "help": "Use strict CommonMark parser",
         },
     )
+
     gfm_only: bool = dc.field(
         default=False,
         metadata={
             "validator": instance_of(bool),
             "help": "Use strict Github Flavoured Markdown parser",
+        },
+    )
+
+    hard_wrap: bool = dc.field(
+        default=False,
+        metadata={
+            "validator": instance_of(bool),
+            "help": "Support hard wrap",
         },
     )
 

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -486,7 +486,12 @@ class DocutilsRenderer(RendererProtocol):
             self.render_children(token)
 
     def render_softbreak(self, token: SyntaxTreeNode) -> None:
-        self.current_node.append(nodes.Text("\n"))
+        # Insert HTML `<br>` tags inside on paragraphs
+        # where the origin Markdown document had newlines
+        if self.md_config.hard_wrap is True:
+            self.current_node.append(nodes.raw("", "<br />\n", format="html"))
+        else:
+            self.current_node.append(nodes.Text("\n"))
 
     def render_hardbreak(self, token: SyntaxTreeNode) -> None:
         self.current_node.append(nodes.raw("", "<br />\n", format="html"))


### PR DESCRIPTION
Insert HTML `<br>` tags inside on paragraphs where the origin Markdown document had newlines

default: `myst_hard_wrap = False`
```html
<p>foo
bar</p>
```

`myst_hard_wrap = True`
```html
<p>foo<br>
bar</p>
```

p.s. I am noob in python

