### PR TITLE
👌 Enhance `[](#id)` references

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 90%
+        target: 89%
         threshold: 0.5%
     patch:
       default:

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -248,36 +248,14 @@ class DocutilsRenderer(RendererProtocol):
     def _render_finalise(self) -> None:
         """Finalise the render of the document."""
 
-        # attempt to replace id_link references with internal links
-        for refnode in findall(self.document)(nodes.reference):
-            if not refnode.get("id_link"):
-                continue
-            target = refnode["refuri"][1:]
-            if target in self._slug_to_section:
-                section_node = self._slug_to_section[target]
-                refnode["refid"] = section_node["ids"][0]
-
-                if not refnode.children:
-                    implicit_text = clean_astext(section_node[0])
-                    refnode += nodes.inline(
-                        implicit_text, implicit_text, classes=["std", "std-ref"]
-                    )
-            else:
-                self.create_warning(
-                    f"local id not found: {refnode['refuri']!r}",
-                    MystWarnings.XREF_MISSING,
-                    line=refnode.line,
-                    append_to=refnode,
-                )
-                refnode["refid"] = target
-            del refnode["refuri"]
-
-        if self._slug_to_section and self.sphinx_env:
-            # save for later reference resolution
-            self.sphinx_env.metadata[self.sphinx_env.docname]["myst_slugs"] = {
-                slug: (snode["ids"][0], clean_astext(snode[0]))
-                for slug, snode in self._slug_to_section.items()
-            }
+        # save for later reference resolution
+        slugs = {
+            slug: (snode.line, snode["ids"][0], clean_astext(snode[0]))
+            for slug, snode in self._slug_to_section.items()
+        }
+        self.document.myst_slugs = slugs
+        if slugs and self.sphinx_env:
+            self.sphinx_env.metadata[self.sphinx_env.docname]["myst_slugs"] = slugs
 
         # log warnings for duplicate reference definitions
         # "duplicate_refs": [{"href": "ijk", "label": "B", "map": [4, 5], "title": ""}],
@@ -795,7 +773,7 @@ class DocutilsRenderer(RendererProtocol):
             token.attrs.get("toc", None) == "false"
             or self.md_env.get("match_titles", None) is False
         ):
-            if self.md_env.get("match_titles", None) is False:
+            if token.attrs.get("toc", None) != "false":
                 # this can occur if a nested parse is performed by a directive
                 # (such as an admonition) which contains a header.
                 # this would break the document structure
@@ -984,8 +962,14 @@ class DocutilsRenderer(RendererProtocol):
         self.copy_attributes(
             token, ref_node, ("class", "id", "reftitle"), aliases={"title": "reftitle"}
         )
