### PR TITLE
🐛 FIX: don't fail with docutils 0.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ keywords = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "docutils>=0.15,<0.19",
+    "docutils>=0.19,<0.20",
     "jinja2", # required for substitutions, but let sphinx choose version
     "markdown-it-py>=1.0.0,<3.0.0",
     "mdit-py-plugins~=0.3.0",

--- a/tests/test_renderers/fixtures/docutil_roles.md
+++ b/tests/test_renderers/fixtures/docutil_roles.md
@@ -93,7 +93,7 @@
 .
 <document source="notset">
     <paragraph>
-        <reference refuri="http://www.python.org/dev/peps/pep-0000">
+        <reference refuri="https://peps.python.org/pep-0000">
             PEP 0
 .
 
@@ -104,7 +104,7 @@
 .
 <document source="notset">
     <paragraph>
-        <reference refuri="http://tools.ietf.org/html/rfc1.html">
+        <reference refuri="https://tools.ietf.org/html/rfc1.html">
             RFC 1
 .
 


### PR DESCRIPTION
Update the version bounds to allow docutils 0.19, and update the
fixtures to match the output produced by 0.19.

Fixes https://github.com/executablebooks/MyST-Parser/issues/591.