### PR TITLE
👌 Nested parse attribution in `attr_block`

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,2 +1,3 @@
 _build/
 _api/
+apidocs/

--- a/docs/syntax/optional.md
+++ b/docs/syntax/optional.md
@@ -749,7 +749,7 @@ c = 3
 For **block quotes**, the `attribution` key is supported:
 
 :::{myst-example}
-{attribution="Chris Sewell"}
+{attribution="Chris Sewell, [link](https://example.com)"}
 > Hallo
 :::
 

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -582,12 +582,15 @@ class DocutilsRenderer(RendererProtocol):
         self.add_line_and_source_path(quote, token)
         with self.current_node_context(quote, append=True):
             self.render_children(token)
-        if "attribution" in token.attrs:
-            attribution = nodes.attribution(
-                token.attrs["attribution"], "", nodes.Text(token.attrs["attribution"])
-            )
-            self.add_line_and_source_path(attribution, token)
-            quote.append(attribution)
+            if "attribution" in token.attrs:
+                attribution = nodes.attribution(token.attrs["attribution"], "")
+                self.add_line_and_source_path(attribution, token)
+                with self.current_node_context(attribution, append=True):
+                    self.nested_render_text(
+                        str(token.attrs["attribution"]),
+                        token_line(token, 0),
+                        inline=True,
+                    )
 
     def render_hr(self, token: SyntaxTreeNode) -> None:
         node = nodes.transition()

--- a/tests/test_renderers/fixtures/attributes.md
+++ b/tests/test_renderers/fixtures/attributes.md
@@ -16,7 +16,7 @@ c = 3
 
 blockquote
 .
-{attribution="Chris Sewell"}
+{attribution="Chris Sewell [link](https://source.com)"}
 > Hallo
 .
 <document source="<src>/index.md">
@@ -25,6 +25,8 @@ blockquote
             Hallo
         <attribution>
             Chris Sewell
+            <reference refuri="https://source.com">
+                link
 .
 
 list-style


### PR DESCRIPTION
This is in keeping with the restructured text implementation, e.g.

```restructuredtext
  Hallo

  -- Chris Sewell `link <https://source.com>`__
```

tokenizes to:

```xml
<document source="test.rst">
    <block_quote>
        <paragraph>
            Hallo
        <attribution>
            Chris Sewell 
            <reference name="link" refuri="https://source.com">
                link
```
