### PR TITLE
🔧 mypy- disallow 'any generics'

### DIFF
--- a/myst_parser/inventory.py
+++ b/myst_parser/inventory.py
@@ -231,7 +231,7 @@ class InventoryFileReader:
 
 
 @functools.lru_cache(maxsize=256)
-def _create_regex(pat: str) -> re.Pattern:
+def _create_regex(pat: str) -> re.Pattern[str]:
     r"""Create a regex from a pattern, that can include `*` wildcards,
     to match 0 or more characters.
 

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -33,7 +33,7 @@ from docutils.parsers.rst.directives.misc import Include
 from docutils.parsers.rst.languages import get_language as get_language_rst
 from docutils.statemachine import StringList
 from docutils.transforms.components import Filter
-from docutils.utils import Reporter, new_document
+from docutils.utils import Reporter, SystemMessage, new_document
 from docutils.utils.code_analyzer import Lexer, LexerError, NumberLines
 from markdown_it import MarkdownIt
 from markdown_it.common.utils import escapeHtml
@@ -379,7 +379,7 @@ class DocutilsRenderer(RendererProtocol):
     @contextmanager
     def current_node_context(
         self, node: nodes.Element, append: bool = False
-    ) -> Iterator:
+    ) -> Iterator[None]:
         """Context manager for temporarily setting the current node."""
         if append:
             self.current_node.append(node)
@@ -1724,7 +1724,7 @@ class DocutilsRenderer(RendererProtocol):
         self.document.current_line = position
 
         # get directive class
-        output: tuple[Directive | None, list] = directives.directive(
+        output: tuple[Directive | None, list[SystemMessage]] = directives.directive(
             name, self.language_module_rst, self.document
         )
         directive_class, messages = output

--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -127,8 +127,8 @@ class MockState:
         content: StringList,
         line_offset: int,
         directive: type[Directive],
-        option_presets: dict,
-    ) -> tuple[list, dict, StringList, int]:
+        option_presets: dict[str, Any],
+    ) -> tuple[list[str], dict[str, Any], StringList, int]:
         """Parse the full directive text
 
         :raises MarkupError: for errors in parsing the directive
@@ -324,8 +324,8 @@ class MockIncludeDirective:
         renderer: DocutilsRenderer,
         name: str,
         klass: Include,
-        arguments: list,
-        options: dict,
+        arguments: list[str],
+        options: dict[str, Any],
         body: list[str],
         lineno: int,
     ):

