### PR TITLE
👌 Improve `[](#target)` resolution warnings

### DIFF
--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -1065,8 +1065,7 @@ class DocutilsRenderer(RendererProtocol):
 
         # create the docutils node
         match = matches[0]
-        ref_node = nodes.reference()
-        ref_node["internal"] = False
+        ref_node = nodes.reference("", "", internal=False)
         ref_node["inv_match"] = inventory.filter_string(
             match.inv, match.domain, match.otype, match.name
         )

--- a/myst_parser/mdit_to_docutils/sphinx_.py
+++ b/myst_parser/mdit_to_docutils/sphinx_.py
@@ -83,13 +83,13 @@ class SphinxRenderer(DocutilsRenderer):
                 text = ""
             else:
                 wrap_node = addnodes.download_reference(
-                    refdomain=None, reftarget=path_dest, refwarn=False, **kwargs
+                    refdomain=None, reftarget=path_dest, **kwargs
                 )
                 classes = ["xref", "download", "myst"]
                 text = destination if not token.children else ""
         else:
             wrap_node = addnodes.pending_xref(
-                refdomain=None, reftarget=destination, refwarn=True, **kwargs
+                refdomain=None, reftarget=destination, **kwargs
             )
             classes = ["xref", "myst"]
             text = ""

--- a/myst_parser/mdit_to_docutils/transforms.py
+++ b/myst_parser/mdit_to_docutils/transforms.py
@@ -116,7 +116,6 @@ class ResolveAnchorIds(Transform):
                     refdomain=None,
                     reftype="myst",
                     reftarget=target,
