### PR TITLE
:sparkles: NEW: Emits sphinx include-read event

### DIFF
--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -383,6 +383,7 @@ class MockIncludeDirective:
 
         if self.renderer.sphinx_env is not None:
             # Emit the "include-read" event
+            # see: https://github.com/sphinx-doc/sphinx/commit/ff18318613db56d0000db47e5c8f0140556cef0c
             arg = [file_content]
             relative_path = Path(
                 os.path.relpath(path, start=self.renderer.sphinx_env.srcdir)

--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -380,6 +380,19 @@ class MockIncludeDirective:
                 4, f'Directive "{self.name}": error reading file: {path}\n{error}.'
             )
 
+        if self.renderer.sphinx_env is not None:
+            # Emit the "include-read" event
+            arg = [file_content]
+            relative_path = path.relative_to(source_dir)
+            parent_docname = Path(self.renderer.document["source"]).stem
+            self.renderer.sphinx_env.app.events.emit(
+                "include-read",
+                relative_path,
+                parent_docname,
+                arg,
+            )
+            file_content = arg[0]
+
         # get required section of text
         startline = self.options.get("start-line", None)
         endline = self.options.get("end-line", None)

--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -383,7 +383,10 @@ class MockIncludeDirective:
         if self.renderer.sphinx_env is not None:
             # Emit the "include-read" event
             arg = [file_content]
-            relative_path = path.relative_to(source_dir)
+            relative_path = path.relative_to(
+                self.renderer.sphinx_env.srcdir,
+                walk_up=True,
+            )
             parent_docname = Path(self.renderer.document["source"]).stem
             self.renderer.sphinx_env.app.events.emit(
                 "include-read",

--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -383,9 +383,8 @@ class MockIncludeDirective:
         if self.renderer.sphinx_env is not None:
             # Emit the "include-read" event
             arg = [file_content]
-            relative_path = path.relative_to(
-                self.renderer.sphinx_env.srcdir,
-                walk_up=True,
+            relative_path = Path(
+                os.path.relpath(path, start=self.renderer.sphinx_env.srcdir)
             )
             parent_docname = Path(self.renderer.document["source"]).stem
             self.renderer.sphinx_env.app.events.emit(

--- a/tests/test_sphinx/sourcedirs/includes/index.md
+++ b/tests/test_sphinx/sourcedirs/includes/index.md
@@ -1,5 +1,8 @@
 # Main Title
 
+```{include} ../include_from_rst/include.md
+```
+
 ```{include} include1.inc.md
 ```
 

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -15,6 +15,7 @@ import re
 from pathlib import Path
 
 import pytest
+import sphinx
 from docutils import VersionInfo, __version_info__
 
 SOURCE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "sourcedirs"))
@@ -588,6 +589,9 @@ def test_texinfo(app, status, warning):
     assert warnings == ""
 
 
+@pytest.mark.skipif(
+    sphinx.version_info < (7, 2, 5), reason="include-read event added in sphinx 7.2.5"
+)
 @pytest.mark.sphinx(
     buildername="html",
     srcdir=os.path.join(SOURCE_DIR, "includes"),
@@ -595,10 +599,6 @@ def test_texinfo(app, status, warning):
 )
 def test_include_read_event(app, status, warning):
     """Test that include-read event is emitted correctly."""
-    import sphinx
-
-    if sphinx.version_info < (7, 2, 5):
-        return
 
     include_read_events = []
 

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -8,6 +8,8 @@ which uses semantic HTML tags
 (e.g. converting `<div class="section">` to `<section>`)
 """
 
+from __future__ import annotations
+
 import os
 import re
 from pathlib import Path

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -610,6 +610,7 @@ def test_include_read_event(app, status, warning):
     warnings = warning.getvalue().strip()
     assert warnings == ""
     expected = [
+        ("../include_from_rst/include.md", "index"),
         ("include1.inc.md", "index"),
         (os.path.join("subfolder", "include2.inc.md"), "include1.inc"),
         ("include_code.py", "index"),

--- a/tests/test_sphinx/test_sphinx_builds/test_includes.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_includes.html
@@ -8,6 +8,19 @@
       ¶
      </a>
     </h1>
+   </section>
+   <section id="markdown">
+    <h1>
+     Markdown
+     <a class="headerlink" href="#markdown" title="Permalink to this heading">
+      ¶
+     </a>
+    </h1>
+    <p>
+     <a class="reference external" href="http://example.com/">
+      target
+     </a>
+    </p>
     <section id="a-sub-heading-in-include">
      <span id="inc-header">
      </span>

--- a/tests/test_sphinx/test_sphinx_builds/test_includes.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_includes.xml
@@ -2,6 +2,12 @@
     <section ids="main-title" names="main\ title">
         <title>
             Main Title
+    <section ids="markdown" names="markdown">
+        <title>
+            Markdown
+        <paragraph>
+            <reference refuri="http://example.com/">
+                target
         <target refid="inc-header">
         <section ids="a-sub-heading-in-include inc-header" names="a\ sub-heading\ in\ include inc_header">
             <title>


### PR DESCRIPTION
Adds emission of Sphinx `include-read` events while processing include directives, closes #881.

[include-read](https://www.sphinx-doc.org/en/master/extdev/appapi.html#event-include-read)

If there is a better way to restrict the test to Sphinx>=7.5.2, please let me know.