--- a/myst_parser/parsers/docutils_.py
+++ b/myst_parser/parsers/docutils_.py
@@ -124,7 +124,7 @@ def _validate_url_schemes(
     return output
 
 
-def _attr_to_optparse_option(at: Field, default: Any) -> Tuple[dict[str, Any], str]:
+def _attr_to_optparse_option(at: Field, default: Any) -> Tuple[Dict[str, Any], str]:
     """Convert a field into a Docutils optparse options dict.
 
     :returns: (option_dict, default)

--- a/myst_parser/parsers/docutils_.py
+++ b/myst_parser/parsers/docutils_.py
@@ -124,7 +124,7 @@ def _validate_url_schemes(
     return output
 
 
-def _attr_to_optparse_option(at: Field, default: Any) -> Tuple[dict, str]:
+def _attr_to_optparse_option(at: Field, default: Any) -> Tuple[dict[str, Any], str]:
     """Convert a field into a Docutils optparse options dict.
 
     :returns: (option_dict, default)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "myst-parser"
 dynamic = ["version", "description"]
-authors = [{name = "Chris Sewell", email = "chrisj_sewell@hotmail.com"}]
+authors = [{ name = "Chris Sewell", email = "chrisj_sewell@hotmail.com" }]
 readme = "README.md"
-license = {file = "LICENSE"}
+license = { file = "LICENSE" }
 classifiers = [
     "Development Status :: 4 - Beta",
     "Framework :: Sphinx :: Extension",
@@ -25,18 +25,11 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Text Processing :: Markup",
 ]
-keywords = [
-    "markdown",
-    "lexer",
-    "parser",
-    "development",
-    "docutils",
-    "sphinx",
-]
+keywords = ["markdown", "lexer", "parser", "development", "docutils", "sphinx"]
 requires-python = ">=3.8"
 dependencies = [
     "docutils>=0.16,<0.21",
-    "jinja2", # required for substitutions, but let sphinx choose version
+    "jinja2",               # required for substitutions, but let sphinx choose version
     "markdown-it-py~=3.0",
     "mdit-py-plugins~=0.4",
     "pyyaml",
@@ -76,11 +69,7 @@ testing = [
     "pytest-param-files~=0.6.0",
     "sphinx-pytest",
 ]
-testing-docutils = [
-    "pygments",
-    "pytest>=7,<8",
-    "pytest-param-files~=0.6.0",
-]
+testing-docutils = ["pygments", "pytest>=7,<8", "pytest-param-files~=0.6.0"]
 
 [project.scripts]
 myst-anchors = "myst_parser.cli:print_anchors"
@@ -96,10 +85,7 @@ myst-docutils-pseudoxml = "myst_parser.parsers.docutils_:cli_pseudoxml"
 name = "myst_parser"
 
 [tool.flit.sdist]
-exclude = [
-    "docs/",
-    "tests/",
-]
+exclude = ["docs/", "tests/"]
 
 [tool.ruff]
 extend-select = ["B0", "C4", "I", "ICN", "ISC", "N", "RUF", "SIM", "UP"]
@@ -111,15 +97,26 @@ check_untyped_defs = true
 strict_equality = true
 no_implicit_optional = true
 warn_unused_ignores = true
+disallow_any_generics = true
 
 [[tool.mypy.overrides]]
 module = ["docutils.*", "yaml.*", "pygments.*"]
 ignore_missing_imports = true
 
-[tool.pytest.ini_options]
-filterwarnings = [
-    "ignore:.*The default for the setting.*:FutureWarning",
+[[tool.mypy.overrides]]
+# shrink me
+module = [
+    "myst_parser.config.dc_validators",
+    "myst_parser.config.main",
+    "myst_parser.inventory",
+    "myst_parser.parsers.directives",
+    "myst_parser.parsers.docutils_",
+    "myst_parser.parsers.parse_html",
 ]
+disallow_any_generics = false
+
+[tool.pytest.ini_options]
+filterwarnings = ["ignore:.*The default for the setting.*:FutureWarning"]
 
 [tool.coverage.run]
 omit = ["*/_docs.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,9 @@ build-backend = "flit_core.buildapi"
 [project]
 name = "myst-parser"
 dynamic = ["version", "description"]
-authors = [{ name = "Chris Sewell", email = "chrisj_sewell@hotmail.com" }]
+authors = [{name = "Chris Sewell", email = "chrisj_sewell@hotmail.com"}]
 readme = "README.md"
-license = { file = "LICENSE" }
+license = {file = "LICENSE"}
 classifiers = [
     "Development Status :: 4 - Beta",
     "Framework :: Sphinx :: Extension",
@@ -25,11 +25,18 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Text Processing :: Markup",
 ]
-keywords = ["markdown", "lexer", "parser", "development", "docutils", "sphinx"]
+keywords = [
+    "markdown",
+    "lexer",
+    "parser",
+    "development",
+    "docutils",
+    "sphinx",
+]
 requires-python = ">=3.8"
 dependencies = [
     "docutils>=0.16,<0.21",
-    "jinja2",               # required for substitutions, but let sphinx choose version
+    "jinja2", # required for substitutions, but let sphinx choose version
     "markdown-it-py~=3.0",
     "mdit-py-plugins~=0.4",
     "pyyaml",
@@ -69,7 +76,11 @@ testing = [
     "pytest-param-files~=0.6.0",
     "sphinx-pytest",
 ]
-testing-docutils = ["pygments", "pytest>=7,<8", "pytest-param-files~=0.6.0"]
+testing-docutils = [
+    "pygments",
+    "pytest>=7,<8",
+    "pytest-param-files~=0.6.0",
+]
 
 [project.scripts]
 myst-anchors = "myst_parser.cli:print_anchors"
@@ -85,7 +96,10 @@ myst-docutils-pseudoxml = "myst_parser.parsers.docutils_:cli_pseudoxml"
 name = "myst_parser"
 
 [tool.flit.sdist]
-exclude = ["docs/", "tests/"]
+exclude = [
+    "docs/",
+    "tests/",
+]
 
 [tool.ruff]
 extend-select = ["B", "C4", "FA", "FURB", "I", "ICN", "ISC", "N", "PERF", "PGH", "PIE", "RUF", "SIM", "UP"]
@@ -119,7 +133,9 @@ module = [
 disallow_any_generics = false
 
 [tool.pytest.ini_options]
-filterwarnings = ["ignore:.*The default for the setting.*:FutureWarning"]
+filterwarnings = [
+    "ignore:.*The default for the setting.*:FutureWarning",
+]
 
 [tool.coverage.run]
 omit = ["*/_docs.py"]


### PR DESCRIPTION
- make mypy config stricter by disallowing 'any' generics
- fix some errors by adding generics
- 'whitelist' the modules with excessive errors
- includes some changes due to autoformatting `pyproject.toml`

this whitelist should be shrunk and eventually removed over time. It should never get larger.