-                    refwarn=True,
                     refexplicit=bool(refnode.children),
                 )
                 inner_node = nodes.inline(

--- a/tests/test_renderers/fixtures/sphinx_link_resolution.md
+++ b/tests/test_renderers/fixtures/sphinx_link_resolution.md
@@ -23,13 +23,13 @@
 .
 <document source="<src>/index.md">
     <paragraph>
-        <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="test" reftype="myst" refwarn="True">
+        <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="test" reftype="myst">
             <inline classes="xref myst">
 
-        <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="test" reftype="myst" refwarn="True">
+        <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="test" reftype="myst">
             <inline classes="xref myst">
 
-        <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="test" reftype="myst" refwarn="True">
+        <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="test" reftype="myst">
             <inline classes="xref myst">
                 explicit
 .
@@ -97,7 +97,7 @@
             <reference id_link="True" refid="target">
                 explicit
 
-            <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="name with spaces" reftype="myst" refwarn="True">
+            <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="name with spaces" reftype="myst">
                 <inline classes="xref myst">
 .
 
@@ -198,14 +198,14 @@ c  | d
 .
 <document source="<src>/index.md">
     <paragraph>
-        <download_reference filename="dd18bf3a8e0a2a3e53e2661c7fb53534/test.txt" refdoc="index" refdomain="True" refexplicit="False" reftarget="test.txt" reftype="myst" refwarn="False">
+        <download_reference filename="dd18bf3a8e0a2a3e53e2661c7fb53534/test.txt" refdoc="index" refdomain="True" refexplicit="False" reftarget="test.txt" reftype="myst">
             <inline classes="xref download myst">
                 test.txt
 
-        <download_reference filename="dd18bf3a8e0a2a3e53e2661c7fb53534/test.txt" refdoc="index" refdomain="True" refexplicit="False" reftarget="./test.txt" reftype="myst" refwarn="False">
+        <download_reference filename="dd18bf3a8e0a2a3e53e2661c7fb53534/test.txt" refdoc="index" refdomain="True" refexplicit="False" reftarget="./test.txt" reftype="myst">
             <inline classes="xref download myst">
 
-        <download_reference filename="dd18bf3a8e0a2a3e53e2661c7fb53534/test.txt" refdoc="index" refdomain="True" refexplicit="True" reftarget="/test.txt" reftype="myst" refwarn="False">
+        <download_reference filename="dd18bf3a8e0a2a3e53e2661c7fb53534/test.txt" refdoc="index" refdomain="True" refexplicit="True" reftarget="/test.txt" reftype="myst">
             <inline classes="xref download myst">
                 relative to source dir
 .

--- a/tests/test_renderers/fixtures/sphinx_syntax_elements.md
+++ b/tests/test_renderers/fixtures/sphinx_syntax_elements.md
@@ -400,7 +400,7 @@ Link Definition in directive:
 <document source="<src>/index.md">
     <note>
         <paragraph>
-            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="link" reftype="myst" refwarn="True">
+            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="link" reftype="myst">
                 <inline classes="xref myst">
                     a
 .
@@ -424,7 +424,7 @@ Link Definition in nested directives:
     <note>
     <note>
         <paragraph>
-            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="link" reftype="myst" refwarn="True">
+            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="link" reftype="myst">
                 <inline classes="xref myst">
                     ref1
 
@@ -769,6 +769,6 @@ a = 1
         <literal_block language="::python" xml:space="preserve">
             a = 1
         <paragraph>
-            <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="target" reftype="myst" refwarn="True">
+            <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="target" reftype="myst">
                 <inline classes="xref myst">
 .

--- a/tests/test_sphinx/sourcedirs/references/conf.py
+++ b/tests/test_sphinx/sourcedirs/references/conf.py
@@ -1,3 +1,9 @@
-extensions = ["myst_parser"]
+extensions = ["myst_parser", "sphinx.ext.intersphinx"]
 exclude_patterns = ["_build"]
 myst_heading_anchors = 2
+
+intersphinx_mapping = {
+    "inter": ("https://example.com", "objects.inv"),
+}
+
+nitpick_ignore = [("myst", "unknown")]

--- a/tests/test_sphinx/sourcedirs/references/index.md
+++ b/tests/test_sphinx/sourcedirs/references/index.md
@@ -52,3 +52,18 @@ subfolder/other2.md
 [](other.md#title-anchors)
 
 [](subfolder/other2.md#title-anchors)
+
+
+# Intersphinx via `#`
+
+Unknown [](#unknown)
+
+Unknown explicit [**hallo**](#unknown)
+
+Known no title [](#paragraph-target)
+
+Known explicit [**hallo**](#paragraph-target)
+
+Known with title [](#title-target)
+
+Ambiguous [](#duplicate)

--- a/tests/test_sphinx/sourcedirs/references/objects.inv
+++ b/tests/test_sphinx/sourcedirs/references/objects.inv
@@ -1,0 +1,6 @@
+# Sphinx inventory version 2
+# Project: Example
+# Version: 0.0.1
+# The remainder of this file is compressed using zlib.
+xÚ…A
+Â0E÷9E@·İö.„‚^`L†$¶¡¢½½M§ÕÔîÂŸ÷ÿüŒécğeŠª1}@y”¾6ø<8ªÂ5µ—J˜7Û‘)Ü1HuZÃ‰²XOJ-êÄÉszŠf'É›§€b\ş%+j0|áŞœ¡ÛBtŠ µHË®¢6v”¹¦ÎWu­v¹‘5ö\y^‚E1—yx4v?‹1ªªfT	JÙşßí–¤.

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -90,8 +90,12 @@ def test_references(
     app.build()
 
     assert "build succeeded" in status.getvalue()  # Build succeeded
-    warnings = warning.getvalue().strip()
-    assert warnings == ""
+    # should be one warning:
+    # WARNING: Multiple matches found for 'duplicate':
+    # inter:py:module:duplicate, inter:std:label:duplicate [myst.iref_ambiguous]
+    warnings = warning.getvalue().strip().splitlines()
+    assert len(warnings) == 1
+    assert "[myst.iref_ambiguous]" in warnings[0]
 
     try:
         get_sphinx_app_doctree(app, docname="index", regress=True)

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.xml
@@ -35,7 +35,7 @@
         <admonition classes="admonition-title-with-link-target2">
             <title>
                 Title with 
-                <pending_xref refdoc="content" refdomain="True" refexplicit="True" reftarget="target2" reftype="myst" refwarn="True">
+                <pending_xref refdoc="content" refdomain="True" refexplicit="True" reftarget="target2" reftype="myst">
                     <inline classes="xref myst">
                         link
             <paragraph>

--- a/tests/test_sphinx/test_sphinx_builds/test_references.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.html
@@ -190,6 +190,73 @@
      </p>
     </section>
    </section>
+   <section class="tex2jax_ignore mathjax_ignore" id="intersphinx-via">
+    <h1>
+     Intersphinx via
+     <code class="docutils literal notranslate">
+      <span class="pre">
+       #
+      </span>
+     </code>
+     <a class="headerlink" href="#intersphinx-via" title="Permalink to this heading">
+      ¶
+     </a>
+    </h1>
+    <p>
+     Unknown
+     <a class="reference internal" href="#unknown">
+      <code class="xref myst docutils literal notranslate">
+       <span class="pre">
+        unknown
+       </span>
+      </code>
+     </a>
+    </p>
+    <p>
+     Unknown explicit
+     <a class="reference internal" href="#unknown">
+      <span class="xref myst">
+       <strong>
+        hallo
+       </strong>
+      </span>
+     </a>
+    </p>
+    <p>
+     Known no title
+     <a class="reference external" href="https://example.com/index.html#paragraph-target" title="Example 0.0.1">
+      <span class="iref myst">
+       paragraph-target
+      </span>
+     </a>
+    </p>
+    <p>
+     Known explicit
+     <a class="reference external" href="https://example.com/index.html#paragraph-target" title="Example 0.0.1">
+      <span class="xref myst">
+       <strong>
+        hallo
+       </strong>
+      </span>
+     </a>
+    </p>
+    <p>
+     Known with title
+     <a class="reference external" href="https://example.com/index.html#title-target" title="Example 0.0.1">
+      <span class="iref myst">
+       Title
+      </span>
+     </a>
+    </p>
+    <p>
+     Ambiguous
+     <a class="reference external" href="https://example.com/index.html#module-duplicate" title="Example 0.0.1">
+      <span class="iref myst">
+       duplicate
+      </span>
+     </a>
+    </p>
+   </section>
   </div>
  </div>
 </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_references.resolved.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.resolved.xml
@@ -47,13 +47,13 @@
                     <emphasis>
                         syntax
         <paragraph>
-            <download_reference filename="ab0d698fdd2b6a81c34b5ed380fe6f61/file_link.txt" refdoc="index" refdomain="True" refexplicit="True" reftarget="file_link.txt" reftype="myst" refwarn="False">
+            <download_reference filename="ab0d698fdd2b6a81c34b5ed380fe6f61/file_link.txt" refdoc="index" refdomain="True" refexplicit="True" reftarget="file_link.txt" reftype="myst">
                 <inline classes="xref download myst">
                     download 
                     <strong>
                         link
         <paragraph>
-            <download_reference filename="1952147a8403903cb78cecf56f049085/file_link2.txt" refdoc="index" refdomain="True" refexplicit="False" reftarget="subfolder/file_link2.txt" reftype="myst" refwarn="False">
+            <download_reference filename="1952147a8403903cb78cecf56f049085/file_link2.txt" refdoc="index" refdomain="True" refexplicit="False" reftarget="subfolder/file_link2.txt" reftype="myst">
                 <inline classes="xref download myst">
                     subfolder/file_link2.txt
         <target refid="insidecodeblock">
@@ -113,3 +113,40 @@
                 <reference internal="True" refuri="subfolder/other2.html#title-anchors">
                     <inline classes="std std-ref">
                         Title anchors
+    <section classes="tex2jax_ignore mathjax_ignore" ids="intersphinx-via" names="intersphinx\ via\ #" slug="intersphinx-via-">
+        <title>
+            Intersphinx via 
+            <literal>
+                #
+        <paragraph>
+            Unknown 
+            <reference refid="unknown">
+                <literal classes="xref myst">
+                    unknown
+        <paragraph>
+            Unknown explicit 
+            <reference refid="unknown">
+                <inline classes="xref myst">
+                    <strong>
+                        hallo
+        <paragraph>
+            Known no title 
+            <reference internal="False" reftitle="Example 0.0.1" refuri="https://example.com/index.html#paragraph-target">
+                <inline classes="iref myst">
+                    paragraph-target
+        <paragraph>
+            Known explicit 
+            <reference internal="False" reftitle="Example 0.0.1" refuri="https://example.com/index.html#paragraph-target">
+                <inline classes="xref myst">
+                    <strong>
+                        hallo
+        <paragraph>
+            Known with title 
+            <reference internal="False" reftitle="Example 0.0.1" refuri="https://example.com/index.html#title-target">
+                <inline classes="iref myst">
+                    Title
+        <paragraph>
+            Ambiguous 
+            <reference internal="False" reftitle="Example 0.0.1" refuri="https://example.com/index.html#module-duplicate">
+                <inline classes="iref myst">
+                    duplicate

--- a/tests/test_sphinx/test_sphinx_builds/test_references.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.xml
@@ -19,14 +19,14 @@
                 <emphasis>
                     syntax
         <paragraph>
-            <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="title" reftype="myst" refwarn="True">
+            <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="title" reftype="myst">
                 <inline classes="xref myst">
         <paragraph>
-            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="title" reftype="myst" refwarn="True">
+            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="title" reftype="myst">
                 <inline classes="xref myst">
                     plain text
         <paragraph>
-            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="title" reftype="myst" refwarn="True">
+            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="title" reftype="myst">
                 <inline classes="xref myst">
                     nested 
                     <emphasis>
@@ -45,13 +45,13 @@
                     <emphasis>
                         syntax
         <paragraph>
-            <download_reference filename="ab0d698fdd2b6a81c34b5ed380fe6f61/file_link.txt" refdoc="index" refdomain="True" refexplicit="True" reftarget="file_link.txt" reftype="myst" refwarn="False">
+            <download_reference filename="ab0d698fdd2b6a81c34b5ed380fe6f61/file_link.txt" refdoc="index" refdomain="True" refexplicit="True" reftarget="file_link.txt" reftype="myst">
                 <inline classes="xref download myst">
                     download 
                     <strong>
                         link
         <paragraph>
-            <download_reference filename="1952147a8403903cb78cecf56f049085/file_link2.txt" refdoc="index" refdomain="True" refexplicit="False" reftarget="subfolder/file_link2.txt" reftype="myst" refwarn="False">
+            <download_reference filename="1952147a8403903cb78cecf56f049085/file_link2.txt" refdoc="index" refdomain="True" refexplicit="False" reftarget="subfolder/file_link2.txt" reftype="myst">
                 <inline classes="xref download myst">
                     subfolder/file_link2.txt
         <target refid="insidecodeblock">
@@ -68,7 +68,7 @@
                 insidecodeblock
         <paragraph>
             I am outside the 
-            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="insidecodeblock" reftype="myst" refwarn="True">
+            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="insidecodeblock" reftype="myst">
                 <inline classes="xref myst">
                     fence
         <section ids="title-anchors" names="title\ anchors" slug="title-anchors">
@@ -94,3 +94,36 @@
             <paragraph>
                 <pending_xref refdoc="index" refdomain="doc" refexplicit="False" reftarget="subfolder/other2" reftargetid="title-anchors" reftype="myst">
                     <inline classes="xref myst">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="intersphinx-via" names="intersphinx\ via\ #" slug="intersphinx-via-">
+        <title>
+            Intersphinx via 
+            <literal>
+                #
+        <paragraph>
+            Unknown 
+            <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="unknown" reftype="myst">
+                <inline classes="xref myst">
+        <paragraph>
+            Unknown explicit 
+            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="unknown" reftype="myst">
+                <inline classes="xref myst">
+                    <strong>
+                        hallo
+        <paragraph>
+            Known no title 
+            <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="paragraph-target" reftype="myst">
+                <inline classes="xref myst">
+        <paragraph>
+            Known explicit 
+            <pending_xref refdoc="index" refdomain="True" refexplicit="True" reftarget="paragraph-target" reftype="myst">
+                <inline classes="xref myst">
+                    <strong>
+                        hallo
+        <paragraph>
+            Known with title 
+            <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="title-target" reftype="myst">
+                <inline classes="xref myst">
+        <paragraph>
+            Ambiguous 
+            <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="duplicate" reftype="myst">
+                <inline classes="xref myst">


### PR DESCRIPTION
Previously, if `[](#target)` matched nothing locally, but multiple items in intersphinx inventories, then no warning would be logged, and the first match silently used.
Resolution of intersphinx now proceeds (if no local matches found) the same as for `[](inv:#target)`, such that a `myst.iref_ambiguous` warning is emitted in this case (the first match is then still used).

Warnings coming from resolution of `[](#target)` can also now be "individually" turned off using https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-nitpick_ignore, e.g. `nitpick_ignore = [("myst", "target")]`