### PR TITLE
Fallback to uri if alt text is empty in inline image

### DIFF
--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -1175,7 +1175,7 @@ class DocutilsRenderer(RendererProtocol):
 
         img_node["uri"] = destination
 
-        img_node["alt"] = self.renderInlineAsText(token.children or [])
+        img_node["alt"] = self.renderInlineAsText(token.children or []) or destination
 
         self.copy_attributes(
             token,

--- a/tests/test_renderers/fixtures/docutil_syntax_elements.md
+++ b/tests/test_renderers/fixtures/docutil_syntax_elements.md
@@ -172,6 +172,15 @@ Image empty:
         <image alt="" uri="">
 .
 
+Image without alt:
+.
+![](src)
+.
+<document source="notset">
+    <paragraph>
+        <image alt="src" uri="src">
+.
+
 Image with alt and title:
 .
 ![alt](src "title")

--- a/tests/test_renderers/fixtures/sphinx_syntax_elements.md
+++ b/tests/test_renderers/fixtures/sphinx_syntax_elements.md
@@ -172,6 +172,15 @@ Image empty:
         <image alt="" uri="">
 .
 
+Image without alt:
+.
+![](src)
+.
+<document source="<src>/index.md">
+    <paragraph>
+        <image alt="src" uri="src">
+.
+
 Image with alt and title:
 .
 ![alt](src "title")


### PR DESCRIPTION
Right now, it might be difficult to find the missing image on the page if a user has forgotten to add an alt text to it:
![image](https://github.com/user-attachments/assets/f049471a-9c04-4cae-b969-5a7437425b24)

I've added a fallback to use the image source as an alt text so that a broken image icon would appear on the page:
![image](https://github.com/user-attachments/assets/7d03d06e-0137-4dd2-8685-e2cef882d4fb)
