### PR TITLE
Aligns directive's `block_text` content to rST's

### DIFF
--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -1773,8 +1773,13 @@ class DocutilsRenderer(RendererProtocol):
                 lineno=position,
                 # the line offset of the first line of the content
                 content_offset=parsed.body_offset,
-                # a string containing the entire directive
-                block_text="\n".join(parsed.body),
+                # A string containing the entire directive, including options and full,
+                # unparsed content.
+                # XXX Ideally, and to mirros rST's behavior, it should also contain the
+                # complete directive header (i.e the "```{name} {arguments}" line), and
+                # the directive closing line (i.e. the "```" line), but that is not
+                # currently possible unless we refactor the parser.
+                block_text=content,
                 state=state,
                 state_machine=state_machine,
             )


### PR DESCRIPTION
In rST, a directive's `block_text` contains the entire directive, including options and full, unparsed content.

This aligns MyST parser to rST.

### Context

I stumbled upon this issue while implementing my own `click:example` and `click:run` directives within my Click Extra project: https://kdeldycke.github.io/click-extra/sphinx.html

My implementation is trying to report, within these directives, of the absolute line in the document where a problem occured. The line number and offset calculation works perfectly in rST, but [requires some hacks to report the right one in MyST](https://github.com/kdeldycke/click-extra/blob/7d076f8d708ac76e9916caf53fb441ca94b5d412/click_extra/sphinx.py#L251-L265). 

But even with these hacks, there is no way to retro-actively compute the absolute line number, because the directive object do not carry its unparsed content.

### Example

Compare a given rST directive defined as:

```rst
 .. click:run::
    :linenos:

    # This should fail due to variable conflict.
    isolated_filesystem = "Do not overwrite me!"
```

Its properties are:

```pycon
>>> print("\n".join(directive.content))
# This should fail due to variable conflict.
isolated_filesystem = "Do not overwrite me!"

>>> print(directive.block_text)
.. click:run::
    :linenos:

    # This should fail due to variable conflict.
    isolated_filesystem = "Do not overwrite me!"
```

And for its MyST equivalent:

````md
```{click:run}
:linenos:
# This should fail due to variable conflict.
isolated_filesystem = "Do not overwrite me!"
```
````

```pycon
>>> print("\n".join(directive.content))
# This should fail due to variable conflict.
isolated_filesystem = "Do not overwrite me!"

>>> print(directive.block_text)
# This should fail due to variable conflict.
isolated_filesystem = "Do not overwrite me!"
```


### Limitations

Note that it is not perfect, as it is supposed to also contain:
- the complete directive header (i.e the ` ```{name} {arguments}` first line), and
- the directive closing line (i.e. the ` ``` ` line).

But I doubt we can find a way to do it unless we introduce heavier refactor.
