### PR TITLE
📚 Fix typos discovered by codespell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,8 +168,8 @@ The `docutils` parser now supports many more features, and improvements to suppo
 - `myst_meta_html` and `myst_substitutions` options are now supported (<gh-pr:672>)
 - `myst_heading_anchors` option is now supported (<gh-pr:678>)
 - Math block labels syntax is now supported (<gh-pr:668>)
-- Missing directive/role errors errors are now suppressable warnings (<gh-pr:687>)
-- Non-fatal directive parsing errors are now suppressable warnings (<gh-pr:682>)
+- Missing directive/role errors errors are now suppressible warnings (<gh-pr:687>)
+- Non-fatal directive parsing errors are now suppressible warnings (<gh-pr:682>)
 - Most of the extended markdown syntax below is also supported
 
 ### 🔗 Extended Markdown links

--- a/docs/develop/background.md
+++ b/docs/develop/background.md
@@ -22,7 +22,7 @@ syntax pieces to utilize the most powerful parts of reStructuredText.
 The CommonMark community has been discussing an "official" extension syntax for many
 years now (for example, see
 [this seven-year-old thread about directives](https://talk.commonmark.org/t/generic-directives-plugins-syntax/444) as well as
-[this more recent converstaion](https://talk.commonmark.org/t/support-for-extension-token/2771),
+[this more recent conversation](https://talk.commonmark.org/t/support-for-extension-token/2771),
 and [this comment listing several more threads on this topic](https://talk.commonmark.org/t/extension-terminology-and-rules/1233)).
 
 We have chosen a "roles and directives" syntax that seems reasonable and follows other

--- a/docs/syntax/cross-referencing.md
+++ b/docs/syntax/cross-referencing.md
@@ -14,7 +14,7 @@ Targets are used to define custom anchors that you can refer to elsewhere in you
 There are three primary ways to create targets:
 
 1. Annotating a syntax block with `(target)=`
-2. Annotating a syntax bloc/inline/span with an `{#id}` attribute (using the [attrs_block](#syntax/attributes/block) and [attrs_inline](#syntax/attributes/inline) extensions)
+2. Annotating a syntax block/inline/span with an `{#id}` attribute (using the [attrs_block](#syntax/attributes/block) and [attrs_inline](#syntax/attributes/inline) extensions)
 3. Adding a `name` option to a directive
 
 ::::{myst-example}

--- a/docs/syntax/math.md
+++ b/docs/syntax/math.md
@@ -71,7 +71,7 @@ Conversely `\\` will negate the escaping, so `\\$a$` renders as \\$a$.
 
 Enabling the [amsmath](#syntax/amsmath) extension will directly parse the following top-level math environments:
 
-> equation, multline, gather, align, alignat, flalign, matrix, pmatrix, bmatrix, Bmatrix, vmatrix, Vmatrix, eqnarray.
+> equation, multiline, gather, align, alignat, flalign, matrix, pmatrix, bmatrix, Bmatrix, vmatrix, Vmatrix, eqnarray.
 
 As expected, environments ending in `*` will not be numbered, for example:
 

--- a/docs/syntax/optional.md
+++ b/docs/syntax/optional.md
@@ -218,7 +218,7 @@ By adding `"amsmath"` to `myst_enable_extensions` (in the {{ confpy }}),
 you can enable direct parsing of [amsmath](https://ctan.org/pkg/amsmath) LaTeX equations.
 These top-level math environments will then be directly parsed:
 
-> equation, multline, gather, align, alignat, flalign, matrix, pmatrix, bmatrix, Bmatrix, vmatrix, Vmatrix, eqnarray.
+> equation, multiline, gather, align, alignat, flalign, matrix, pmatrix, bmatrix, Bmatrix, vmatrix, Vmatrix, eqnarray.
 
 As expected, environments ending in `*` will not be numbered, for example:
 

--- a/myst_parser/mdit_to_docutils/sphinx_.py
+++ b/myst_parser/mdit_to_docutils/sphinx_.py
@@ -182,7 +182,7 @@ class SphinxRenderer(DocutilsRenderer):
         )
 
     def render_math_block_label(self, token: SyntaxTreeNode) -> None:
-        """Render math with referencable labels, e.g. ``$a=1$ (label)``."""
+        """Render math with referenceable labels, e.g. ``$a=1$ (label)``."""
         label = token.info
         content = token.content
         node = nodes.math_block(

--- a/myst_parser/parsers/directives.py
+++ b/myst_parser/parsers/directives.py
@@ -269,19 +269,19 @@ def _parse_directive_options(
     value: str | None
     for name, value in options.items():
         try:
-            convertor = options_spec[name]
+            converter = options_spec[name]
         except KeyError:
             unknown_options.append(name)
             continue
         if not value:
             # restructured text parses empty option values as None
             value = None
-        if convertor is flag:
+        if converter is flag:
             # flag will error if value is not empty,
             # but to be more permissive we allow any value
             value = None
         try:
-            converted_value = convertor(value)
+            converted_value = converter(value)
         except (ValueError, TypeError) as error:
             validation_errors.append(
                 ParseWarnings(

--- a/myst_parser/warnings_.py
+++ b/myst_parser/warnings_.py
@@ -55,7 +55,7 @@ class MystWarnings(Enum):
 
     # extensions
     HEADING_SLUG = "heading_slug"
-    """An error occured computing a heading slug."""
+    """An error occurred computing a heading slug."""
     STRIKETHROUGH = "strikethrough"
     """Strikethrough warning, since only implemented in HTML."""
     HTML_PARSE = "html"


### PR DESCRIPTION
https://pypi.org/project/codespell

% `codespell --ignore-words-list=nd,rsource --quiet-level=3`
```
./CHANGELOG.md:171: suppressable ==> suppressible
./CHANGELOG.md:172: suppressable ==> suppressible
./docs/develop/background.md:25: converstaion ==> conversation
./docs/syntax/cross-referencing.md:17: bloc ==> block
./docs/syntax/math.md:74: multline ==> multiline
./docs/syntax/optional.md:221: multline ==> multiline
./myst_parser/warnings_.py:58: occured ==> occurred
./myst_parser/parsers/directives.py:272: convertor ==> converter
./myst_parser/parsers/directives.py:279: convertor ==> converter
./myst_parser/parsers/directives.py:284: convertor ==> converter
./myst_parser/mdit_to_docutils/sphinx_.py:185: referencable ==> referenceable
```
% `codespell --ignore-words-list=nd,rsource --quiet-level=3 --write-changes`