### PR TITLE
⬆️ UPGRADE: Drop Python 3.7

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
       - sphinx~=5.0
       - markdown-it-py>=1.0.0,<3.0.0
       - mdit-py-plugins~=0.3.4
+      - types-urllib3
       files: >
         (?x)^(
             myst_parser/.*py|

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,8 +71,6 @@ autodoc2_replace_annotations = [
     ("markdown_it.MarkdownIt", "markdown_it.main.MarkdownIt"),
 ]
 autodoc2_replace_bases = [
-    ("myst_parser._compat.Protocol", "typing.Protocol"),
-    ("myst_parser._compat.TypedDict", "typing.TypedDict"),
     ("sphinx.directives.SphinxDirective", "sphinx.util.docutils.SphinxDirective"),
 ]
 autodoc2_docstring_parser_regexes = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,8 +63,12 @@ intersphinx_mapping = {
 
 # -- Autodoc settings ---------------------------------------------------
 
-autodoc2_packages = ["../myst_parser"]
-autodoc2_exclude_files = ["_docs.py"]
+autodoc2_packages = [
+    {
+        "path": "../myst_parser",
+        "exclude_files": ["_docs.py"],
+    }
+]
 autodoc2_hidden_objects = ["dunder", "private", "inherited"]
 autodoc2_replace_annotations = [
     ("re.Pattern", "typing.Pattern"),

--- a/myst_parser/_compat.py
+++ b/myst_parser/_compat.py
@@ -1,19 +1,7 @@
 """Helpers for cross compatibility across dependency versions."""
-import sys
 from typing import Callable, Iterable
 
 from docutils.nodes import Element
-
-if sys.version_info >= (3, 8):
-    from typing import Literal, Protocol, TypedDict, get_args, get_origin
-else:
-    from typing_extensions import (  # noqa: F401
-        Literal,
-        Protocol,
-        TypedDict,
-        get_args,
-        get_origin,
-    )
 
 
 def findall(node: Element) -> Callable[..., Iterable[Element]]:

--- a/myst_parser/_docs.py
+++ b/myst_parser/_docs.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import io
-from typing import Sequence, Union
+from typing import Sequence, Union, get_args, get_origin
 
 from docutils import nodes
 from docutils.frontend import OptionParser
@@ -13,7 +13,6 @@ from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
 
 from myst_parser.parsers.docutils_ import to_html5_demo
-from ._compat import get_args, get_origin
 from .config.main import MdParserConfig
 from .parsers.docutils_ import Parser as DocutilsParser
 from .warnings_ import MystWarnings

--- a/myst_parser/config/dc_validators.py
+++ b/myst_parser/config/dc_validators.py
@@ -2,9 +2,7 @@
 from __future__ import annotations
 
 import dataclasses as dc
-from typing import Any, Sequence
-
-from myst_parser._compat import Protocol
+from typing import Any, Protocol, Sequence
 
 
 def validate_field(inst: Any, field: dc.Field, value: Any) -> None:

--- a/myst_parser/config/main.py
+++ b/myst_parser/config/main.py
@@ -12,10 +12,10 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    TypedDict,
     Union,
 )
 
-from myst_parser._compat import TypedDict
 from myst_parser.warnings_ import MystWarnings
 from .dc_validators import (
     deep_iterable,

--- a/myst_parser/inventory.py
+++ b/myst_parser/inventory.py
@@ -13,12 +13,10 @@ import json
 import re
 import zlib
 from dataclasses import asdict, dataclass
-from typing import IO, TYPE_CHECKING, Iterator
+from typing import IO, TYPE_CHECKING, Iterator, TypedDict
 from urllib.request import urlopen
 
 import yaml
-
-from ._compat import TypedDict
 
 if TYPE_CHECKING:
     # domain_type:object_type -> name -> (project, version, loc, text)

--- a/myst_parser/parsers/docutils_.py
+++ b/myst_parser/parsers/docutils_.py
@@ -6,11 +6,14 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Optional,
     Sequence,
     Set,
     Tuple,
     Union,
+    get_args,
+    get_origin,
 )
 
 import yaml
@@ -20,7 +23,6 @@ from docutils.frontend import filter_settings_spec
 from docutils.parsers.rst import Parser as RstParser
 from docutils.writers.html5_polyglot import HTMLTranslator, Writer
 
-from myst_parser._compat import Literal, get_args, get_origin
 from myst_parser.config.main import (
     MdParserConfig,
     TopmatterReadError,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,10 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -32,7 +32,7 @@ keywords = [
     "docutils",
     "sphinx",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "docutils>=0.15,<0.20",
     "jinja2", # required for substitutions, but let sphinx choose version
@@ -40,7 +40,6 @@ dependencies = [
     "mdit-py-plugins~=0.3.4",
     "pyyaml",
     "sphinx>=5,<7",
-    'typing-extensions; python_version < "3.8"',
 ]
 
 [project.urls]

--- a/tests/test_docutils.py
+++ b/tests/test_docutils.py
@@ -1,11 +1,11 @@
 import io
 from dataclasses import dataclass, field, fields
 from textwrap import dedent
+from typing import Literal
 
 import pytest
 from docutils import VersionInfo, __version_info__
 
-from myst_parser._compat import Literal
 from myst_parser.mdit_to_docutils.base import make_document
 from myst_parser.parsers.docutils_ import (
     Parser,
@@ -23,7 +23,7 @@ from myst_parser.parsers.docutils_ import (
 def test_attr_to_optparse_option():
     @dataclass
     class Config:
-        name: Literal["a"] = field(default="default")  # noqa: F821
+        name: Literal["a"] = field(default="default")
 
     output = attr_to_optparse_option(fields(Config)[0], "default")
     assert len(output) == 3


### PR DESCRIPTION
Python 3.7 is now end-of-life