### PR TITLE
👌 IMPROVE: Allow setting {#id} on headings

### DIFF
--- a/myst_parser/cli.py
+++ b/myst_parser/cli.py
@@ -2,6 +2,8 @@ import argparse
 import sys
 
 from markdown_it.renderer import RendererHTML
+from markdown_it.rules_core import StateCore
+from mdit_py_plugins.anchors import anchors_plugin
 
 from myst_parser.config.main import MdParserConfig
 from myst_parser.parsers.mdit import create_md_parser
@@ -28,9 +30,10 @@ def print_anchors(args=None):
         "-l", "--level", type=int, default=2, help="Maximum heading level."
     )
     args = arg_parser.parse_args(args)
-    parser = create_md_parser(MdParserConfig(heading_anchors=args.level), RendererHTML)
+    parser = create_md_parser(MdParserConfig(), RendererHTML)
+    parser.use(anchors_plugin, max_level=args.level)
 
-    def _filter_plugin(state):
+    def _filter_plugin(state: StateCore) -> None:
         state.tokens = [
             t
             for t in state.tokens

--- a/myst_parser/config/main.py
+++ b/myst_parser/config/main.py
@@ -267,10 +267,10 @@ class MdParserConfig:
         },
     )
 
-    heading_anchors: Optional[int] = dc.field(
-        default=None,
+    heading_anchors: int = dc.field(
+        default=0,
         metadata={
-            "validator": optional(in_([1, 2, 3, 4, 5, 6, 7])),
+            "validator": optional(in_([0, 1, 2, 3, 4, 5, 6, 7])),
             "help": "Heading level depth to assign HTML anchors",
         },
     )

--- a/myst_parser/parsers/mdit.py
+++ b/myst_parser/parsers/mdit.py
@@ -8,7 +8,6 @@ from typing import Callable
 from markdown_it import MarkdownIt
 from markdown_it.renderer import RendererProtocol
 from mdit_py_plugins.amsmath import amsmath_plugin
-from mdit_py_plugins.anchors import anchors_plugin
 from mdit_py_plugins.attrs import attrs_block_plugin, attrs_plugin
 from mdit_py_plugins.colon_fence import colon_fence_plugin
 from mdit_py_plugins.deflist import deflist_plugin
@@ -113,12 +112,6 @@ def create_md_parser(
         md.use(attrs_plugin, after=("image",))
     if "attrs_block" in config.enable_extensions:
         md.use(attrs_block_plugin)
-    if config.heading_anchors is not None:
-        md.use(
-            anchors_plugin,
-            max_level=config.heading_anchors,
-            slug_func=config.heading_slug_func,
-        )
     for name in config.disable_syntax:
         md.disable(name, True)
 

--- a/myst_parser/warnings_.py
+++ b/myst_parser/warnings_.py
@@ -51,8 +51,8 @@ class MystWarnings(Enum):
     """A legacy domain found, which does not support `resolve_any_xref`."""
 
     # extensions
-    ANCHOR_DUPE = "anchor_dupe"
-    """Duplicate heading anchors generated in same document."""
+    HEADING_SLUG = "heading_slug"
+    """An error occured computing a heading slug."""
     STRIKETHROUGH = "strikethrough"
     """Strikethrough warning, since only implemented in HTML."""
     HTML_PARSE = "html"

--- a/tests/test_renderers/fixtures/myst-config.txt
+++ b/tests/test_renderers/fixtures/myst-config.txt
@@ -433,16 +433,38 @@ My paragraph
 <string>:3: (WARNING/2) Multiple matches for '*:*:*:*index': key:std:label:genindex, key:std:label:modindex, key:std:label:py-modindex, ... [myst.iref_ambiguous]
 .
 
-[heading_slug_func] --myst-heading-anchors=1 --myst-heading-slug-func=myst_parser.config.main._test_slug_func
+[heading_slug_func] --myst-heading-anchors=2 --myst-heading-slug-func=myst_parser.config.main._test_slug_func
 .
 # title
 
+## title
+
+## title a b c
+
+## title *nested syntax*
+
+### other
+
 [reversed](#eltit)
 .
-<document ids="title" names="title" slug="eltit" source="<string>" title="title">
+<document dupnames="title" ids="title" slug="eltit" source="<string>" title="title">
     <title>
         title
-    <paragraph>
-        <reference id_link="True" refid="title">
-            reversed
+    <section dupnames="title" ids="title-1" slug="eltit-1">
+        <title>
+            title
+    <section ids="title-a-b-c" names="title\ a\ b\ c" slug="c b a eltit">
+        <title>
+            title a b c
+    <section ids="title-nested-syntax" names="title\ nested\ syntax" slug="xatnys detsen eltit">
+        <title>
+            title
+            <emphasis>
+                nested syntax
+        <section ids="other" names="other">
+            <title>
+                other
+            <paragraph>
+                <reference id_link="True" refid="title">
+                    reversed
 .

--- a/tests/test_renderers/test_myst_config.py
+++ b/tests/test_renderers/test_myst_config.py
@@ -19,6 +19,8 @@ def test_cmdline(file_params: ParamTestData):
     """The description is parsed as a docutils commandline"""
     if "url_schemes_list" in file_params.title and __version_info__ < (0, 18):
         pytest.skip("problematic node ids changed in docutils 0.18")
+    if "heading_slug_func" in file_params.title and __version_info__ < (0, 18):
+        pytest.skip("dupnames ids changed in docutils 0.18")
     pub = Publisher(parser=Parser())
     option_parser = pub.setup_option_parser()
     try:


### PR DESCRIPTION
For use with the `attrs_block` extension.
This just moves around the logic for implicit heading anchors a bit (without changing anything user facing), to allow distinguishing between explicit and implicit heading ids.