### PR TITLE
👌 Change missing directive/role errors to warnings

### DIFF
--- a/docs/live_preview.py
+++ b/docs/live_preview.py
@@ -1,3 +1,4 @@
+import traceback
 from io import StringIO
 
 import yaml
@@ -30,7 +31,7 @@ def convert(input_config: str, input_myst: str, writer_name: str) -> dict:
             settings_overrides=settings,
         )
     except Exception as exc:
-        output = f"ERROR: conversion:\n{exc}"
+        output = f"ERROR: conversion:\n{exc}\n{traceback.format_exc()}"
     return {"output": output, "warnings": warning_stream.getvalue()}
 
 

--- a/myst_parser/warnings_.py
+++ b/myst_parser/warnings_.py
@@ -31,6 +31,10 @@ class MystWarnings(Enum):
 
     DIRECTIVE_PARSING = "directive_parse"
     """Issue parsing directive."""
+    UNKNOWN_DIRECTIVE = "directive_unknown"
+    """Unknown directive."""
+    UNKNOWN_ROLE = "role_unknown"
+    """Unknown role."""
 
     # cross-reference resolution
     XREF_AMBIGUOUS = "xref_ambiguous"

--- a/tests/test_renderers/fixtures/directive_options.md
+++ b/tests/test_renderers/fixtures/directive_options.md
@@ -147,9 +147,9 @@ Unknown Directive:
 ```
 .
 <document source="<src>/index.md">
-    <system_message level="3" line="1" source="<src>/index.md" type="ERROR">
+    <system_message level="2" line="1" source="<src>/index.md" type="WARNING">
         <paragraph>
-            Unknown directive type "unknown".
+            Unknown directive type: 'unknown' [myst.directive_unknown]
     <system_message level="1" line="1" source="<src>/index.md" type="INFO">
         <paragraph>
             No directive entry for "unknown" in module "docutils.parsers.rst.languages.en".

--- a/tests/test_renderers/fixtures/mock_include_errors.md
+++ b/tests/test_renderers/fixtures/mock_include_errors.md
@@ -20,5 +20,5 @@ Error in include file:
 ```{include} bad.md
 ```
 .
-tmpdir/bad.md:2: (ERROR/3) Unknown interpreted text role "a".
+tmpdir/bad.md:2: (WARNING/2) Unknown interpreted text role "a". [myst.role_unknown]
 .

--- a/tests/test_renderers/fixtures/reporter_warnings.md
+++ b/tests/test_renderers/fixtures/reporter_warnings.md
@@ -19,7 +19,7 @@ abc
 
 {xyz}`a`
 .
-<string>:3: (ERROR/3) Unknown interpreted text role "xyz".
+<string>:3: (WARNING/2) Unknown interpreted text role "xyz". [myst.role_unknown]
 .
 
 Unknown directive:
@@ -28,7 +28,7 @@ Unknown directive:
 ```{xyz}
 ```
 .
-<string>:2: (ERROR/3) Unknown directive type "xyz".
+<string>:2: (WARNING/2) Unknown directive type: 'xyz' [myst.directive_unknown]
 .
 
 Bad Front Matter:
@@ -174,5 +174,5 @@ Paragraph
 {unknown}`a`
 ```
 .
-<string>:7: (ERROR/3) Unknown interpreted text role "unknown".
+<string>:7: (WARNING/2) Unknown interpreted text role "unknown". [myst.role_unknown]
 .


### PR DESCRIPTION
If an unknown directive/role name is encountered,
then a warning is emitted with the `myst.directive_unknown` or `myst.role_unknown` type,
which can be suppressed.