### PR TITLE
✨ NEW: Add `myst_fence_as_directive` config

### DIFF
--- a/myst_parser/config/main.py
+++ b/myst_parser/config/main.py
@@ -166,6 +166,14 @@ def _test_slug_func(text: str) -> str:
     return text[::-1]
 
 
+def check_fence_as_directive(
+    inst: "MdParserConfig", field: dc.Field, value: Any
+) -> None:
+    """Check that the extensions are a sequence of known strings"""
+    deep_iterable(instance_of(str), instance_of((list, tuple, set)))(inst, field, value)
+    setattr(inst, field.name, set(value))
+
+
 @dc.dataclass()
 class MdParserConfig:
     """Configuration options for the Markdown Parser.
@@ -247,6 +255,16 @@ class MdParserConfig:
             ),
             "help": "Sphinx domain names to search in for link references",
             "omit": ["docutils"],
+        },
+    )
+
+    fence_as_directive: Set[str] = dc.field(
+        default_factory=set,
+        metadata={
+            "validator": check_fence_as_directive,
+            "help": "Interpret a code fence as a directive, for certain language names. "
+            "This can be useful for fences like dot and mermaid, "
+            "and interoperability with other Markdown renderers.",
         },
     )
 

--- a/tests/test_renderers/fixtures/myst-config.txt
+++ b/tests/test_renderers/fixtures/myst-config.txt
@@ -360,7 +360,7 @@ My paragraph
             Chris Sewell
 .
 
-[inv_link] 
+[inv_link]
 .
 <inv:#index>
 [](inv:#index)
@@ -411,7 +411,7 @@ My paragraph
             Title
 .
 
-[inv_link_error] 
+[inv_link_error]
 .
 <inv:#other>
 

--- a/tests/test_renderers/fixtures/myst-config.txt
+++ b/tests/test_renderers/fixtures/myst-config.txt
@@ -360,7 +360,7 @@ My paragraph
             Chris Sewell
 .
 
-[inv_link]
+[inv_link] 
 .
 <inv:#index>
 [](inv:#index)
@@ -411,7 +411,7 @@ My paragraph
             Title
 .
 
-[inv_link_error]
+[inv_link_error] 
 .
 <inv:#other>
 
@@ -467,4 +467,32 @@ My paragraph
             <paragraph>
                 <reference id_link="True" refid="title">
                     reversed
+.
+
+[fence_as_directive] --myst-fence-as-directive=unknown,admonition --myst-enable-extensions=attrs_block
+.
+```unknown
+```
+
+{#myname .class1}
+{a=b}
+```admonition title
+content
+```
+.
+<document source="<string>">
+    <system_message level="2" line="1" source="<string>" type="WARNING">
+        <paragraph>
+            Unknown directive type: 'unknown' [myst.directive_unknown]
+    <system_message level="2" line="6" source="<string>" type="WARNING">
+        <paragraph>
+            'admonition': Unknown option keys: ['a'] (allowed: ['class', 'name']) [myst.directive_parse]
+    <admonition classes="class1" ids="myname" names="myname">
+        <title>
+            title
+        <paragraph>
+            content
+
+<string>:1: (WARNING/2) Unknown directive type: 'unknown' [myst.directive_unknown]
+<string>:6: (WARNING/2) 'admonition': Unknown option keys: ['a'] (allowed: ['class', 'name']) [myst.directive_parse]
 .


### PR DESCRIPTION
closes #366

Setting the following config, for example:

```python
extensions = ["myst_parser", "sphinxcontrib.mermaid"]
myst_fence_as_directive = ["mermaid"]
# optional to use https://sphinxcontrib-mermaid-demo.readthedocs.io/en/latest/#directive-options
myst_enable_extensions = ["attrs_block"]
```

allows for one to write

````markdown
{caption="My caption"}
{alt="HTML alt" align=center}
```mermaid
graph LR
a --> b
```
````

and have interoperable rendering with places like GitHub:

{caption="My caption"}
{alt="HTML alt" align=center}
```mermaid
graph LR
a --> b
```