### PR TITLE
⬆️ UPGRADE: docutils 0.19 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        docutils-version: ["0.16", "0.17", "0.18"]
+        docutils-version: ["0.17", "0.18", "0.19"]
 
     steps:
     - name: Checkout source

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -1391,11 +1391,16 @@ def html_meta_to_nodes(
         return []
 
     try:
+        # if sphinx available
         from sphinx.addnodes import meta as meta_cls
     except ImportError:
-        from docutils.parsers.rst.directives.html import MetaBody
+        try:
+            # docutils >= 0.19
+            meta_cls = nodes.meta  # type: ignore
+        except AttributeError:
+            from docutils.parsers.rst.directives.html import MetaBody
 
-        meta_cls = MetaBody.meta  # type: ignore
+            meta_cls = MetaBody.meta  # type: ignore
 
     output = []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ keywords = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "docutils>=0.15,<0.19",
+    "docutils>=0.15,<0.20",
     "jinja2", # required for substitutions, but let sphinx choose version
     "markdown-it-py>=1.0.0,<3.0.0",
     "mdit-py-plugins~=0.3.0",

--- a/tests/test_renderers/fixtures/docutil_roles.md
+++ b/tests/test_renderers/fixtures/docutil_roles.md
@@ -93,7 +93,7 @@
 .
 <document source="notset">
     <paragraph>
-        <reference refuri="http://www.python.org/dev/peps/pep-0000">
+        <reference refuri="https://peps.python.org/pep-0000">
             PEP 0
 .
 
@@ -104,7 +104,7 @@
 .
 <document source="notset">
     <paragraph>
-        <reference refuri="http://tools.ietf.org/html/rfc1.html">
+        <reference refuri="https://tools.ietf.org/html/rfc1.html">
             RFC 1
 .
 

--- a/tests/test_renderers/test_fixtures_docutils.py
+++ b/tests/test_renderers/test_fixtures_docutils.py
@@ -50,7 +50,18 @@ def test_docutils_roles(file_params, monkeypatch):
         parser=Parser(),
     )
 
-    file_params.assert_expected(doctree.pformat(), rstrip_lines=True)
+    ptree = doctree.pformat()
+    # docutils >=0.19 changes:
+    ptree = ptree.replace(
+        'refuri="http://tools.ietf.org/html/rfc1.html"',
+        'refuri="https://tools.ietf.org/html/rfc1.html"',
+    )
+    ptree = ptree.replace(
+        'refuri="http://www.python.org/dev/peps/pep-0000"',
+        'refuri="https://peps.python.org/pep-0000"',
+    )
+
+    file_params.assert_expected(ptree, rstrip_lines=True)
 
 
 @pytest.mark.param_file(FIXTURE_PATH / "docutil_directives.md")

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -299,6 +299,10 @@ def test_include_from_rst(
     )
 
 
+@pytest.mark.skipif(
+    __version_info__ < VersionInfo(0, 19, 0, "final", 0, True),
+    reason="Footnote HTML changed in docutils 0.19",
+)
 @pytest.mark.sphinx(
     buildername="html", srcdir=os.path.join(SOURCE_DIR, "footnotes"), freshenv=True
 )

--- a/tests/test_sphinx/test_sphinx_builds/test_footnotes.sphinx5.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_footnotes.sphinx5.html
@@ -97,113 +97,115 @@
      </div>
     </blockquote>
     <hr class="footnotes docutils"/>
-    <aside class="footnote brackets" id="c" role="note">
-     <span class="label">
-      <span class="fn-bracket">
-       [
+    <aside class="footnote-list brackets">
+     <aside class="footnote brackets" id="c" role="note">
+      <span class="label">
+       <span class="fn-bracket">
+        [
+       </span>
+       <a href="#id1" role="doc-backlink">
+        1
+       </a>
+       <span class="fn-bracket">
+        ]
+       </span>
       </span>
-      <a href="#id1" role="doc-backlink">
-       1
-      </a>
-      <span class="fn-bracket">
-       ]
+      <p>
+       a footnote referenced first
+      </p>
+     </aside>
+     <aside class="footnote brackets" id="d" role="note">
+      <span class="label">
+       <span class="fn-bracket">
+        [
+       </span>
+       <a href="#id2" role="doc-backlink">
+        2
+       </a>
+       <span class="fn-bracket">
+        ]
+       </span>
       </span>
