### PR TITLE
✨ NEW: Add `attrs_block` extension

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       additional_dependencies:
       - sphinx~=5.0
       - markdown-it-py>=1.0.0,<3.0.0
-      - mdit-py-plugins~=0.3.1
+      - mdit-py-plugins~=0.3.4
       files: >
         (?x)^(
             myst_parser/.*py|

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,6 +100,7 @@ myst_enable_extensions = [
     "substitution",
     "tasklist",
     "attrs_inline",
+    "attrs_block",
     "inv_link",
 ]
 myst_url_schemes = {

--- a/docs/syntax/optional.md
+++ b/docs/syntax/optional.md
@@ -653,13 +653,6 @@ based on the [reStructureText syntax](https://docutils.sourceforge.io/docs/ref/r
 :Paragraphs: Since the field marker may be quite long, the second
    and subsequent lines of a paragraph do not have to line up
    with the first line.
-:Alignment 1: If the field body starts on the first line...
-
-              Then the entire field body must be indented the same.
-:Alignment 2:
-  If the field body starts on a subsequent line...
-
-  Then the indentation is always two spaces.
 :Blocks:
 
   As well as paragraphs, any block syntaxes may be used in a field body:
@@ -679,13 +672,6 @@ based on the [reStructureText syntax](https://docutils.sourceforge.io/docs/ref/r
 :Paragraphs: Since the field marker may be quite long, the second
    and subsequent lines of a paragraph do not have to line up
    with the first line.
-:Alignment 1: If the field body starts on the first line...
-
-              Then the entire field body must be indented the same.
-:Alignment 2:
-  If the field body starts on a subsequent line...
-
-  Then the indentation is always two spaces.
 :Blocks:
 
   As well as paragraphs, any block syntaxes may be used in a field body:
@@ -731,19 +717,20 @@ Currently `sphinx.ext.autodoc` does not support MyST, see [](howto/autodoc).
 :::
 
 (syntax/attributes)=
-## Inline attributes
+## Attributes
 
 :::{versionadded} 0.19
-This feature is in *beta*, and may change in future versions.
-It replace the previous `attrs_image` extension, which is now deprecated.
+This feature is in *beta*, and feedback is welcome.
+
+`attrs_inline` also replace the previous `attrs_image` extension, which is now deprecated.
 :::
 
-By adding `"attrs_inline"` to `myst_enable_extensions` (in the {{ confpy }}),
-you can enable parsing of inline attributes after certain inline syntaxes.
-This is adapted from [djot inline attributes](https://htmlpreview.github.io/?https://github.com/jgm/djot/blob/master/doc/syntax.html#inline-attributes),
-and also related to [pandoc bracketed spans](https://pandoc.org/MANUAL.html#extension-bracketed_spans).
+Attributes are a way of enriching standard CommonMark syntax, by adding additional information to elements.
 
-Attributes are specified in curly braces after the inline syntax.
+Attributes are specified inside curly braces `{}`,
+for example `{#my-id .my-class key="value"}`,
+and come before a block element or after an inline element.
+
 Inside the curly braces, the following syntax is recognised:
 
 - `.foo` specifies `foo` as a class.
@@ -757,6 +744,126 @@ Inside the curly braces, the following syntax is recognised:
     Backslash escapes may be used inside quoted values.
     **Note** only certain keys are supported, see below.
 - `%` begins a comment, which ends with the next `%` or the end of the attribute (`}`).
+
+Attributes are cumulative, so that if multiple attributes follow each other, the inner attributes override the outer ones. One exception is that if multiple classes are given, they are combined.
+For example:
+
+```markdown
+{#id1 .class1 key1="value1"}
+{#id2 .class2 key2="value2"}
+block
+
+[inline]{#id2 .class2 key2="value2"}{#id1 .class1 key1="value1"}
+```
+
+is equivalent to:
+
+```markdown
+{#id2 .class1 .class2 key1="value1" key2="value2"}
+block
+
+[inline]{#id2 .class1 .class2 key1="value1" key2="value2"}
+```
+
+:::{seealso}
+This is adapted from [djot inline/block attributes](https://htmlpreview.github.io/?https://github.com/jgm/djot/blob/master/doc/syntax.html#inline-attributes),
+and also related to [pandoc bracketed spans](https://pandoc.org/MANUAL.html#extension-bracketed_spans).
+:::
+
+(syntax/attributes/block)=
+### Block attributes
+
+By adding `"attrs_block"` to `myst_enable_extensions` (in the {{ confpy }}),
+you can enable parsing of block attributes before certain block syntaxes.
+
+For example, the following Markdown:
+
+```markdown
+{#mypara .bg-warning}
+Here is a paragraph with attributes.
+
+{ref}`A reference to my paragraph <mypara>`
+```
+
+will be rendered as:
+
+{#mypara .bg-warning}
+Here is a paragraph with attributes.
+
+{ref}`A reference to my paragraph <mypara>`
+
+`id` and `class` are supported for most block syntaxes,
+but only certain key-value attributes are supported for each syntax.
+
+For **ordered lists**, the `style` key is supported, and can be one of `decimal`, `lower-alpha`, `upper-alpha`, `lower-roman`, `upper-roman`:
+
+```markdown
+{style=lower-alpha}
+1. a
+2. b
+
+{style=upper-alpha}
+1. a
+2. b
+
+{style=lower-roman}
+1. a
+2. b
+
+{style=upper-roman}
+1. a
+2. b
+```
+
+{style=lower-alpha}
+1. a
+2. b
+
+{style=upper-alpha}
+1. a
+2. b
+
+{style=lower-roman}
+1. a
+2. b
+
+{style=upper-roman}
+1. a
+2. b
+
+For **code fences**, the `lineno-start` and `emphasize-lines` keys are supported:
+
+````md
+{lineno-start=1 emphasize-lines="2,3"}
+```python
+a = 1
+b = 2
+c = 3
+```
+````
+
+{lineno-start=1 emphasize-lines="2,3"}
+```python
+a = 1
+b = 2
+c = 3
+```
+
+For **block quotes**, the `attribution` key is supported:
+
+```markdown
+{attribution="Chris Sewell"}
+> Hallo
+```
+
+{attribution="Chris Sewell"}
+> Hallo
+
+(syntax/attributes/inline)=
+### Inline attributes
+
+By adding `"attrs_inline"` to `myst_enable_extensions` (in the {{ confpy }}),
+you can enable parsing of inline attributes after certain inline syntaxes.
 
 For example, the following Markdown:
 
@@ -794,9 +901,7 @@ will be parsed as:
 - ![An image with attribute](img/fun-fish.png){#imgid .bg-warning w="100px" align=center}
   {ref}`a reference to the image <imgid>`
 
-### key-value attributes
-
-`id` and `class` are supported for all inline syntaxes,
+`id` and `class` are supported for most inline syntaxes,
 but only certain key-value attributes are supported for each syntax.
 
 For **literals**, the following attributes are supported:
@@ -812,7 +917,6 @@ For **images**, the following attributes are supported (equivalent to the `image
 - `align`/`a` defines the scale of the image (`left`, `center`, or `right`)
 
 (syntax/images)=
-
 ## HTML Images
 
 MyST provides a few different syntaxes for including images in your documentation, as explained below.

--- a/docs/syntax/syntax.md
+++ b/docs/syntax/syntax.md
@@ -38,6 +38,10 @@ Ordered List    | `1. item`
 Unordered List  | `- item`
 Code Fence      | opening ```` ```lang ```` to closing ```` ``` ````
 
+:::{tip}
+The {ref}`attribute extensions <syntax/attributes>` allow you to enrich these syntaxes with additional information.
+:::
+
 (syntax/frontmatter)=
 
 ## Front Matter
@@ -314,7 +318,7 @@ You can customise this behaviour in a number of ways using [configuration option
 Most simply, by setting the `myst_all_links_external` configuration option to `True`,
 all links will be treated as external [URL] links.
 
-To apply selectively to specific links, you can enable the [attrs_inline](optional.md#inline-attributes) extension,
+To apply selectively to specific links, you can enable the [attrs_inline](syntax/attributes/inline) extension,
 then add an `external` class to the link.\
 For example, `[my-external-link](my-external-link){.external}` becomes [my-external-link](my-external-link){.external}.
 

--- a/myst_parser/config/main.py
+++ b/myst_parser/config/main.py
@@ -37,6 +37,7 @@ def check_extensions(inst: "MdParserConfig", field: dc.Field, value: Any) -> Non
             "amsmath",
             "attrs_image",
             "attrs_inline",
+            "attrs_block",
             "colon_fence",
             "deflist",
             "dollarmath",

--- a/myst_parser/parsers/mdit.py
+++ b/myst_parser/parsers/mdit.py
@@ -9,7 +9,7 @@ from markdown_it import MarkdownIt
 from markdown_it.renderer import RendererProtocol
 from mdit_py_plugins.amsmath import amsmath_plugin
 from mdit_py_plugins.anchors import anchors_plugin
-from mdit_py_plugins.attrs import attrs_plugin
+from mdit_py_plugins.attrs import attrs_block_plugin, attrs_plugin
 from mdit_py_plugins.colon_fence import colon_fence_plugin
 from mdit_py_plugins.deflist import deflist_plugin
 from mdit_py_plugins.dollarmath import dollarmath_plugin
@@ -111,6 +111,8 @@ def create_md_parser(
     elif "attrs_image" in config.enable_extensions:
         # TODO deprecate
         md.use(attrs_plugin, after=("image",))
+    if "attrs_block" in config.enable_extensions:
+        md.use(attrs_block_plugin)
     if config.heading_anchors is not None:
         md.use(
             anchors_plugin,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "docutils>=0.15,<0.20",
     "jinja2", # required for substitutions, but let sphinx choose version
     "markdown-it-py>=1.0.0,<3.0.0",
-    "mdit-py-plugins~=0.3.3",
+    "mdit-py-plugins~=0.3.4",
     "pyyaml",
     "sphinx>=5,<7",
     'typing-extensions; python_version < "3.8"',

--- a/tests/test_renderers/fixtures/attributes.md
+++ b/tests/test_renderers/fixtures/attributes.md
@@ -1,0 +1,77 @@
+code fence
+.
+{lineno-start=1 emphasize-lines="2,3"}
+```python
+a = 1
+b = 2
+c = 3
+```
+.
+<document source="<src>/index.md">
+    <literal_block highlight_args="{'hl_lines': [2, 3]}" language="python" linenos="True" xml:space="preserve">
+        a = 1
+        b = 2
+        c = 3
+.
+
+blockquote
+.
+{attribution="Chris Sewell"}
+> Hallo
+.
+<document source="<src>/index.md">
+    <block_quote>
+        <paragraph>
+            Hallo
+        <attribution>
+            Chris Sewell
+.
+
+list-style
+.
+{style=lower-alpha}
+1. a
+2. b
+
+{style=upper-alpha}
+1. a
+2. b
+
+{style=lower-roman}
+1. a
+2. b
+
+{style=upper-roman}
+1. a
+2. b
+.
+<document source="<src>/index.md">
+    <enumerated_list enumtype="loweralpha" prefix="" suffix=".">
+        <list_item>
+            <paragraph>
+                a
+        <list_item>
+            <paragraph>
+                b
+    <enumerated_list enumtype="upperalpha" prefix="" suffix=".">
+        <list_item>
+            <paragraph>
+                a
+        <list_item>
+            <paragraph>
+                b
+    <enumerated_list enumtype="lowerroman" prefix="" suffix=".">
+        <list_item>
+            <paragraph>
+                a
+        <list_item>
+            <paragraph>
+                b
+    <enumerated_list enumtype="upperroman" prefix="" suffix=".">
+        <list_item>
+            <paragraph>
+                a
+        <list_item>
+            <paragraph>
+                b
+.

--- a/tests/test_renderers/fixtures/myst-config.txt
+++ b/tests/test_renderers/fixtures/myst-config.txt
@@ -341,6 +341,25 @@ a
 <string>:1: (WARNING/2) Invalid 'align' attribute value: 'other' [myst.attribute]
 .
 
+[attr_block] --myst-enable-extensions=attrs_block
+.
+{#myid1 .class1 .class2}
+{#myid2 .class3}
+My paragraph
+
+{attribution="Chris Sewell"}
+> Hallo
+.
+<document source="<string>">
+    <paragraph classes="class1 class2 class3" ids="myid2" names="myid2">
+        My paragraph
+    <block_quote>
+        <paragraph>
+            Hallo
+        <attribution>
+            Chris Sewell
+.
+
 [inv_link] --myst-enable-extensions=inv_link
 .
 <inv:#index>

--- a/tests/test_renderers/test_fixtures_docutils.py
+++ b/tests/test_renderers/test_fixtures_docutils.py
@@ -32,6 +32,7 @@ def test_syntax_elements(file_params, monkeypatch):
 
     # in docutils 0.18 footnote ids have changed
     outcome = doctree.pformat().replace('"footnote-reference-1"', '"id1"')
+    outcome = outcome.replace(' language=""', "")
     file_params.assert_expected(outcome, rstrip_lines=True)
 
 

--- a/tests/test_renderers/test_fixtures_sphinx.py
+++ b/tests/test_renderers/test_fixtures_sphinx.py
@@ -124,3 +124,15 @@ def test_definition_lists(file_params, sphinx_doctree_no_tr: CreateDoctree):
     )
     result = sphinx_doctree_no_tr(file_params.content, "index.md")
     file_params.assert_expected(result.pformat("index"), rstrip_lines=True)
+
+
+@pytest.mark.param_file(FIXTURE_PATH / "attributes.md")
+def test_attributes(file_params, sphinx_doctree_no_tr: CreateDoctree):
+    sphinx_doctree_no_tr.set_conf(
+        {
+            "extensions": ["myst_parser"],
+            "myst_enable_extensions": ["attrs_inline", "attrs_block"],
+        }
+    )
+    result = sphinx_doctree_no_tr(file_params.content, "index.md")
+    file_params.assert_expected(result.pformat("index"), rstrip_lines=True)

--- a/tests/test_sphinx/test_sphinx_builds/test_fieldlist_extension.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_fieldlist_extension.xml
@@ -2,7 +2,7 @@
     <section ids="test" names="test">
         <title>
             Test
-        <field_list classes="myst">
+        <field_list classes="myst field-list">
             <field>
                 <field_name>
                     field
@@ -29,7 +29,7 @@
             <desc_content>
                 <paragraph>
                     Send a message to a recipient
-                <field_list classes="myst">
+                <field_list classes="myst field-list">
                     <field>
                         <field_name>
                             Parameters

--- a/tox.ini
+++ b/tox.ini
@@ -32,6 +32,8 @@ extras =
 whitelist_externals =
     rm
     echo
+passenv =
+    TERM
 commands =
     clean: rm -rf docs/_build/{posargs:html}
     sphinx-build -nW --keep-going -b {posargs:html} docs/ docs/_build/{posargs:html}


### PR DESCRIPTION
By adding `"attrs_block"` to `myst_enable_extensions` (in the sphinx `conf.py`), you can enable parsing of inline attributes after certain inline syntaxes. This is adapted from [djot block attributes](https://htmlpreview.github.io/?https://github.com/jgm/djot/blob/master/doc/syntax.html#block-attributes)