### PR TITLE
📚 DOCS: fix tip CSS

### DIFF
--- a/docs/_static/local.css
+++ b/docs/_static/local.css
@@ -1,18 +1,24 @@
 /** Add a counter before subsections **/
-h1:not(.tippy-header) {
+h1 {
     counter-reset: subsection;
     text-decoration: underline;
 }
-h2:not(.tippy-header) {
+h2 {
     counter-reset: subsubsection;
 }
-h2:not(.tippy-header)::before {
+h2::before {
     counter-increment: subsection;
     content: counter(subsection) ". ";
 }
-h3:not(.tippy-header)::before {
+.tippy-box h2::before {
+    content: unset;
+}
+h3::before {
     counter-increment: subsubsection;
     content: counter(subsection) "." counter(subsubsection) ". ";
+}
+.tippy-box h3::before {
+    content: unset;
 }
 
 /** MyST examples */


### PR DESCRIPTION
Minor fix to stop the hover tips getting heading numbers