### PR TITLE
Enable :widths: option in table directives.

### DIFF
--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -1349,7 +1349,6 @@ class DocutilsRenderer(RendererProtocol):
 
         # top-level element
         table = nodes.table()
-        table["classes"] += ["colwidths-auto"]
         self.copy_attributes(token, table, ("class", "id"))
         self.add_line_and_source_path(table, token)
         self.current_node.append(table)

--- a/tests/test_renderers/fixtures/docutil_link_resolution.md
+++ b/tests/test_renderers/fixtures/docutil_link_resolution.md
@@ -169,7 +169,7 @@ c  | d
 [explicit](#table)
 .
 <document source="<src>/index.md">
-    <table classes="colwidths-auto" ids="table" names="table">
+    <table ids="table" names="table">
         <title>
             caption
         <tgroup cols="2">

--- a/tests/test_renderers/fixtures/sphinx_directives.md
+++ b/tests/test_renderers/fixtures/sphinx_directives.md
@@ -236,6 +236,43 @@ table (`sphinx.directives.patches.RSTTable`):
 ```
 .
 <document source="<src>/index.md">
+    <table ids="name" names="name">
+        <title>
+            <emphasis>
+                title
+        <tgroup cols="2">
+            <colspec colwidth="50">
+            <colspec colwidth="50">
+            <thead>
+                <row>
+                    <entry>
+                        <paragraph>
+                            a
+                    <entry>
+                        <paragraph>
+                            b
+            <tbody>
+                <row>
+                    <entry>
+                        <paragraph>
+                            1
+                    <entry>
+                        <paragraph>
+                            2
+.
+
+table widths auto (`sphinx.directives.patches.RSTTable`):
+.
+```{table} *title*
+:name: name
+:widths: auto
+
+| a | b |
+|---|---|
+| 1 | 2 |
+```
+.
+<document source="<src>/index.md">
     <table classes="colwidths-auto" ids="name" names="name">
         <title>
             <emphasis>
@@ -243,6 +280,80 @@ table (`sphinx.directives.patches.RSTTable`):
         <tgroup cols="2">
             <colspec colwidth="50">
             <colspec colwidth="50">
+            <thead>
+                <row>
+                    <entry>
+                        <paragraph>
+                            a
+                    <entry>
+                        <paragraph>
+                            b
+            <tbody>
+                <row>
+                    <entry>
+                        <paragraph>
+                            1
+                    <entry>
+                        <paragraph>
+                            2
+.
+
+table widths grid (`sphinx.directives.patches.RSTTable`):
+.
+```{table} *title*
+:name: name
+:widths: grid
+
+| a | b |
+|---|---|
+| 1 | 2 |
+```
+.
+<document source="<src>/index.md">
+    <table classes="colwidths-given" ids="name" names="name">
+        <title>
+            <emphasis>
+                title
+        <tgroup cols="2">
+            <colspec colwidth="50">
+            <colspec colwidth="50">
+            <thead>
+                <row>
+                    <entry>
+                        <paragraph>
+                            a
+                    <entry>
+                        <paragraph>
+                            b
+            <tbody>
+                <row>
+                    <entry>
+                        <paragraph>
+                            1
+                    <entry>
+                        <paragraph>
+                            2
+.
+
+table widths given (`sphinx.directives.patches.RSTTable`):
+.
+```{table} *title*
+:name: name
+:widths: 1 2
+
+| a | b |
+|---|---|
+| 1 | 2 |
+```
+.
+<document source="<src>/index.md">
+    <table classes="colwidths-given" ids="name" names="name">
+        <title>
+            <emphasis>
+                title
+        <tgroup cols="2">
+            <colspec colwidth="1">
+            <colspec colwidth="2">
             <thead>
                 <row>
                     <entry>

--- a/tests/test_renderers/fixtures/sphinx_link_resolution.md
+++ b/tests/test_renderers/fixtures/sphinx_link_resolution.md
@@ -155,7 +155,7 @@ c  | d
 [explicit](#table)
 .
 <document source="<src>/index.md">
-    <table classes="colwidths-auto" ids="table" names="table">
+    <table ids="table" names="table">
         <title>
             caption
         <tgroup cols="2">

--- a/tests/test_renderers/fixtures/tables.md
+++ b/tests/test_renderers/fixtures/tables.md
@@ -5,7 +5,7 @@ a|b
 1|2
 .
 <document source="<src>/index.md">
-    <table classes="colwidths-auto">
+    <table>
         <tgroup cols="2">
             <colspec colwidth="50">
             <colspec colwidth="50">
@@ -33,7 +33,7 @@ Header only:
 | --- | --- |
 .
 <document source="<src>/index.md">
-    <table classes="colwidths-auto">
+    <table>
         <tgroup cols="2">
             <colspec colwidth="50">
             <colspec colwidth="50">
@@ -54,7 +54,7 @@ a | b | c
 1 | 2 | 3
 .
 <document source="<src>/index.md">
-    <table classes="colwidths-auto">
+    <table>
         <tgroup cols="3">
             <colspec colwidth="33">
             <colspec colwidth="33">
@@ -90,7 +90,7 @@ Nested syntax:
 |c  | {sub}`x` |
 .
 <document source="<src>/index.md">
-    <table classes="colwidths-auto">
+    <table>
         <tgroup cols="2">
             <colspec colwidth="50">
             <colspec colwidth="50">
@@ -123,7 +123,7 @@ a|b
 [link-a](https://www.google.com/)|[link-b](https://www.python.org/)
 .
 <document source="<src>/index.md">
-    <table classes="colwidths-auto">
+    <table>
         <tgroup cols="2">
             <colspec colwidth="50">
             <colspec colwidth="50">

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.resolved.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.resolved.xml
@@ -73,7 +73,7 @@
         <paragraph>
             <literal>
                 a=1{`}
