### PR TITLE
👌 IMPROVE: Allow for opening external links in new tabs (#856)

### DIFF
--- a/myst_parser/config/main.py
+++ b/myst_parser/config/main.py
@@ -233,6 +233,14 @@ class MdParserConfig:
         },
     )
 
+    links_external_new_tab: bool = dc.field(
+        default=False,
+        metadata={
+            "validator": instance_of(bool),
+            "help": "Open all external links in a new tab",
+        },
+    )
+
     url_schemes: Dict[str, Optional[UrlSchemeType]] = dc.field(
         default_factory=lambda: {
             "http": None,

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -952,8 +952,12 @@ class DocutilsRenderer(RendererProtocol):
         """
         ref_node = nodes.reference()
         self.add_line_and_source_path(ref_node, token)
+        attribute_keys = ["class", "id", "reftitle", "target", "rel"]
+        if self.md_config.links_external_new_tab:
+            token.attrs["target"] = "_blank"
+            token.attrs["rel"] = "noreferer noopener"
         self.copy_attributes(
-            token, ref_node, ("class", "id", "reftitle"), aliases={"title": "reftitle"}
+            token, ref_node, attribute_keys, aliases={"title": "reftitle"}
         )
         uri = cast(str, token.attrGet("href") or "")
         implicit_text: str | None = None

--- a/tests/test_renderers/fixtures/myst-config.txt
+++ b/tests/test_renderers/fixtures/myst-config.txt
@@ -301,6 +301,10 @@ a
 [ref]{#id3 .e .f}
 
 [ref]: https://example.com
+
+[text3](https://example.com){target="g"}
+
+[text4](https://example.com){rel="h"}
 .
 <document source="<string>">
     <paragraph>
@@ -319,6 +323,12 @@ a
     <paragraph>
         <reference classes="e f" ids="id3" names="id3" refuri="https://example.com">
             ref
+    <paragraph>
+        <reference refuri="https://example.com" target="g">
+            text3
+    <paragraph>
+        <reference refuri="https://example.com" rel="h">
+            text4
 .
 
 [attrs_inline_image] --myst-enable-extensions=attrs_inline
@@ -506,4 +516,14 @@ content
 
 <string>:1: (WARNING/2) Unknown directive type: 'unknown' [myst.directive_unknown]
 <string>:6: (WARNING/2) 'admonition': Unknown option keys: ['a'] (allowed: ['class', 'name']) [myst.directive_parse]
+.
+
+[links-external-new-tab] --myst-links-external-new-tab="true"
+.
+[text](https://example.com)
+.
+<document source="<string>">
+    <paragraph>
+        <reference refuri="https://example.com" rel="noreferer noopener" target="_blank">
+            text
 .


### PR DESCRIPTION
Add support to enable external links to open in a new tab. Expose the configuration option myst_links_external_new_tab, which if set will set all URL links to open in a new tab on the browser.

Besides that, we allow the user to set the target and rel attributes when using the extension inline_attrs (#820).

Closes #820
Closes #856