### PR TITLE
Fix detection of YAML option block when using colon fences (fixes #963)

### DIFF
--- a/myst_parser/parsers/directives.py
+++ b/myst_parser/parsers/directives.py
@@ -192,7 +192,8 @@ def _parse_directive_options(
         content_lines = content.splitlines()
         yaml_lines = []
         while content_lines:
-            if not content_lines[0].lstrip().startswith(":"):
+            next_line = content_lines[0].lstrip()
+            if not next_line.startswith(":") or next_line.lstrip(":").startswith("{"):
                 break
             yaml_lines.append(content_lines.pop(0).lstrip()[1:])
         options_block = "\n".join(yaml_lines)


### PR DESCRIPTION
This is a quick change to fix issue #963. I think this is a reasonable solution even if the colon fence extension is not enabled, because valid YAML will never begin with `:{` (with any number of colons).

Suggestions/alternatives are welcome.