-        with self.current_node_context(ref_node, append=True):
-            self.render_children(token)
+        self.current_node.append(ref_node)
+        if token.info != "auto" and not (
+            len(token.children) == 1
+            and token.children[0].type == "text"
+            and token.children[0].content in ("...", "…")
+        ):
+            with self.current_node_context(ref_node):
+                self.render_children(token)
 
     def render_internal_link(self, token: SyntaxTreeNode) -> None:
         """Render link token `[text](link "title")`,

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -963,11 +963,7 @@ class DocutilsRenderer(RendererProtocol):
             token, ref_node, ("class", "id", "reftitle"), aliases={"title": "reftitle"}
         )
         self.current_node.append(ref_node)
-        if token.info != "auto" and not (
-            len(token.children) == 1
-            and token.children[0].type == "text"
-            and token.children[0].content in ("...", "…")
-        ):
+        if token.info != "auto" and not is_ellipsis(token):
             with self.current_node_context(ref_node):
                 self.render_children(token)
 
@@ -1008,7 +1004,9 @@ class DocutilsRenderer(RendererProtocol):
         href = self.md.normalizeLinkText(cast(str, token.attrGet("href") or ""))
 
         # note if the link had explicit text or not (autolinks are always implicit)
-        explicit = False if token.info == "auto" else bool(token.children)
+        explicit = (
+            (token.info != "auto") and bool(token.children) and not is_ellipsis(token)
+        )
 
         # split the href up into parts
         uri_parts = urlparse(href)
@@ -1881,3 +1879,12 @@ def compute_unique_slug(
         slug = f"{slug}-{i}"
         i += 1
     return slug
+
+
+def is_ellipsis(token: SyntaxTreeNode) -> bool:
+    """Check if a token content only contains an ellipsis."""
+    return (
+        len(token.children) == 1
+        and token.children[0].type == "text"
+        and token.children[0].content in ("...", "…")
+    )

--- a/myst_parser/mdit_to_docutils/sphinx_.py
+++ b/myst_parser/mdit_to_docutils/sphinx_.py
@@ -16,7 +16,7 @@ from sphinx.ext.intersphinx import InventoryAdapter
 from sphinx.util import logging
 
 from myst_parser import inventory
-from myst_parser.mdit_to_docutils.base import DocutilsRenderer
+from myst_parser.mdit_to_docutils.base import DocutilsRenderer, is_ellipsis
 
 LOGGER = logging.getLogger(__name__)
 
@@ -46,11 +46,7 @@ class SphinxRenderer(DocutilsRenderer):
             destination = os.path.relpath(
                 os.path.join(include_dir, os.path.normpath(destination)), source_dir
             )
-        explicit = len(token.children or []) > 0 and not (
-            len(token.children) == 1
-            and token.children[0].type == "text"
-            and token.children[0].content in ("...", "…")
-        )
+        explicit = len(token.children or []) > 0 and not is_ellipsis(token)
         kwargs = {
             "refdoc": self.sphinx_env.docname,
             "reftype": "myst",

--- a/myst_parser/mdit_to_docutils/transforms.py
+++ b/myst_parser/mdit_to_docutils/transforms.py
@@ -1,0 +1,145 @@
+"""Directives that can be applied to both Sphinx and docutils."""
+from __future__ import annotations
+
+import typing as t
+
+from docutils import nodes
+from docutils.transforms import Transform
+
+from myst_parser._compat import findall
+from myst_parser.mdit_to_docutils.base import clean_astext
+from myst_parser.warnings_ import MystWarnings, create_warning
+
+
+class ResolveAnchorIds(Transform):
+    """Directive for resolving `[name](#id)` type links."""
+
+    default_priority = 879  # this is the same as Sphinx's StandardDomain.process_doc
+
+    def apply(self, **kwargs: t.Any) -> None:
+        """Apply the transform."""
+        # gather the implicit heading slugs
+        # name -> (line, slug, title)
+        slugs: dict[str, tuple[int, str, str]] = getattr(
+            self.document, "myst_slugs", {}
+        )
+
+        # gather explicit references
+        # this follows the same logic as Sphinx's StandardDomain.process_doc
+        explicit: dict[str, tuple[str, None | str]] = {}
+        for name, is_explicit in self.document.nametypes.items():
+            if not is_explicit:
+                continue
+            labelid = self.document.nameids[name]
+            if labelid is None:
+                continue
+            if labelid is None:
+                continue
+            node = self.document.ids[labelid]
+            if isinstance(node, nodes.target) and "refid" in node:
+                # indirect hyperlink targets
+                node = self.document.ids.get(node["refid"])
+                labelid = node["names"][0]
+            if (
+                node.tagname == "footnote"
+                or "refuri" in node
+                or node.tagname.startswith("desc_")
+            ):
+                # ignore footnote labels, labels automatically generated from a
+                # link and object descriptions
+                continue
+
+            implicit_title = None
+            if node.tagname == "rubric":
+                implicit_title = clean_astext(node)
+            if implicit_title is None:
+                # handle sections and and other captioned elements
+                for subnode in node:
+                    if isinstance(subnode, (nodes.caption, nodes.title)):
+                        implicit_title = clean_astext(subnode)
+                        break
+            if implicit_title is None:
+                # handle definition lists and field lists
+                if (
+                    isinstance(node, (nodes.definition_list, nodes.field_list))
+                    and node.children
+                ):
+                    node = node[0]
+                if (
+                    isinstance(node, (nodes.field, nodes.definition_list_item))
+                    and node.children
+                ):
+                    node = node[0]
+                if isinstance(node, (nodes.term, nodes.field_name)):
+                    implicit_title = clean_astext(node)
+
+            explicit[name] = (labelid, implicit_title)
+
+        for refnode in findall(self.document)(nodes.reference):
+            if not refnode.get("id_link"):
+                continue
+
+            target = refnode["refuri"][1:]
+            del refnode["refuri"]
+
+            # search explicit first
+            if target in explicit:
+                ref_id, implicit_title = explicit[target]
+                refnode["refid"] = ref_id
+                if not refnode.children and implicit_title:
+                    refnode += nodes.inline(
+                        implicit_title, implicit_title, classes=["std", "std-ref"]
+                    )
+                elif not refnode.children:
+                    refnode += nodes.inline(
+                        "#" + target, "#" + target, classes=["std", "std-ref"]
+                    )
+                continue
+
+            # now search implicit
+            if target in slugs:
+                _, sect_id, implicit_title = slugs[target]
+                refnode["refid"] = sect_id
+                if not refnode.children and implicit_title:
+                    refnode += nodes.inline(
+                        implicit_title, implicit_title, classes=["std", "std-ref"]
+                    )
+                continue
+
+            # if still not found, and using sphinx, then create a pending_xref
+            if hasattr(self.document.settings, "env"):
+                from sphinx import addnodes
+
+                pending = addnodes.pending_xref(
+                    refdoc=self.document.settings.env.docname,
+                    refdomain=None,
+                    reftype="myst",
+                    reftarget=target,
+                    refwarn=True,
+                    refexplicit=bool(refnode.children),
+                )
+                inner_node = nodes.inline(
+                    "", "", classes=["xref", "myst"] + refnode["classes"]
+                )
+                for attr in ("ids", "names", "dupnames"):
+                    inner_node[attr] = refnode[attr]
+                inner_node += refnode.children
+                pending += inner_node
+                refnode.parent.replace(refnode, pending)
+                continue
+
+            # if still not found, and using docutils, then create a warning
+            # and simply output as a url
+
+            create_warning(
+                self.document,
+                f"'myst' reference target not found: {target!r}",
+                MystWarnings.XREF_MISSING,
+                line=refnode.line,
+                append_to=refnode,
+            )
+            refnode["refid"] = target
+            if not refnode.children:
+                refnode += nodes.inline(
+                    "#" + target, "#" + target, classes=["std", "std-ref"]
+                )

--- a/myst_parser/parsers/docutils_.py
+++ b/myst_parser/parsers/docutils_.py
@@ -26,6 +26,7 @@ from myst_parser.config.main import (
     read_topmatter,
 )
 from myst_parser.mdit_to_docutils.base import DocutilsRenderer
+from myst_parser.mdit_to_docutils.transforms import ResolveAnchorIds
 from myst_parser.parsers.mdit import create_md_parser
 from myst_parser.warnings_ import MystWarnings, create_warning
 
@@ -246,6 +247,9 @@ class Parser(RstParser):
     config_section = "myst parser"
     config_section_dependencies = ("parsers",)
     translate_section_name = None
+
+    def get_transforms(self):
+        return super().get_transforms() + [ResolveAnchorIds]
 
     def parse(self, inputstring: str, document: nodes.document) -> None:
         """Parse source text.

