### PR TITLE
🔧 Fix docutils deprecation in option parsing

### DIFF
--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -22,10 +22,10 @@ from typing import (
 )
 from urllib.parse import urlparse
 
+import docutils
 import jinja2
 import yaml
 from docutils import nodes
-from docutils.frontend import OptionParser
 from docutils.languages import get_language
 from docutils.parsers.rst import Directive, DirectiveError, directives, roles
 from docutils.parsers.rst import Parser as RSTParser
@@ -63,7 +63,14 @@ if TYPE_CHECKING:
 
 def make_document(source_path="notset", parser_cls=RSTParser) -> nodes.document:
     """Create a new docutils document, with the parser classes' default settings."""
-    settings = OptionParser(components=(parser_cls,)).get_default_values()
+    if docutils.__version_info__[:2] >= (0, 19):
+        from docutils.frontend import get_default_settings
+
+        settings = get_default_settings(parser_cls)
+    else:
+        from docutils.frontend import OptionParser
+
+        settings = OptionParser(components=(parser_cls,)).get_default_values()
     return new_document(source_path, settings=settings)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,8 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 filterwarnings = [
     "ignore:.*The default for the setting.*:FutureWarning",
+#    'ignore:.*The frontend\.OptionParser class will be replaced.*:DeprecationWarning',
+#    'ignore:.*The frontend\.Option class will be removed.*:DeprecationWarning'
 ]
 
 [tool.coverage.run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,8 +118,6 @@ ignore_missing_imports = true
 [tool.pytest.ini_options]
 filterwarnings = [
     "ignore:.*The default for the setting.*:FutureWarning",
-#    'ignore:.*The frontend\.OptionParser class will be replaced.*:DeprecationWarning',
-#    'ignore:.*The frontend\.Option class will be removed.*:DeprecationWarning'
 ]
 
 [tool.coverage.run]

--- a/tests/test_docutils.py
+++ b/tests/test_docutils.py
@@ -1,4 +1,5 @@
 import io
+import contextlib
 from dataclasses import dataclass, field, fields
 from textwrap import dedent
 from typing import Literal
@@ -91,10 +92,16 @@ def test_cli_pseudoxml(monkeypatch, capsys):
 
 def test_help_text():
     """Test retrieving settings help text."""
-    from docutils.frontend import OptionParser
+    from docutils.core import Publisher
 
     stream = io.StringIO()
-    OptionParser(components=(Parser,)).print_help(stream)
+    pub = Publisher(parser=Parser())
+    with contextlib.redirect_stdout(stream):
+        try:
+            pub.process_command_line(["--help"])
+        except SystemExit as exc:
+            assert not exc.code
+
     assert "MyST options" in stream.getvalue()
 
 

--- a/tests/test_docutils.py
+++ b/tests/test_docutils.py
@@ -1,5 +1,5 @@
-import io
 import contextlib
+import io
 from dataclasses import dataclass, field, fields
 from textwrap import dedent
 from typing import Literal

--- a/tests/test_renderers/test_fixtures_docutils.py
+++ b/tests/test_renderers/test_fixtures_docutils.py
@@ -128,9 +128,8 @@ def settings_from_cmdline(cmdline: str | None) -> dict[str, Any]:
     if cmdline is None or not cmdline.strip():
         return {}
     pub = Publisher(parser=Parser())
-    option_parser = pub.setup_option_parser()
     try:
-        settings = option_parser.parse_args(shlex.split(cmdline)).__dict__
+        pub.process_command_line(shlex.split(cmdline))
     except Exception as err:
         raise AssertionError(f"Failed to parse commandline: {cmdline}\n{err}")
-    return settings
+    return vars(pub.settings)

--- a/tests/test_renderers/test_myst_config.py
+++ b/tests/test_renderers/test_myst_config.py
@@ -22,15 +22,13 @@ def test_cmdline(file_params: ParamTestData):
     if "heading_slug_func" in file_params.title and __version_info__ < (0, 18):
         pytest.skip("dupnames ids changed in docutils 0.18")
     pub = Publisher(parser=Parser())
-    option_parser = pub.setup_option_parser()
     try:
-        settings = option_parser.parse_args(
-            shlex.split(file_params.description)
-        ).__dict__
+        pub.process_command_line(shlex.split(file_params.description))
     except Exception as err:
         raise AssertionError(
             f"Failed to parse commandline: {file_params.description}\n{err}"
         )
+    settings = vars(pub.settings)
     report_stream = StringIO()
     settings["output_encoding"] = "unicode"
     settings["warning_stream"] = report_stream


### PR DESCRIPTION
This PR fixes the deprecation warnings raised by docutils' deprecation of `OptionParser`.

The help handling is a little ugly - we could introduce a switch on the docutils version like we do for the default settings. However, I *think* this approach will be less likely to break once the breaking change is introduced. 