### PR TITLE
🔧 Disable codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,15 +55,16 @@ jobs:
       run: |
         pytest --cov=myst_parser --cov-report=xml --cov-report=term-missing
         coverage xml
-    - name: Upload to Codecov
-      if: github.repository == 'executablebooks/MyST-Parser' && matrix.python-version == 3.11 && matrix.os == 'ubuntu-latest'
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        name: myst-parser-pytests
-        flags: pytests
-        file: ./coverage.xml
-        fail_ci_if_error: true
+    # TODO there is currently problem with this action and pull-requests from external forks
+    # - name: Upload to Codecov
+    #   if: github.repository == 'executablebooks/MyST-Parser' && matrix.python-version == 3.11 && matrix.os == 'ubuntu-latest'
+    #   uses: codecov/codecov-action@v4
+    #   with:
+    #     token: ${{ secrets.CODECOV_TOKEN }}
+    #     name: myst-parser-pytests
+    #     flags: pytests
+    #     file: ./coverage.xml
+    #     fail_ci_if_error: true
 
   check-myst-docutils:
 


### PR DESCRIPTION
there is currently problems with this action and pull-requests from external forks

```
Run codecov/codecov-action@v4
eventName: pull_request
baseRef: executablebooks:master | headRef: executablebooks:dependabot/github_actions/actions/setup-python-6
==> linux OS detected
https://cli.codecov.io/latest/linux/codecov.SHA256SUM
gpg: directory '/home/runner/.gnupg' created
gpg: keybox '/home/runner/.gnupg/pubring.kbx' created
gpg: /home/runner/.gnupg/trustdb.gpg: trustdb created
gpg: key 806BB28AED779869: public key "Codecov Uploader (Codecov Uploader Verification Key) <security@codecov.io>" imported
gpg: Total number processed: 1
gpg:               imported: 1
gpg: Signature made Mon Nov 10 14:58:43 2025 UTC
gpg:                using RSA key 27034E7FDB850E0BBC2C62FF806BB28AED779869
gpg: Good signature from "Codecov Uploader (Codecov Uploader Verification Key) <security@codecov.io>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: 2703 4E7F DB85 0E0B BC2C  62FF 806B B28A ED77 9869
==> Uploader SHASUM verified (80b5e6f898d6080be523f53ff169702a008a1c91b20c63c49df1175ed794d822  codecov)
==> Running version latest
Could not pull latest version information: SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
==> Running git config --global --add safe.directory /home/runner/work/MyST-Parser/MyST-Parser
/usr/bin/git config --global --add safe.directory /home/runner/work/MyST-Parser/MyST-Parser
==> Running command '/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov create-commit'
/home/runner/work/_actions/codecov/codecov-action/v4/dist/codecov create-commit --git-service github -C b658ac647cd794b254af98efe3e40bcffe687646 -Z
info - 2025-12-01 14:24:25,174 -- ci service found: github-actions
warning - 2025-12-01 14:24:25,214 -- Branch `dependabot/github_actions/actions/setup-python-6` is protected but no token was provided
warning - 2025-12-01 14:24:25,214 -- For information on Codecov upload tokens, see https://docs.codecov.com/docs/codecov-tokens
info - 2025-12-01 14:24:25,656 -- Process Commit creating complete
error - 2025-12-01 14:24:25,656 -- Commit creating failed: {"message":"Token required because branch is protected"}
Sentry is attempting to send 3 pending events
Waiting up to 2 seconds
Press Ctrl-C to quit
```