### PR TITLE
Enable using MockInliner in place of `Inliner` for runtime type checking

### DIFF
--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -34,6 +34,16 @@ class MockInliner:
     This is parsed to role functions.
     """
 
+    # Override the ``__class__`` attribute to enable runtime type checking.
+    # See https://beartype.readthedocs.io/en/latest/faq/#mock-types.
+    @property
+    def __class__(self) -> type:
+        return Inliner
+
+    @__class__.setter
+    def __class__(self, value: type) -> None:
+        raise NotImplementedError
+
     def __init__(self, renderer: DocutilsRenderer):
         """Initialize the mock inliner."""
         self._renderer = renderer


### PR DESCRIPTION
Fixes https://github.com/executablebooks/MyST-Parser/issues/1017.