### PR TITLE
🐛 FIX encoded URL ID references

### DIFF
--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -969,7 +969,7 @@ class DocutilsRenderer(RendererProtocol):
         ref_node = nodes.reference()
         self.add_line_and_source_path(ref_node, token)
         ref_node["id_link"] = True
-        ref_node["refuri"] = token.attrGet("href") or ""
+        ref_node["refuri"] = self.md.normalizeLinkText(str(token.attrGet("href") or ""))
         self.copy_attributes(
             token, ref_node, ("class", "id", "reftitle"), aliases={"title": "reftitle"}
         )

--- a/myst_parser/mdit_to_docutils/transforms.py
+++ b/myst_parser/mdit_to_docutils/transforms.py
@@ -5,6 +5,7 @@ import typing as t
 
 from docutils import nodes
 from docutils.transforms import Transform
+from markdown_it.common.normalize_url import normalizeLink
 
 from myst_parser._compat import findall
 from myst_parser.mdit_to_docutils.base import clean_astext
@@ -138,7 +139,7 @@ class ResolveAnchorIds(Transform):
                 line=refnode.line,
                 append_to=refnode,
             )
-            refnode["refid"] = target
+            refnode["refid"] = normalizeLink(target)
             if not refnode.children:
                 refnode += nodes.inline(
                     "#" + target, "#" + target, classes=["std", "std-ref"]

--- a/tests/test_renderers/fixtures/docutil_link_resolution.md
+++ b/tests/test_renderers/fixtures/docutil_link_resolution.md
@@ -15,11 +15,12 @@
             https://www.google.com
 .
 
-[missing]
+[missing] 
 .
 [](#test)
 [...](#test)
 [explicit](#test)
+[](<#name with spaces>)
 .
 <document source="<src>/index.md">
     <paragraph>
@@ -39,10 +40,16 @@
                 <paragraph>
                     'myst' reference target not found: 'test' [myst.xref_missing]
 
+        <reference id_link="True" refid="name%20with%20spaces">
+            <system_message level="2" line="1" source="<src>/index.md" type="WARNING">
+                <paragraph>
+                    'myst' reference target not found: 'name with spaces' [myst.xref_missing]
+
 
 <src>/index.md:1: (WARNING/2) 'myst' reference target not found: 'test' [myst.xref_missing]
 <src>/index.md:1: (WARNING/2) 'myst' reference target not found: 'test' [myst.xref_missing]
 <src>/index.md:1: (WARNING/2) 'myst' reference target not found: 'test' [myst.xref_missing]
+<src>/index.md:1: (WARNING/2) 'myst' reference target not found: 'name with spaces' [myst.xref_missing]
 .
 
 [implicit_anchor] --myst-heading-anchors=1
@@ -129,6 +136,23 @@
         <reference id_link="True" refid="test-1">
             <inline classes="std std-ref">
                 Other
+.
+
+[id-with-spaces] 
+.
+(name with spaces)=
+Paragraph
+
+[](<#name with spaces>)
+.
+<document source="<src>/index.md">
+    <target refid="name-with-spaces">
+    <paragraph ids="name-with-spaces" names="name\ with\ spaces">
+        Paragraph
+    <paragraph>
+        <reference id_link="True" refid="name-with-spaces">
+            <inline classes="std std-ref">
+                #name with spaces
 .
 
 [ref-table] 

--- a/tests/test_renderers/fixtures/sphinx_link_resolution.md
+++ b/tests/test_renderers/fixtures/sphinx_link_resolution.md
@@ -78,6 +78,7 @@
 [](#target)
 [...](#target)
 [explicit](#target)
+[](<#name with spaces>)
 .
 <document source="<src>/index.md">
     <target refid="target">
@@ -95,6 +96,9 @@
 
             <reference id_link="True" refid="target">
                 explicit
+
+            <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="name with spaces" reftype="myst" refwarn="True">
+                <inline classes="xref myst">
 .
 
 [explicit>implicit] {"myst_heading_anchors": 1}
@@ -118,6 +122,23 @@
                 <reference id_link="True" refid="id1">
                     <inline classes="std std-ref">
                         Other
+.
+
+[id-with-spaces] 
+.
+(name with spaces)=
+Paragraph
+
+[](<#name with spaces>)
+.
+<document source="<src>/index.md">
+    <target refid="name-with-spaces">
+    <paragraph ids="name-with-spaces" names="name\ with\ spaces">
+        Paragraph
+    <paragraph>
+        <reference id_link="True" refid="name-with-spaces">
+            <inline classes="std std-ref">
+                #name with spaces
 .
 
 [ref-table] 
@@ -189,7 +210,7 @@ c  | d
                 relative to source dir
 .
 
-[source-file]
+[source-file] 
 .
 [](other.rst)
 [...](./other.rst)


### PR DESCRIPTION
For example `<#name with spaces>` will be encoded as `#name%20with%20spaces`, so we need to decode before resolving the reference.