### PR TITLE
📚 Fix the double `used` in docs/syntax/math.md

### DIFF
--- a/docs/syntax/math.md
+++ b/docs/syntax/math.md
@@ -6,7 +6,7 @@ depending on your preference.
 
 ## Math role and directive
 
-The `math` {{role}} and {{directive}} are used used to define inline and block math respectively.
+The `math` {{role}} and {{directive}} are used to define inline and block math respectively.
 
 The directive supports multiple equations, which should be separated by a blank line.
 Each single equation can have multiple aligned lines, which should be separated by `\\` characters, and each line can have multiple `&` characters to align the equations.


### PR DESCRIPTION
# Motivation
- The double `used` seems a typo?
https://github.com/executablebooks/MyST-Parser/blob/350c6331da4738057556d966b0bfd9d98d570352/docs/syntax/math.md?plain=1#L9

# Modification
- `docs/syntax/math.md`
  - Remove the redundant `used`.