### PR TITLE
Expose myst_substitions to RST

### DIFF
--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -280,6 +280,17 @@ class DocutilsRenderer(RendererProtocol):
                     substitution_node, f"wordcount-{key}"
                 )
 
+        for key, value in self.md_config.substitutions.items():
+            if value is None:
+                continue
+
+            substitution_node = nodes.substitution_definition(
+                str(value), nodes.Text(str(value))
+            )
+            substitution_node.source = self.document["source"]
+            substitution_node["names"].append(key)
+            self.document.note_substitution_def(substitution_node, key)
+
     def nested_render_text(
         self,
         text: str,

--- a/tests/test_sphinx/sourcedirs/substitutions/index.md
+++ b/tests/test_sphinx/sourcedirs/substitutions/index.md
@@ -52,6 +52,12 @@ This will not process the substitution
 {{ text_with_nest }}
 ```
 
+Test substitutions are processed within eval-rst
+
+```{eval-rst}
+a |text| b
+```
+
 Using env and filters:
 
 {{ env.docname | upper }}

--- a/tests/test_sphinx/test_sphinx_builds/test_substitutions.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_substitutions.html
@@ -63,6 +63,12 @@
     </div>
    </div>
    <p>
+    Test substitutions are processed within eval-rst
+   </p>
+   <p>
+    a - text b
+   </p>
+   <p>
     Using env and filters:
    </p>
    <p>

--- a/tests/test_sphinx/test_sphinx_builds/test_substitutions.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_substitutions.xml
@@ -48,6 +48,12 @@
     <literal_block language="python" xml:space="preserve">
         {{ text_with_nest }}
     <paragraph>
+        Test substitutions are processed within eval-rst
+    <paragraph>
+        a 
+        - text
+         b
+    <paragraph>
         Using env and filters:
     <paragraph>
         INDEX


### PR DESCRIPTION
While this doesn't fix the fact that `.. replace::` does not work within eval-rst, it does make it possible to perform substitutions within eval-rst using the same substitutions available to Jinja substitutions.

Related: #680

Honestly I have very little experience with docutils, or even MyST but I basically figured out substitutions need to be registered by calling `self.document.note_substitution_def` from reading where the `Undefined substitution referenced:` error message comes from and determining that it reads from two dictionaries that the `document.note_substitution_def` updates. I then kind of got lucky and found that `MyST` already called the necessary function for the wordcount extension, which gave me a basic example of what I needed to do. I literally just copy and pasted the code used for the word count extension but using the values from `self.md_config.substitutions` which is where `myst_substitutions` values are stored, and it "just worked".

Let me know what you think, like I said, it was really just a stab at trying to make something substitution related work for `eval-rst`. I'd still love to get `.. replace::` working but this will solve my needs pretty well I think.