### PR TITLE
[RFC] Rebuild link labels for Sphinx i18n support

### DIFF
--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -948,6 +948,15 @@ class DocutilsRenderer(RendererProtocol):
         uri = cast(str, token.attrGet("href") or "")
         implicit_text: str | None = None
 
+        # cache label references for possible i8n support
+        # (see also: MystParser.parse)
+        if uri and 'label' in token.meta:
+            label = token.meta['label']
+            env = self.sphinx_env
+            docname = env.docname
+            labelrefs = env.metadata[docname].setdefault('myst_labelrefs', {})
+            labelrefs[label] = uri
+
         if conversion is not None:
             # implicit_template: str | None = None
             # if isinstance(conversion, (list, tuple)):

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -950,11 +950,11 @@ class DocutilsRenderer(RendererProtocol):
 
         # cache label references for possible i8n support
         # (see also: MystParser.parse)
-        if uri and 'label' in token.meta:
-            label = token.meta['label']
+        if uri and "label" in token.meta:
+            label = token.meta["label"]
             env = self.sphinx_env
             docname = env.docname
-            labelrefs = env.metadata[docname].setdefault('myst_labelrefs', {})
+            labelrefs = env.metadata[docname].setdefault("myst_labelrefs", {})
             labelrefs[label] = uri
 
         if conversion is not None:

--- a/myst_parser/parsers/mdit.py
+++ b/myst_parser/parsers/mdit.py
@@ -120,6 +120,9 @@ def create_md_parser(
             "typographer": typographer,
             "linkify": "linkify" in config.enable_extensions,
             "myst_config": config,
+            # store labels for references so we can rebuild link labels
+            # when using Sphinx Internationalization translation building
+            "store_labels": True,
         }
     )
 

--- a/myst_parser/parsers/sphinx_.py
+++ b/myst_parser/parsers/sphinx_.py
@@ -81,11 +81,11 @@ class MystParser(SphinxParser):
         # to be parsed. This will ensure references will be resolved/built as
         # expected.
         env = document.settings.env
-        labelrefs = env.metadata[env.docname].get('myst_labelrefs', {})
+        labelrefs = env.metadata[env.docname].get("myst_labelrefs", {})
         if labelrefs:
-            postfix = '\n\n'
+            postfix = "\n\n"
             for label, uri in labelrefs.items():
-                postfix += f'[{label}]: {uri}\n'
+                postfix += f"[{label}]: {uri}\n"
             inputstring += postfix
 
         parser = create_md_parser(config, SphinxRenderer)


### PR DESCRIPTION
When processing translations in Sphinx, after Sphinx's i8n transform replaces parts of a document with a translation, a document is processed a message at a time through the MyST-parser. For references using link labels, these may not be to the parse for the specific messages that need them and links may be left unbuilt after processing a document.

To prevent issues when using translations, cache any detected label references when processing a given document. And when individual messages are parsed after translation, rebuild any label references and append them to the message first. This will ensure references will be resolved/built as expected.

# RFC

Limited testing has been done. This appears to resolve my use case; however, I cannot say I have a complete understanding of MyST with Sphinx to know if the changes are right. If this (with maybe tweaks) works, great; if a completely different approach is needed, that's fine -- hopefully this example/workaround can provide hints to a better implementation.

# About

Noticed after converting a project from using reStructuredText to Markdown, any references built using labels would not be properly rendered when inside a part of a document that had a translation. For example, the default English document:

![image](https://github.com/executablebooks/MyST-Parser/assets/1834509/6001a7f2-c542-4757-a7f1-6f5dd1ea78bd)

Would result in the following using stock MyST-parser with Sphinx:

![image](https://github.com/executablebooks/MyST-Parser/assets/1834509/a6b37ecd-7411-4dc4-97fd-bfd8a6dc305c)

And after applying the changes in this pull request, translated messages would work as expected:

![image](https://github.com/executablebooks/MyST-Parser/assets/1834509/abdb30ac-f565-4626-a375-27dae5e6b3ee)

The following repository can be used to demonstrate the issue:
- https://github.com/jdknight/sphinx-i8n-myst-example
