### PR TITLE
🔧 Fix type of MockIncludeDirective’s `klass` parameter

### DIFF
--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -353,7 +353,7 @@ class MockIncludeDirective:
         self,
         renderer: DocutilsRenderer,
         name: str,
-        klass: Include,
+        klass: type[Include],
         arguments: list[str],
         options: dict[str, Any],
         body: list[str],


### PR DESCRIPTION
Fixes  #974