### PR TITLE
📚 Fix the sphinx-design example

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -133,7 +133,7 @@ For example, let's install the [sphinx-design](https://github.com/executablebook
 First, install `sphinx-design`:
 
 ```shell
-pip install sphinxcontrib-mermaid
+pip install sphinx-design
 ```
 
 Next, add it to your list of extensions in `conf.py`:


### PR DESCRIPTION
Under the `## Extending Sphinx` heading, the text of the example discusses `sphinx-design`, but the pip install command was installing `sphinxcontrib.mermaid`. I see there is a commented-out example, below, which is related to mermaid, so perhaps this was missed in a copy/paste.