--- a/myst_parser/parsers/sphinx_.py
+++ b/myst_parser/parsers/sphinx_.py
@@ -13,6 +13,7 @@ from myst_parser.config.main import (
     read_topmatter,
 )
 from myst_parser.mdit_to_docutils.sphinx_ import SphinxRenderer
+from myst_parser.mdit_to_docutils.transforms import ResolveAnchorIds
 from myst_parser.parsers.mdit import create_md_parser
 from myst_parser.warnings_ import create_warning
 
@@ -42,6 +43,9 @@ class MystParser(SphinxParser):
     config_section = "myst parser"
     config_section_dependencies = ("parsers",)
     translate_section_name = None
+
+    def get_transforms(self):
+        return super().get_transforms() + [ResolveAnchorIds]
 
     def parse(self, inputstring: str, document: nodes.document) -> None:
         """Parse source text.

--- a/tests/test_renderers/fixtures/docutil_link_resolution.md
+++ b/tests/test_renderers/fixtures/docutil_link_resolution.md
@@ -1,0 +1,181 @@
+[external] 
+.
+[alt2](https://www.google.com)
+[](https://www.google.com)
+<https://www.google.com>
+.
+<document source="<src>/index.md">
+    <paragraph>
+        <reference refuri="https://www.google.com">
+            alt2
+
+        <reference refuri="https://www.google.com">
+
+        <reference refuri="https://www.google.com">
+            https://www.google.com
+.
+
+[missing]
+.
+[](#test)
+[...](#test)
+[explicit](#test)
+.
+<document source="<src>/index.md">
+    <paragraph>
+        <reference id_link="True" refid="test">
+            <system_message level="2" line="1" source="<src>/index.md" type="WARNING">
+                <paragraph>
+                    'myst' reference target not found: 'test' [myst.xref_missing]
+
+        <reference id_link="True" refid="test">
+            <system_message level="2" line="1" source="<src>/index.md" type="WARNING">
+                <paragraph>
+                    'myst' reference target not found: 'test' [myst.xref_missing]
+
+        <reference id_link="True" refid="test">
+            explicit
+            <system_message level="2" line="1" source="<src>/index.md" type="WARNING">
+                <paragraph>
+                    'myst' reference target not found: 'test' [myst.xref_missing]
+
+
+<src>/index.md:1: (WARNING/2) 'myst' reference target not found: 'test' [myst.xref_missing]
+<src>/index.md:1: (WARNING/2) 'myst' reference target not found: 'test' [myst.xref_missing]
+<src>/index.md:1: (WARNING/2) 'myst' reference target not found: 'test' [myst.xref_missing]
+.
+
+[implicit_anchor] --myst-heading-anchors=1
+.
+# Title
+# Longer title with **nested** (syntax)
+## Non-anchor heading
+
+[](#title)
+[...](#longer-title-with-nested-syntax)
+[explicit](#title)
+.
+<document source="<src>/index.md">
+    <section ids="title" names="title" slug="title">
+        <title>
+            Title
+    <section ids="longer-title-with-nested-syntax" names="longer\ title\ with\ nested\ (syntax)" slug="longer-title-with-nested-syntax">
+        <title>
+            Longer title with
+            <strong>
+                nested
+             (syntax)
+        <section ids="non-anchor-heading" names="non-anchor\ heading">
+            <title>
+                Non-anchor heading
+            <paragraph>
+                <reference id_link="True" refid="title">
+                    <inline classes="std std-ref">
+                        Title
+
+                <reference id_link="True" refid="longer-title-with-nested-syntax">
+                    <inline classes="std std-ref">
+                        Longer title with nested (syntax)
+
+                <reference id_link="True" refid="title">
+                    explicit
+.
+
+[explicit-heading] 
+.
+(target)=
+# Test
+
+[](#target)
+[...](#target)
+[explicit](#target)
+.
+<document ids="test target" names="test target" source="<src>/index.md" title="Test">
+    <title>
+        Test
+    <target refid="target">
+    <paragraph>
+        <reference id_link="True" refid="target">
+            <inline classes="std std-ref">
+                Test
+
+        <reference id_link="True" refid="target">
+            <inline classes="std std-ref">
+                Test
+
+        <reference id_link="True" refid="target">
+            explicit
+.
+
+[explicit>implicit] --myst-heading-anchors=1
+.
+# Test
+
+(test)=
+## Other
+
+[](#test)
+.
+<document dupnames="test" ids="test" slug="test" source="<src>/index.md" title="Test">
+    <title>
+        Test
+    <subtitle ids="other test-1" names="other test">
+        Other
+    <system_message backrefs="test-1" level="1" line="3" source="<src>/index.md" type="INFO">
+        <paragraph>
+            Duplicate implicit target name: "test".
+    <target refid="test-1">
+    <paragraph>
+        <reference id_link="True" refid="test-1">
+            <inline classes="std std-ref">
+                Other
+.
+
+[ref-table] 
+.
+```{table} caption
+:name: table
+a  | b
+-- | --
+c  | d
+```
+
+[](#table)
+[...](#table)
+[explicit](#table)
+.
+<document source="<src>/index.md">
+    <table classes="colwidths-auto" ids="table" names="table">
+        <title>
+            caption
+        <tgroup cols="2">
+            <colspec colwidth="50">
+            <colspec colwidth="50">
+            <thead>
+                <row>
+                    <entry>
+                        <paragraph>
+                            a
+                    <entry>
+                        <paragraph>
+                            b
+            <tbody>
+                <row>
+                    <entry>
+                        <paragraph>
+                            c
+                    <entry>
+                        <paragraph>
+                            d
+    <paragraph>
+        <reference id_link="True" refid="table">
+            <inline classes="std std-ref">
+                caption
+
+        <reference id_link="True" refid="table">
+            <inline classes="std std-ref">
+                caption
+
+        <reference id_link="True" refid="table">
+            explicit
+.

--- a/tests/test_renderers/fixtures/docutil_syntax_elements.md
+++ b/tests/test_renderers/fixtures/docutil_syntax_elements.md
@@ -311,42 +311,6 @@ Target with whitespace:
     <target ids="target-with-space" names="target\ with\ space">
 .
 
-Referencing:
-.
-(target)=
-
-Title
-=====
-
-[alt1](target)
-
-[](target2)
-
-[alt2](https://www.google.com)
-
-[alt3](#target3)
-.
-<document source="notset">
-    <target ids="target" names="target">
-    <section ids="title" names="title">
-        <title>
-            Title
-        <paragraph>
-            <reference refname="target">
-                alt1
-        <paragraph>
-            <reference refname="target2">
-        <paragraph>
-            <reference refuri="https://www.google.com">
-                alt2
-        <paragraph>
-            <reference id_link="True" refid="target3">
-                alt3
-                <system_message level="2" line="12" source="notset" type="WARNING">
-                    <paragraph>
-                        local id not found: '#target3' [myst.xref_missing]
-.
-
 Comments:
 .
 line 1

--- a/tests/test_renderers/fixtures/sphinx_link_resolution.md
+++ b/tests/test_renderers/fixtures/sphinx_link_resolution.md
@@ -1,0 +1,209 @@
+[external] 
+.
+[alt2](https://www.google.com)
+[](https://www.google.com)
+<https://www.google.com>
+.
+<document source="<src>/index.md">
+    <paragraph>
+        <reference refuri="https://www.google.com">
+            alt2
+
+        <reference refuri="https://www.google.com">
+
+        <reference refuri="https://www.google.com">
+            https://www.google.com
+.
+
+[missing] 
+.
+[](#test)
+[...](#test)
+[explicit](#test)
+.
+<document source="<src>/index.md">
+    <paragraph>
+        <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="test" reftype="myst" refwarn="True">
+            <inline classes="xref myst">
+
+        <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="test" reftype="myst" refwarn="True">
+            <inline classes="xref myst">
+
+        <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="test" reftype="myst" refwarn="True">
+            <inline classes="xref myst">
+                explicit
+.
+
+[implicit_anchor] {"myst_heading_anchors": 1}
+.
+# Title
+# Longer title with **nested** (syntax)
+## Non-anchor heading
+
+[](#title)
+[...](#longer-title-with-nested-syntax)
+[explicit](#title)
+.
+<document source="<src>/index.md">
+    <section ids="title" names="title" slug="title">
+        <title>
+            Title
+    <section ids="longer-title-with-nested-syntax" names="longer\ title\ with\ nested\ (syntax)" slug="longer-title-with-nested-syntax">
+        <title>
+            Longer title with
+            <strong>
+                nested
+             (syntax)
+        <section ids="non-anchor-heading" names="non-anchor\ heading">
+            <title>
+                Non-anchor heading
+            <paragraph>
+                <reference id_link="True" refid="title">
+                    <inline classes="std std-ref">
+                        Title
+
+                <reference id_link="True" refid="longer-title-with-nested-syntax">
+                    <inline classes="std std-ref">
+                        Longer title with nested (syntax)
+
+                <reference id_link="True" refid="title">
+                    explicit
+.
+
+[explicit-heading] 
+.
+(target)=
+# Test
+
+[](#target)
+[...](#target)
+[explicit](#target)
+.
+<document source="<src>/index.md">
+    <target refid="target">
+    <section ids="test target" names="test target">
+        <title>
+            Test
+        <paragraph>
+            <reference id_link="True" refid="target">
+                <inline classes="std std-ref">
+                    Test
+
+            <reference id_link="True" refid="target">
+                <inline classes="std std-ref">
+                    Test
+
+            <reference id_link="True" refid="target">
+                explicit
+.
+
+[explicit>implicit] {"myst_heading_anchors": 1}
+.
+# Test
+
+(test)=
+## Other
+
+[](#test)
+.
+<document source="<src>/index.md">
+    <section dupnames="test" ids="test" slug="test">
+        <title>
+            Test
+        <target refid="id1">
+        <section ids="other id1" names="other test">
+            <title>
+                Other
+            <paragraph>
+                <reference id_link="True" refid="id1">
+                    <inline classes="std std-ref">
+                        Other
+.
+
+[ref-table] 
+.
+```{table} caption
+:name: table
+a  | b
+-- | --
+c  | d
+```
+
+[](#table)
+[...](#table)
+[explicit](#table)
+.
+<document source="<src>/index.md">
+    <table classes="colwidths-auto" ids="table" names="table">
+        <title>
+            caption
+        <tgroup cols="2">
+            <colspec colwidth="50">
+            <colspec colwidth="50">
+            <thead>
+                <row>
+                    <entry>
+                        <paragraph>
+                            a
+                    <entry>
+                        <paragraph>
+                            b
+            <tbody>
+                <row>
+                    <entry>
+                        <paragraph>
+                            c
+                    <entry>
+                        <paragraph>
+                            d
+    <paragraph>
+        <reference id_link="True" refid="table">
+            <inline classes="std std-ref">
+                caption
+
+        <reference id_link="True" refid="table">
+            <inline classes="std std-ref">
+                caption
+
+        <reference id_link="True" refid="table">
+            explicit
+.
+
+[external-file] 
+.
+[](test.txt)
+[...](./test.txt)
+[relative to source dir](/test.txt)
+.
+<document source="<src>/index.md">
+    <paragraph>
+        <download_reference filename="dd18bf3a8e0a2a3e53e2661c7fb53534/test.txt" refdoc="index" refdomain="True" refexplicit="False" reftarget="test.txt" reftype="myst" refwarn="False">
+            <inline classes="xref download myst">
+                test.txt
+
+        <download_reference filename="dd18bf3a8e0a2a3e53e2661c7fb53534/test.txt" refdoc="index" refdomain="True" refexplicit="False" reftarget="./test.txt" reftype="myst" refwarn="False">
+            <inline classes="xref download myst">
+
+        <download_reference filename="dd18bf3a8e0a2a3e53e2661c7fb53534/test.txt" refdoc="index" refdomain="True" refexplicit="True" reftarget="/test.txt" reftype="myst" refwarn="False">
+            <inline classes="xref download myst">
+                relative to source dir
+.
+
+[source-file]
+.
+[](other.rst)
+[...](./other.rst)
+[relative to source dir](/other.rst)
+.
+<document source="<src>/index.md">
+    <paragraph>
+        <pending_xref refdoc="index" refdomain="doc" refexplicit="False" reftarget="other" reftargetid="True" reftype="myst">
+            <inline classes="xref myst">
+
+        <pending_xref refdoc="index" refdomain="doc" refexplicit="False" reftarget="other" reftargetid="True" reftype="myst">
+            <inline classes="xref myst">
+
+        <pending_xref refdoc="index" refdomain="doc" refexplicit="True" reftarget="other" reftargetid="True" reftype="myst">
+            <inline classes="xref myst">
+                relative to source dir
+.

--- a/tests/test_renderers/fixtures/sphinx_syntax_elements.md
+++ b/tests/test_renderers/fixtures/sphinx_syntax_elements.md
@@ -311,44 +311,6 @@ Target with whitespace:
     <target ids="target-with-space" names="target\ with\ space">
 .
 
-Referencing:
-.
-(target)=
-
-Title
-=====
-
-[alt1](target)
-
-[](target2)
-
-[alt2](https://www.google.com)
-
-[alt3](#title)
-.
-<document source="<src>/index.md">
-    <target ids="target" names="target">
-    <section ids="title" names="title">
-        <title>
-            Title
-        <paragraph>
-            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="target" reftype="myst" refwarn="True">
-                <inline classes="xref myst">
-                    alt1
-        <paragraph>
-            <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="target2" reftype="myst" refwarn="True">
-                <inline classes="xref myst">
-        <paragraph>
-            <reference refuri="https://www.google.com">
-                alt2
-        <paragraph>
-            <reference id_link="True" refid="title">
-                alt3
-                <system_message level="2" line="12" source="<src>/index.md" type="WARNING">
-                    <paragraph>
-                        local id not found: '#title' [myst.xref_missing]
-.
-
 Comments:
 .
 line 1

--- a/tests/test_renderers/test_fixtures_docutils.py
+++ b/tests/test_renderers/test_fixtures_docutils.py
@@ -2,11 +2,15 @@
 
 Note, the output AST is before any transforms are applied.
 """
