### PR TITLE
🧪 Introduce a gate/check GHA job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,12 @@ jobs:
           python-version: "3.8"
           sphinx: ">=5,<6"
 
+    continue-on-error: >-
+      ${{
+        (matrix.python-version == '3.8' && matrix.sphinx == '>=5,<6')
+        && true || false
+      }}
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -101,10 +107,29 @@ jobs:
     - name: Run docutils CLI
       run: echo "test" | myst-docutils-html
 
+  # https://github.com/marketplace/actions/alls-green#why
+  check:  # This job does nothing and is only used for the branch protection
+
+    if: always()
+
+    needs:
+    - pre-commit
+    - tests
+    - check-myst-docutils
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}
+
   publish:
 
     name: Publish myst-parser to PyPi
-    needs: [pre-commit, tests, check-myst-docutils]
+    needs:
+    - check
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,12 +36,6 @@ jobs:
           python-version: "3.8"
           sphinx: ">=5,<6"
 
-    continue-on-error: >-
-      ${{
-        (matrix.python-version == '3.8' && matrix.sphinx == '>=5,<6')
-        && true || false
-      }}
-
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
This adds a GHA job that reliably determines if all the required dependencies have succeeded or not.

It also allows to reduce the list of required branch protection CI statuses to just one — `check`. This reduces the maintenance burden by a lot and have been battle-tested across a small bunch of projects in its action form and in-house implementations of other people.

This action is now in use in aiohttp (and other aio-libs projects), CherryPy, conda, coveragepy, Open edX, Towncrier some of the Ansible repositories, pip-tools, all of the jaraco's projects (like `setuptools`, `importlib_metadata`), some of hynek's projects (like `attrs`, `structlog`), some PyCQA, PyCA, PyPA and pytest projects, a few AWS Labs projects. Admittedly, I maintain a few of these but it seems to address some of the pain folks have:
https://github.com/jaraco/skeleton/pull/55#issuecomment-1106638475.

I figured, this might be useful for MyST too, which is why I'm submitting this patch.

The story behind this is explained in more detail at https://github.com/marketplace/actions/alls-green#why.