### PR TITLE
Unify the conftest imports and set the import mode to discover them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,7 @@ filterwarnings = [
     "ignore:.*The default for the setting.*:FutureWarning",
     "ignore:.*:PendingDeprecationWarning",
 ]
+addopts = "--import-mode=importlib"
 
 [tool.coverage.run]
 omit = ["*/_docs.py"]

--- a/tests/test_renderers/test_fixtures_docutils.py
+++ b/tests/test_renderers/test_fixtures_docutils.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from conftest import normalize_doctree_xml
+from tests.conftest import normalize_doctree_xml
 from docutils import __version_info__ as docutils_version
 from docutils.core import Publisher, publish_doctree
 from pytest_param_files import ParamTestData

--- a/tests/test_renderers/test_fixtures_docutils.py
+++ b/tests/test_renderers/test_fixtures_docutils.py
@@ -11,12 +11,12 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from tests.conftest import normalize_doctree_xml
 from docutils import __version_info__ as docutils_version
 from docutils.core import Publisher, publish_doctree
 from pytest_param_files import ParamTestData
 
 from myst_parser.parsers.docutils_ import Parser
+from tests.conftest import normalize_doctree_xml
 
 FIXTURE_PATH = Path(__file__).parent.joinpath("fixtures")
 

--- a/tests/test_renderers/test_include_directive.py
+++ b/tests/test_renderers/test_include_directive.py
@@ -3,10 +3,10 @@ from io import StringIO
 from pathlib import Path
 
 import pytest
-from tests.conftest import normalize_doctree_xml
 from docutils.core import publish_doctree
 
 from myst_parser.parsers.docutils_ import Parser
+from tests.conftest import normalize_doctree_xml
 
 FIXTURE_PATH = Path(__file__).parent.joinpath("fixtures")
 

--- a/tests/test_renderers/test_include_directive.py
+++ b/tests/test_renderers/test_include_directive.py
@@ -3,7 +3,7 @@ from io import StringIO
 from pathlib import Path
 
 import pytest
-from conftest import normalize_doctree_xml
+from tests.conftest import normalize_doctree_xml
 from docutils.core import publish_doctree
 
 from myst_parser.parsers.docutils_ import Parser

--- a/tests/test_renderers/test_myst_config.py
+++ b/tests/test_renderers/test_myst_config.py
@@ -5,7 +5,7 @@ from io import StringIO
 from pathlib import Path
 
 import pytest
-from conftest import normalize_doctree_xml
+from tests.conftest import normalize_doctree_xml
 from docutils import __version_info__ as docutils_version
 from docutils.core import Publisher, publish_string
 from pytest_param_files import ParamTestData

--- a/tests/test_renderers/test_myst_config.py
+++ b/tests/test_renderers/test_myst_config.py
@@ -5,12 +5,12 @@ from io import StringIO
 from pathlib import Path
 
 import pytest
-from tests.conftest import normalize_doctree_xml
 from docutils import __version_info__ as docutils_version
 from docutils.core import Publisher, publish_string
 from pytest_param_files import ParamTestData
 
 from myst_parser.parsers.docutils_ import Parser
+from tests.conftest import normalize_doctree_xml
 
 FIXTURE_PATH = Path(__file__).parent.joinpath("fixtures")
 INV_PATH = Path(__file__).parent.parent.absolute() / "static" / "objects_v2.inv"

--- a/tests/test_renderers/test_myst_refs.py
+++ b/tests/test_renderers/test_myst_refs.py
@@ -1,7 +1,7 @@
 import sys
 
 import pytest
-from conftest import normalize_doctree_xml
+from tests.conftest import normalize_doctree_xml
 from sphinx.util.console import strip_colors
 from sphinx_pytest.plugin import CreateDoctree
 

--- a/tests/test_renderers/test_myst_refs.py
+++ b/tests/test_renderers/test_myst_refs.py
@@ -1,9 +1,10 @@
 import sys
 
 import pytest
-from tests.conftest import normalize_doctree_xml
 from sphinx.util.console import strip_colors
 from sphinx_pytest.plugin import CreateDoctree
+
+from tests.conftest import normalize_doctree_xml
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The tests have two ways of importing from conftest: directly and via tests.conftest.
In Fedora I've encountered issues with running tests of 5.0.0 during the build.

When running the tests directly via `pytest`, the output is:

```
___________________ ERROR collecting tests/test_html/test_html_to_nodes.py ____________________ 
ImportError while importing test module
'/builddir/build/BUILD/python-myst-parser-5.0.0-build/MyST-Parser-5.0.0/tests/test_html/test_html_to_nodes.py'. 
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib64/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/test_html/test_html_to_nodes.py:9: in <module>
    from tests.conftest import normalize_doctree_xml
E   ModuleNotFoundError: No module named 'tests'
```

When running with `pytest --import-mode=importlib`, other tests raise ImportError:

```
_______________ ERROR collectingtests/test_renderers/test_fixtures_docutils.py _______________ 
ImportError while importing test module
'/builddir/build/BUILD/python-myst-parser-5.0.0-build/MyST-Parser-5.0.0/tests/test_renderers/test_fixtures_docutils.py'. 
Hint: make sure your test modules/packages have valid Python names. 
Traceback:
tests/test_renderers/test_fixtures_docutils.py:14: in <module>
    from conftest import normalize_doctree_xml
    E   ModuleNotFoundError: No module named 'conftest'
```

It's not possible to fix everything so that the direct imports from conftest are applied, because there are two conftest.py files present in the repository at different locations.

The fix applied imports from `tests.conftest` everywhere, which also requires a change in the import mode, added to pyproject.toml. The end result works consistently when invoked just with `pytest`.