### PR TITLE
🐛 FIX: Use docname instead of source path in warning locations

### DIFF
--- a/myst_parser/warnings_.py
+++ b/myst_parser/warnings_.py
@@ -126,7 +126,9 @@ def create_warning(
             message,
             type=type_str,
             subtype=subtype_str,
-            location=node if node is not None else (document["source"], line),
+            location=node
+            if node is not None
+            else (document.settings.env.docname, line),
         )
         if _is_suppressed_warning(
             type_str, subtype_str, document.settings.env.config.suppress_warnings

--- a/tests/test_sphinx/sourcedirs/substitutions_missing/conf.py
+++ b/tests/test_sphinx/sourcedirs/substitutions_missing/conf.py
@@ -1,0 +1,4 @@
+extensions = ["myst_parser"]
+exclude_patterns = ["_build"]
+myst_enable_extensions = ["substitution"]
+myst_substitutions = {"defined": "This is defined"}

--- a/tests/test_sphinx/sourcedirs/substitutions_missing/index.md
+++ b/tests/test_sphinx/sourcedirs/substitutions_missing/index.md
@@ -1,0 +1,5 @@
+# Title
+
+{{ defined }}
+
+{{ missing }}

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -452,6 +452,27 @@ def test_substitutions(
 
 
 @pytest.mark.sphinx(
+    buildername="html",
+    srcdir=os.path.join(SOURCE_DIR, "substitutions_missing"),
+    freshenv=True,
+)
+def test_substitutions_missing(
+    app,
+    status,
+    warning,
+):
+    """Test that missing substitution generate warning without '.rst' suffix in location."""
+    app.build()
+    assert "build succeeded" in status.getvalue()  # Build succeeded
+    warnings = warning.getvalue().strip().splitlines()
+    assert len(warnings) == 1
+    assert (
+        "index.md:5: WARNING: Substitution error:UndefinedError: 'missing' is undefined [myst.substitution]"
+        in warnings[0]
+    )
+
+
+@pytest.mark.sphinx(
     buildername="gettext", srcdir=os.path.join(SOURCE_DIR, "gettext"), freshenv=True
 )
 def test_gettext(


### PR DESCRIPTION
Changed warning location generation to use `document.settings.env.docname` instead of `document["source"]`. This ensures warning locations display clean file names (e.g., `index.md`) rather than full paths with potential `.rst` suffixes (e.g., `index.md.rst`).