-     </span>
-     <p>
-      a footnote referenced first
-     </p>
-    </aside>
-    <aside class="footnote brackets" id="d" role="note">
-     <span class="label">
-      <span class="fn-bracket">
-       [
+      <p>
+       a footnote referenced in a directive
+      </p>
+     </aside>
+     <aside class="footnote brackets" id="a" role="note">
+      <span class="label">
+       <span class="fn-bracket">
+        [
+       </span>
+       <a href="#id3" role="doc-backlink">
+        3
+       </a>
+       <span class="fn-bracket">
+        ]
+       </span>
       </span>
-      <a href="#id2" role="doc-backlink">
-       2
-      </a>
-      <span class="fn-bracket">
-       ]
+      <p>
+       some footnote
+       <em>
+        text
+       </em>
+      </p>
+     </aside>
+     <aside class="footnote brackets" id="b" role="note">
+      <span class="label">
+       <span class="fn-bracket">
+        [
+       </span>
+       <a href="#id4" role="doc-backlink">
+        4
+       </a>
+       <span class="fn-bracket">
+        ]
+       </span>
       </span>
-     </span>
-     <p>
-      a footnote referenced in a directive
-     </p>
-    </aside>
-    <aside class="footnote brackets" id="a" role="note">
-     <span class="label">
-      <span class="fn-bracket">
-       [
+      <p>
+       a footnote before its reference
+      </p>
+     </aside>
+     <aside class="footnote brackets" id="id8" role="note">
+      <span class="label">
+       <span class="fn-bracket">
+        [
+       </span>
+       123
+       <span class="fn-bracket">
+        ]
+       </span>
       </span>
-      <a href="#id3" role="doc-backlink">
-       3
-      </a>
-      <span class="fn-bracket">
-       ]
+      <span class="backrefs">
+       (
+       <a href="#id5" role="doc-backlink">
+        1
+       </a>
+       ,
+       <a href="#id6" role="doc-backlink">
+        2
+       </a>
+       )
       </span>
-     </span>
-     <p>
-      some footnote
-      <em>
-       text
-      </em>
-     </p>
-    </aside>
-    <aside class="footnote brackets" id="b" role="note">
-     <span class="label">
-      <span class="fn-bracket">
-       [
+      <p>
+       multiple references footnote
+      </p>
+     </aside>
+     <aside class="footnote brackets" id="e" role="note">
+      <span class="label">
+       <span class="fn-bracket">
+        [
+       </span>
+       <a href="#id7" role="doc-backlink">
+        5
+       </a>
+       <span class="fn-bracket">
+        ]
+       </span>
       </span>
-      <a href="#id4" role="doc-backlink">
-       4
-      </a>
-      <span class="fn-bracket">
-       ]
-      </span>
-     </span>
-     <p>
-      a footnote before its reference
-     </p>
-    </aside>
-    <aside class="footnote brackets" id="id8" role="note">
-     <span class="label">
-      <span class="fn-bracket">
-       [
-      </span>
-      123
-      <span class="fn-bracket">
-       ]
-      </span>
-     </span>
-     <span class="backrefs">
-      (
-      <a href="#id5" role="doc-backlink">
-       1
-      </a>
-      ,
-      <a href="#id6" role="doc-backlink">
-       2
-      </a>
-      )
-     </span>
-     <p>
-      multiple references footnote
-     </p>
-    </aside>
-    <aside class="footnote brackets" id="e" role="note">
-     <span class="label">
-      <span class="fn-bracket">
-       [
-      </span>
-      <a href="#id7" role="doc-backlink">
-       5
-      </a>
-      <span class="fn-bracket">
-       ]
-      </span>
-     </span>
-     <p>
-      footnote definition in a block element
-     </p>
+      <p>
+       footnote definition in a block element
+      </p>
+     </aside>
     </aside>
    </section>
   </div>


### PR DESCRIPTION
This PR allows docutils 0.19 to be used with myst-parser.
See: https://docutils.sourceforge.io/RELEASE-NOTES.html#release-0-19-2022-07-05.
Note though, it does not fix a number of `DeprecationWarning` that arise from using docutils 0.19, which will be addressed at a later date.

closes #591