+from __future__ import annotations
+
 import shlex
 from io import StringIO
 from pathlib import Path
+from typing import Any
 
 import pytest
+from docutils import __version_info__
 from docutils.core import Publisher, publish_doctree
 
 from myst_parser.parsers.docutils_ import Parser
@@ -33,6 +37,26 @@ def test_syntax_elements(file_params, monkeypatch):
     # in docutils 0.18 footnote ids have changed
     outcome = doctree.pformat().replace('"footnote-reference-1"', '"id1"')
     outcome = outcome.replace(' language=""', "")
+    file_params.assert_expected(outcome, rstrip_lines=True)
+
+
+@pytest.mark.param_file(FIXTURE_PATH / "docutil_link_resolution.md")
+def test_link_resolution(file_params):
+    """Test that Markdown links resolve to the correct target, or give the correct warning."""
+    if "explicit>implicit" in file_params.title and __version_info__ < (0, 18):
+        pytest.skip("ids changed in docutils 0.18+")
+    settings = settings_from_cmdline(file_params.description)
+    report_stream = StringIO()
+    settings["warning_stream"] = report_stream
+    doctree = publish_doctree(
+        file_params.content,
+        source_path="<src>/index.md",
+        parser=Parser(),
+        settings_overrides=settings,
+    )
+    outcome = doctree.pformat()
+    if report_stream.getvalue().strip():
+        outcome += "\n\n" + report_stream.getvalue().strip()
     file_params.assert_expected(outcome, rstrip_lines=True)
 
 
