### PR TITLE
:bug: FIX: Double encoded ampersands in query params

### DIFF
--- a/tests/test_sphinx/sourcedirs/references/index.md
+++ b/tests/test_sphinx/sourcedirs/references/index.md
@@ -8,6 +8,8 @@
 
 [nested *syntax*](https://example.com)
 
+[query params](https://example.com?foo=bar&a=1)
+
 [](title)
 
 [plain text](title)

--- a/tests/test_sphinx/test_sphinx_builds/test_references.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.html
@@ -34,6 +34,11 @@
      </a>
     </p>
     <p>
+     <a class="reference external" href="https://example.com?foo=bar&amp;a=1">
+      query params
+     </a>
+    </p>
+    <p>
      <a class="reference internal" href="#title">
       <span class="std std-ref">
        Title with nested a=1

--- a/tests/test_sphinx/test_sphinx_builds/test_references.resolved.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.resolved.xml
@@ -19,6 +19,9 @@
                 <emphasis>
                     syntax
         <paragraph>
+            <reference refuri="https://example.com?foo=bar&amp;a=1">
+                query params
+        <paragraph>
             <reference internal="True" refid="title">
                 <inline classes="std std-ref">
                     Title with nested a=1

--- a/tests/test_sphinx/test_sphinx_builds/test_references.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.xml
@@ -19,6 +19,9 @@
                 <emphasis>
                     syntax
         <paragraph>
+            <reference refuri="https://example.com?foo=bar&amp;a=1">
+                query params
+        <paragraph>
             <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="title" reftype="myst">
                 <inline classes="xref myst">
         <paragraph>


### PR DESCRIPTION
This closes #760.

MyST already escapes the `&` in the query params, but docutils escapes them again when rendering HTML, leading to broken query params.
```md
[Link](example.com?foo=1&bar=2)
```
becomes
```html
<p><a href="example.com?foo=1&amp;amp;bar=2">Link</a></p>
```
instead of 
```html
<p><a href="example.com?foo=1&amp;bar=2">Link</a></p>
```

These changes to the docutils parser override the `HTMLTranslator.encode` function so already encoded ampersands are not encoded again.
Since the issue lies in the interaction with docutils, I think it makes sense to fix it here.
Also, simply removing the `escapeHtml` call in MyST makes the sphinx app doctree XML files invalid because the ampersands aren't escaped.