### PR TITLE
👌 Improve default slug generation for heading anchors

### DIFF
--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -1974,7 +1974,7 @@ def default_slugify(title: str) -> str:
     - https://github.com/jch/html-pipeline/blob/master/lib/html/pipeline/toc_filter.rb
     - https://gist.github.com/asabaylus/3071099
     """
-    return _SLUGIFY_CLEAN_REGEX.sub("", title.strip().lower().replace(" ", "-"))
+    return _SLUGIFY_CLEAN_REGEX.sub("", title.lower().replace(" ", "-"))
 
 
 def compute_unique_slug(

--- a/tests/test_sphinx/sourcedirs/references/index.md
+++ b/tests/test_sphinx/sourcedirs/references/index.md
@@ -67,3 +67,7 @@ Known explicit [**hallo**](#paragraph-target)
 Known with title [](#title-target)
 
 Ambiguous [](#duplicate)
+
+# Image in title ![badge](https://shields.io/or/something.svg)
+
+[link up](#image-in-title-)

--- a/tests/test_sphinx/test_sphinx_builds/test_references.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.html
@@ -263,6 +263,20 @@
      </a>
     </p>
    </section>
+   <section class="tex2jax_ignore mathjax_ignore" id="image-in-title">
+    <h1>
+     Image in title
+     <img alt="badge" src="https://shields.io/or/something.svg"/>
+     <a class="headerlink" href="#image-in-title" title="Permalink to this heading">
+      ¶
+     </a>
+    </h1>
+    <p>
+     <a class="reference internal" href="#image-in-title">
+      link up
+     </a>
+    </p>
+   </section>
   </div>
  </div>
 </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_references.resolved.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.resolved.xml
@@ -1,6 +1,6 @@
 <document source="index.md">
     <target refid="title">
-    <section classes="tex2jax_ignore mathjax_ignore" ids="title-with-nested-a-1 title" names="title\ with\ nested\ a=1 title" slug="title-with-nested">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="title-with-nested-a-1 title" names="title\ with\ nested\ a=1 title" slug="title-with-nested-">
         <title>
             Title with 
             <strong>
@@ -150,3 +150,10 @@
             <reference internal="False" reftitle="Example 0.0.1" refuri="https://example.com/index.html#module-duplicate">
                 <literal classes="iref myst">
                     duplicate
+    <section classes="tex2jax_ignore mathjax_ignore" ids="image-in-title" names="image\ in\ title" slug="image-in-title-">
+        <title>
+            Image in title 
+            <image alt="badge" candidates="{'?': 'https://shields.io/or/something.svg'}" uri="https://shields.io/or/something.svg">
+        <paragraph>
+            <reference id_link="True" refid="image-in-title">
+                link up

--- a/tests/test_sphinx/test_sphinx_builds/test_references.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.xml
@@ -1,6 +1,6 @@
 <document source="index.md">
     <target refid="title">
-    <section classes="tex2jax_ignore mathjax_ignore" ids="title-with-nested-a-1 title" names="title\ with\ nested\ a=1 title" slug="title-with-nested">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="title-with-nested-a-1 title" names="title\ with\ nested\ a=1 title" slug="title-with-nested-">
         <title>
             Title with 
             <strong>
@@ -128,3 +128,10 @@
             Ambiguous 
             <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="duplicate" reftype="myst">
                 <inline classes="xref myst">
+    <section classes="tex2jax_ignore mathjax_ignore" ids="image-in-title" names="image\ in\ title" slug="image-in-title-">
+        <title>
+            Image in title 
+            <image alt="badge" candidates="{'?': 'https://shields.io/or/something.svg'}" uri="https://shields.io/or/something.svg">
+        <paragraph>
+            <reference id_link="True" refid="image-in-title">
+                link up


### PR DESCRIPTION
This can be easily tested by visiting the source markdown page on github:

https://github.com/Cimbali/MyST-Parser/blob/master/tests/test_sphinx/sourcedirs/references/index.md#image-in-title-

Fixes #752.

----

Note that for the `nested $a=1$` case I’ve updated the test to match the new behaviour, to allow improving matching github behaviour bit by bit.

Neither the old or new test match Github behaviour:
https://github.com/executablebooks/MyST-Parser/blob/master/tests/test_sphinx/sourcedirs/references/index.md#title-with-nested-a1

The issue seems to be math-to-text conversion (so the trailing `-` added by this PR is “more correct” even though not 100% there).