### PR TITLE
⬆️ UPGRADE: markdown-it-py v3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,9 +47,9 @@ repos:
       args: [--config-file=pyproject.toml]
       additional_dependencies:
       - sphinx~=5.0
-      - markdown-it-py>=1.0.0,<3.0.0
-      - mdit-py-plugins~=0.3.4
       - types-urllib3
+      - markdown-it-py~=3.0
+      - mdit-py-plugins~=0.4.0
       files: >
         (?x)^(
             myst_parser/.*py|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ requires-python = ">=3.8"
 dependencies = [
     "docutils>=0.15,<0.20",
     "jinja2", # required for substitutions, but let sphinx choose version
-    "markdown-it-py>=1.0.0,<3.0.0",
-    "mdit-py-plugins~=0.3.4",
+    "markdown-it-py~=3.0",
+    "mdit-py-plugins~=0.4",
     "pyyaml",
     "sphinx>=5,<7",
 ]

--- a/tests/test_renderers/fixtures/docutil_syntax_extensions.txt
+++ b/tests/test_renderers/fixtures/docutil_syntax_extensions.txt
@@ -107,7 +107,7 @@ content
 .
 <document source="<string>">
     <paragraph>
-        © © ® ® ™ ™ § § ± …
+        © © ® ® ™ ™ (p) (P) ± …
 .
 
 [strikethrough] --myst-enable-extensions=strikethrough


### PR DESCRIPTION
See https://github.com/executablebooks/markdown-it-py/releases/tag/v3.0.0 and https://github.com/executablebooks/mdit-py-plugins/releases/tag/v0.4.0