@@ -88,16 +112,7 @@ def test_docutils_directives(file_params, monkeypatch):
 @pytest.mark.param_file(FIXTURE_PATH / "docutil_syntax_extensions.txt")
 def test_syntax_extensions(file_params):
     """The description is parsed as a docutils commandline"""
-    pub = Publisher(parser=Parser())
-    option_parser = pub.setup_option_parser()
-    try:
-        settings = option_parser.parse_args(
-            shlex.split(file_params.description)
-        ).__dict__
-    except Exception as err:
-        raise AssertionError(
-            f"Failed to parse commandline: {file_params.description}\n{err}"
-        )
+    settings = settings_from_cmdline(file_params.description)
     report_stream = StringIO()
     settings["warning_stream"] = report_stream
     doctree = publish_doctree(
@@ -106,3 +121,16 @@ def test_syntax_extensions(file_params):
         settings_overrides=settings,
     )
     file_params.assert_expected(doctree.pformat(), rstrip_lines=True)
+
+
+def settings_from_cmdline(cmdline: str | None) -> dict[str, Any]:
+    """Parse a docutils commandline into a settings dictionary"""
+    if cmdline is None or not cmdline.strip():
+        return {}
+    pub = Publisher(parser=Parser())
+    option_parser = pub.setup_option_parser()
+    try:
+        settings = option_parser.parse_args(shlex.split(cmdline)).__dict__
+    except Exception as err:
+        raise AssertionError(f"Failed to parse commandline: {cmdline}\n{err}")
+    return settings

