### PR TITLE
📚 Add linkify dependency to contributing docs.

### DIFF
--- a/docs/develop/contributing.md
+++ b/docs/develop/contributing.md
@@ -16,7 +16,7 @@ To install `myst-parser` for development, take the following steps:
 git clone https://github.com/executablebooks/MyST-Parser
 cd MyST-Parser
 git checkout master
-pip install -e .[code_style,testing,rtd]
+pip install -e .[code_style,linkify,testing,rtd]
 ```
 
 ## Code Style


### PR DESCRIPTION
Fix executablebooks/MyST-Parser#791