### PR TITLE
📚 DOCS: Un-wrap announcement in <p>

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -159,7 +159,7 @@ html_theme_options = {
     "use_repository_button": True,
     "use_edit_page_button": True,
     "use_issues_button": True,
-    "announcement": "<p><b>v0.19</b> is now out! See the Changelog for details</p>",
+    "announcement": "<b>v0.19</b> is now out! See the Changelog for details",
 }
 # OpenGraph metadata
 ogp_site_url = "https://myst-parser.readthedocs.io/en/latest"


### PR DESCRIPTION
The announcement text at the top was having a base pydata theme color applied to it because it was wrapped in `<p>`, the simplest fix is just to un-wrap it for now, though this should probably be made more robust in the pydata theme as well.