--- a/tests/test_renderers/test_fixtures_sphinx.py
+++ b/tests/test_renderers/test_fixtures_sphinx.py
@@ -4,6 +4,7 @@ Note, the output AST is before any transforms are applied.
 """
 from __future__ import annotations
 
+import json
 import re
 import sys
 from pathlib import Path
@@ -21,6 +22,32 @@ def test_syntax_elements(file_params, sphinx_doctree_no_tr: CreateDoctree):
     sphinx_doctree_no_tr.set_conf({"extensions": ["myst_parser"]})
     result = sphinx_doctree_no_tr(file_params.content, "index.md")
     file_params.assert_expected(result.pformat("index"), rstrip_lines=True)
+
+
+@pytest.mark.param_file(FIXTURE_PATH / "sphinx_link_resolution.md")
+def test_link_resolution(file_params, sphinx_doctree: CreateDoctree):
+    sphinx_doctree.set_conf(
+        {"extensions": ["myst_parser"], **settings_from_json(file_params.description)}
+    )
+    sphinx_doctree.srcdir.joinpath("test.txt").touch()
+    sphinx_doctree.srcdir.joinpath("other.rst").write_text(":orphan:\n\nTest\n====")
+    result = sphinx_doctree(file_params.content, "index.md")
+    outcome = result.pformat("index")
+    if result.warnings.strip():
+        outcome += "\n\n" + result.warnings.strip()
+    file_params.assert_expected(outcome, rstrip_lines=True)
+
+
+def settings_from_json(string: str | None):
+    """Parse the description for a JSON settings string."""
+    if string is None or not string.strip():
+        return {}
+    try:
+        data = json.loads(string)
+        assert isinstance(data, dict), "settings must be a JSON object"
+    except Exception as err:
+        raise AssertionError(f"Failed to parse JSON settings: {string}\n{err}")
+    return data
 
 
 @pytest.mark.param_file(FIXTURE_PATH / "tables.md")

--- a/tests/test_renderers/test_myst_refs.py
+++ b/tests/test_renderers/test_myst_refs.py
@@ -35,4 +35,9 @@ def test_parse(
         assert not result.warnings
 
     doctree["source"] = "root/index.md"
-    file_regression.check(doctree.pformat(), basename=test_name, extension=".xml")
+    outcome = doctree.pformat()
+    if result.warnings.strip():
+        outcome += "\n\n" + result.warnings.strip().replace("[91m", "").replace(
+            "[39;49;00m", ""
+        )
+    file_regression.check(outcome, basename=test_name, extension=".xml")

--- a/tests/test_renderers/test_myst_refs/duplicate.xml
+++ b/tests/test_renderers/test_myst_refs/duplicate.xml
@@ -7,3 +7,6 @@
             <reference internal="True" refid="index">
                 <inline classes="std std-ref">
                     Title
+
+
+<src>/index.md:3: WARNING: more than one target found for 'myst' cross-reference index: could be :std:ref:`Title` or :std:doc:`Title` [myst.xref_ambiguous]

--- a/tests/test_renderers/test_myst_refs/missing.xml
+++ b/tests/test_renderers/test_myst_refs/missing.xml
@@ -1,3 +1,8 @@
 <document source="root/index.md">
     <paragraph>
-        <inline classes="xref myst">
+        <reference refid="ref">
+            <literal classes="xref myst">
+                ref
+
+
+<src>/index.md:1: WARNING: 'myst' cross-reference target not found: 'ref' [myst.xref_missing]


### PR DESCRIPTION
This PR moves myst-parser in the direction of https://github.com/executablebooks/myst-enhancement-proposals/pull/10, in a relatively back compatible manner, and in a way that supports both docutils and sphinx.

It expands the capability of `[](#id)` to more than just linking to heading slugs, with the order of specificity being:

1. If it matches a local (to that document) "explicit" `std:ref` target, then link to that and stop
   - Note, currently only `std:ref` domain/type are supported, e.g. not `math` etc. That's more difficult and can come later
2. If it matches a local (to that document) "implicit" heading slug, then link to that and stop
3. If using docutils (i.e. single-page) build, then stop here and emit a `myst.xref_missing` warning
4. If using sphinx then create a `pending_xref` node, and hand-off to sphinx's "any" resolver, which takes effect once all documents have been read:
    - This first tries to resolve against a local (to the project) reference and, if matching, stops
    - Otherwise also try to match against any intersphinx reference
    - Otherwise emit a ~~`myst.ref`~~ `myst.xref_missing`  warning
 
If the text is explicit, e.g. `[text](#id)`, that text is used, otherwise a determination of implicit text is attempted, e.g. based on the section title or figure caption.