### PR TITLE
✨ New: add .glossary for attrs_block

### DIFF
--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -1529,8 +1529,21 @@ class DocutilsRenderer(RendererProtocol):
                             child.children[0].content if child.children else ""
                         )
                         self.add_line_and_source_path(term, child)
-                        with self.current_node_context(term, append=True):
+                        with self.current_node_context(term):
                             self.render_children(child)
+                        if "glossary" in node["classes"] and self.sphinx_env:
+                            from sphinx.domains.std import make_glossary_term
+
+                            term = make_glossary_term(
+                                self.sphinx_env,
+                                term.children,
+                                None,  # type: ignore
+                                term.source,
+                                term.line,
+                                node_id=None,  # type: ignore
+                                document=self.document,
+                            )
+                        self.current_node.append(term)
                 elif child.type == "dd":
                     if item is None:
                         error = self.reporter.error(

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -1518,6 +1518,7 @@ class DocutilsRenderer(RendererProtocol):
         node = nodes.definition_list(classes=["simple", "myst"])
         self.copy_attributes(token, node, ("class", "id"))
         self.add_line_and_source_path(node, token)
+        make_terms = ("glossary" in node["classes"]) and (self.sphinx_env is not None)
         with self.current_node_context(node, append=True):
             item = None
             for child in token.children or []:
@@ -1531,11 +1532,11 @@ class DocutilsRenderer(RendererProtocol):
                         self.add_line_and_source_path(term, child)
                         with self.current_node_context(term):
                             self.render_children(child)
-                        if "glossary" in node["classes"] and self.sphinx_env:
+                        if make_terms:
                             from sphinx.domains.std import make_glossary_term
 
                             term = make_glossary_term(
-                                self.sphinx_env,
+                                self.sphinx_env,  # type: ignore
                                 term.children,
                                 None,  # type: ignore
                                 term.source,

--- a/tests/test_renderers/fixtures/myst-config.txt
+++ b/tests/test_renderers/fixtures/myst-config.txt
@@ -341,7 +341,7 @@ a
 <string>:1: (WARNING/2) Invalid 'align' attribute value: 'other' [myst.attribute]
 .
 
-[attr_block] --myst-enable-extensions=attrs_block
+[attrs_block] --myst-enable-extensions=attrs_block
 .
 {#myid1 .class1 .class2}
 {#myid2 .class3}

--- a/tests/test_sphinx/sourcedirs/extended_syntaxes/conf.py
+++ b/tests/test_sphinx/sourcedirs/extended_syntaxes/conf.py
@@ -12,6 +12,8 @@ myst_enable_extensions = [
     "colon_fence",
     "linkify",
     "tasklist",
+    "attrs_inline",
+    "attrs_block",
 ]
 myst_number_code_blocks = ["typescript"]
 myst_html_meta = {

--- a/tests/test_sphinx/sourcedirs/extended_syntaxes/index.md
+++ b/tests/test_sphinx/sourcedirs/extended_syntaxes/index.md
@@ -39,6 +39,15 @@ Term 3
 
   : other
 
+{#myid1 .glossary}
+term
+:  definition
+
+other term
+:  other definition
+
+{term}`other term`
+
 :::{figure-md} target
 :class: other
 

--- a/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.html
@@ -103,6 +103,31 @@ b=2
       </p>
      </dd>
     </dl>
+    <dl class="simple myst glossary" id="myid1">
+     <dt id="term-term">
+      term
+     </dt>
+     <dd>
+      <p>
+       definition
+      </p>
+     </dd>
+     <dt id="term-other-term">
+      other term
+     </dt>
+     <dd>
+      <p>
+       other definition
+      </p>
+     </dd>
+    </dl>
+    <p>
+     <a class="reference internal" href="#term-other-term">
+      <span class="xref std std-term">
+       other term
+      </span>
+     </a>
+    </p>
     <figure class="other align-default" id="target">
      <img alt="fun-fish" src="_images/fun-fish.png"/>
      <figcaption>

--- a/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_extended_syntaxes.xml
@@ -61,6 +61,25 @@
                 <definition>
                     <paragraph>
                         other
+        <definition_list classes="simple myst glossary" ids="myid1" names="myid1">
+            <definition_list_item>
+                <term ids="term-term">
+                    term
+                    <index entries="('single',\ 'term',\ 'term-term',\ 'main',\ None)">
+                <definition>
+                    <paragraph>
+                        definition
+            <definition_list_item>
+                <term ids="term-other-term">
+                    other term
+                    <index entries="('single',\ 'other\ term',\ 'term-other-term',\ 'main',\ None)">
+                <definition>
+                    <paragraph>
+                        other definition
+        <paragraph>
+            <pending_xref refdoc="index" refdomain="std" refexplicit="False" reftarget="other term" reftype="term" refwarn="True">
+                <inline classes="xref std std-term">
+                    other term
         <figure classes="other" ids="target" names="target">
             <image alt="fun-fish" candidates="{'*': 'fun-fish.png'}" uri="fun-fish.png">
             <caption>


### PR DESCRIPTION
MyST follows http://johnmacfarlane.net/pandoc/README.html#definition-lists, to denote lists of term -> definition.

```markdown
Term 1
: Definition

Term 2
: Definition
```

It should be easy for users to turn one of these lists into a glossary,
where each term is uniquely referenceable across the entire project.
(note I don't think this should be "on by default", because there are many use cases where this is not desirable and would lead to many reference clashes, plus that would be breaking in myst-parser and so not really viable)

Sphinx has a [glossary directive](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-glossary), however, this hard-codes in the parsing of their definition lists to have a subtly different syntax to that above, with no `:`
(see https://github.com/sphinx-doc/sphinx/blob/30f347226fa4ccf49b3f7ef860fd962af5bdf4f0/sphinx/domains/std.py#L354)

````
:::{glossary}
Term 1
    Definition

Term 2
    Definition
:::
````

Therefore, I feel that it is not really ideal for MyST.

The easiest way to achieve this with the "correct" syntax, as implemented in this PR, is to "turn on" glossaries, when a particular attribute is assigned to the list, with the simplest being a `.glossary` class:

````
{.glossary}
Term 1
: Definition

Term 2
: Definition
````