-        <table classes="colwidths-auto">
+        <table>
             <tgroup cols="2">
                 <colspec colwidth="50">
                 <colspec colwidth="50">

--- a/tests/test_sphinx/test_sphinx_builds/test_basic.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_basic.xml
@@ -74,7 +74,7 @@
         <paragraph>
             <literal>
                 a=1{`}
-        <table classes="colwidths-auto">
+        <table>
             <tgroup cols="2">
                 <colspec colwidth="50">
                 <colspec colwidth="50">

--- a/tests/test_sphinx/test_sphinx_builds/test_gettext_html.resolved.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_gettext_html.resolved.xml
@@ -41,7 +41,7 @@
                         texte 8 en 
                         <strong>
                             gras
-        <table classes="colwidths-auto">
+        <table>
             <tgroup cols="1">
                 <colspec colwidth="100">
                 <thead>

--- a/tests/test_sphinx/test_sphinx_builds/test_gettext_html.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_gettext_html.xml
@@ -41,7 +41,7 @@
                         texte 8 en 
                         <strong>
                             gras
-        <table classes="colwidths-auto">
+        <table>
             <tgroup cols="1">
                 <colspec colwidth="100">
                 <thead>


### PR DESCRIPTION
Closes executablebooks/MyST-Parser#793

The output from `myst-docutils-html5` differs from the results I'm getting from `jupyter-book build` and I'm still tracking down where the difference are coming from.

There are 4 possible states for the width option of a table directive (not set, "auto", "grid", or a list of integers).

The results from `myst-docutils-html5` are as follows:

| Option | Previous behavior | New behavior |
|--------|-------------------|--------------|
| Not set (default) | no class or colspecs | no class or colspecs  |
| auto | no class or colspecs  | no class or colspecs  |
| grid | no class or colspecs  | Add colgroup with column widths set equal to each other.  |
| a list of integers | no class or colspecs  | Add colgroup with column widths set in proportion to the integers given.  |


The results from `jupyter-book build` are as follows:

| Option | Previous behavior | New behavior |
|--------|-------------------|--------------|
| Not set (default) | Add the class "colwidths-auto" to the table and not set any column widths. | Set equal proportion widths to each column.  This is a regression I hope to fix. |
| auto | Add the class "colwidths-auto" to the table and not set any column widths. | Add the class "colwidths-auto" to the table and not set any column widths (no change in behavior). |
| grid | Add the classes "colwidths-auto" and "colwidths-given" to the table, and not set any column widths. |  Add the class  "colwidths-given" to the table, and set equal widths to each column. The documentation claims this option will set widths based on column contents, but it just sets them all equal. |
| a list of integers | Add the classes "colwidths-auto" and "colwidths-given" to the table, and not set any column widths. | Add the class "colwidths-given" to the table and set columns widths in proportion to the integers given. |
