### PR TITLE
👌 IMPROVE: Allow heading_slug_func to be a string 

### DIFF
--- a/docs/syntax/optional.md
+++ b/docs/syntax/optional.md
@@ -520,6 +520,12 @@ The anchor "slugs" created aim to follow the [GitHub implementation](https://git
 
 To change the slug generation function, set `myst_heading_slug_func` in your `conf.py` to a function that accepts a string and returns a string.
 
+:::{versionadded} 0.19.0
+`myst_heading_slug_func` can now also be set to a string,
+which will be interpreted as an import path to a function,
+e.g. `myst_heading_slug_func = "mypackage.mymodule.slugify"`.
+:::
+
 ### Inspect the links that will be created
 
 You can inspect the links that will be created using the command-line tool:

--- a/myst_parser/parsers/docutils_.py
+++ b/myst_parser/parsers/docutils_.py
@@ -136,7 +136,7 @@ def _attr_to_optparse_option(at: Field, default: Any) -> Tuple[dict, str]:
             "metavar": "<boolean>",
             "validator": frontend.validate_boolean,
         }, str(default)
-    if at.type is str:
+    if at.type is str or at.name == "heading_slug_func":
         return {
             "metavar": "<str>",
         }, f"(default: '{default}')"

--- a/tests/test_renderers/fixtures/myst-config.txt
+++ b/tests/test_renderers/fixtures/myst-config.txt
@@ -413,3 +413,17 @@ a
 <string>:1: (WARNING/2) No matches for '*:*:*:other' [myst.iref_missing]
 <string>:3: (WARNING/2) Multiple matches for '*:*:*:*index': key:std:label:genindex, key:std:label:modindex, key:std:label:py-modindex, ... [myst.iref_ambiguous]
 .
+
+[heading_slug_func] --myst-heading-anchors=1 --myst-heading-slug-func=myst_parser.config.main._test_slug_func
+.
+# title
+
+[reversed](#eltit)
+.
+<document ids="title" names="title" slug="eltit" source="<string>" title="title">
+    <title>
+        title
+    <paragraph>
+        <reference id_link="True" refid="title">
+            reversed
+.


### PR DESCRIPTION
`myst_heading_slug_func` can now also be set to a string,
which will be interpreted as an import path to a function,
e.g. `myst_heading_slug_func = "mypackage.mymodule.slugify"`.