### PR TITLE
Failing test for #852

### DIFF
--- a/tests/test_sphinx/sourcedirs/gettext/fr/LC_MESSAGES/index.po
+++ b/tests/test_sphinx/sourcedirs/gettext/fr/LC_MESSAGES/index.po
@@ -125,3 +125,6 @@ msgid ".. image:: fun-fish.png\n"
 "   :alt: Fun Fish 3"
 msgstr ".. image:: poisson-amusant.png\n"
 "   :alt: Poisson amusant 3"
+
+msgid "1. numbered title"
+msgstr "1. titre numéroté"

--- a/tests/test_sphinx/sourcedirs/gettext/index.md
+++ b/tests/test_sphinx/sourcedirs/gettext/index.md
@@ -61,3 +61,5 @@ doctest block
 ```{figure} fun-fish.png
 :alt: Fun Fish 3
 ```
+
+## 1. numbered title

--- a/tests/test_sphinx/test_sphinx_builds/test_gettext.pot
+++ b/tests/test_sphinx/test_sphinx_builds/test_gettext.pot
@@ -79,3 +79,7 @@ msgstr ""
 #: ../../index.md:61
 msgid "Fun Fish 3"
 msgstr ""
+
+#: ../../index.md:65
+msgid "1. numbered title"
+msgstr ""

--- a/tests/test_sphinx/test_sphinx_builds/test_gettext_additional_targets.pot
+++ b/tests/test_sphinx/test_sphinx_builds/test_gettext_additional_targets.pot
@@ -127,3 +127,7 @@ msgstr ""
 #: ../../index.md:61
 msgid "Fun Fish 3"
 msgstr ""
+
+#: ../../index.md:65
+msgid "1. numbered title"
+msgstr ""

--- a/tests/test_sphinx/test_sphinx_builds/test_gettext_html.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_gettext_html.html
@@ -156,6 +156,14 @@
     <figure class="align-default">
      <img alt="Poisson amusant 3" src="_images/fun-fish.png"/>
     </figure>
+    <section id="numbered-title">
+     <h2>
+      1. titre numéroté
+      <a class="headerlink" href="#numbered-title" title="Lien permanent vers cette rubrique">
+       ¶
+      </a>
+     </h2>
+    </section>
    </section>
   </div>
  </div>

--- a/tests/test_sphinx/test_sphinx_builds/test_gettext_html.resolved.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_gettext_html.resolved.xml
@@ -91,3 +91,6 @@
         <image alt="Poisson amusant 2" candidates="{'*': 'fun-fish.png'}" uri="fun-fish.png">
         <figure>
             <image alt="Poisson amusant 3" candidates="{'*': 'fun-fish.png'}" uri="fun-fish.png">
+        <section ids="numbered-title" names="1.\ numbered\ title 1.\ titre\ numéroté">
+            <title>
+                1. titre numéroté

--- a/tests/test_sphinx/test_sphinx_builds/test_gettext_html.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_gettext_html.xml
@@ -91,3 +91,6 @@
         <image alt="Poisson amusant 2" candidates="{'*': 'fun-fish.png'}" uri="fun-fish.png">
         <figure>
             <image alt="Poisson amusant 3" candidates="{'*': 'fun-fish.png'}" uri="fun-fish.png">
+        <section ids="numbered-title" names="1.\ numbered\ title 1.\ titre\ numéroté">
+            <title>
+                1. titre numéroté


### PR DESCRIPTION
See: <https://github.com/executablebooks/MyST-Parser/issues/852>

I am not sure if the id of the HTML output should contain the number or not. If I am not mistaken, this id is not the one generated by the `heading_anchor` parameter of MyST but by Sphinx.