### PR TITLE
👌 Improve: Apply implicit targets to nested headings

### DIFF
--- a/tests/test_renderers/fixtures/docutil_syntax_elements.md
+++ b/tests/test_renderers/fixtures/docutil_syntax_elements.md
@@ -117,7 +117,7 @@ Nested heading
 .
 <document source="notset">
     <block_quote>
-        <rubric level="1">
+        <rubric ids="heading" level="1" names="heading">
             heading
 .
 

--- a/tests/test_renderers/fixtures/sphinx_syntax_elements.md
+++ b/tests/test_renderers/fixtures/sphinx_syntax_elements.md
@@ -117,7 +117,7 @@ Nested heading
 .
 <document source="<src>/index.md">
     <block_quote>
-        <rubric level="1">
+        <rubric ids="heading" level="1" names="heading">
             heading
 .
 


### PR DESCRIPTION
This commit builds on ac111ea6f58508b0987091595edfb33db1ee033f,
to allow for implicit heading slugs to be applied also to nested headings,
i.e. so they can be referenced in Markdown links