### PR TITLE
🐛 FIX: Correctly encode "&" in Markdown URLs by not HTML-escaping refuri

### DIFF
--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -31,7 +31,6 @@ from docutils.statemachine import StringList
 from docutils.utils import Reporter, SystemMessage, new_document
 from docutils.utils.code_analyzer import Lexer, LexerError, NumberLines
 from markdown_it import MarkdownIt
-from markdown_it.common.utils import escapeHtml
 from markdown_it.renderer import RendererProtocol
 from markdown_it.token import Token
 from markdown_it.tree import SyntaxTreeNode
@@ -954,7 +953,7 @@ class DocutilsRenderer(RendererProtocol):
             if "classes" in conversion:
                 ref_node["classes"].extend(conversion["classes"])
 
-        ref_node["refuri"] = escapeHtml(uri)
+        ref_node["refuri"] = uri
         if implicit_text is not None:
             with self.current_node_context(ref_node, append=True):
                 self.current_node.append(nodes.Text(implicit_text))

--- a/tests/test_renderers/fixtures/docutil_link_resolution.md
+++ b/tests/test_renderers/fixtures/docutil_link_resolution.md
@@ -3,6 +3,7 @@
 [alt2](https://www.google.com)
 [](https://www.google.com)
 <https://www.google.com>
+<https://example.com?foo=bar&a=1>
 .
 <document source="<src>/index.md">
     <paragraph>
@@ -13,6 +14,9 @@
 
         <reference refuri="https://www.google.com">
             https://www.google.com
+
+        <reference refuri="https://example.com?foo=bar&a=1">
+            https://example.com?foo=bar&a=1
 .
 
 [missing] 

--- a/tests/test_renderers/fixtures/docutil_syntax_elements.md
+++ b/tests/test_renderers/fixtures/docutil_syntax_elements.md
@@ -747,3 +747,33 @@ a = 1
         <paragraph>
             <reference refname="target">
 .
+
+URL with ampersand in query string
+.
+[link](https://example.com/search?q=foo&bar=baz)
+.
+<document source="notset">
+    <paragraph>
+        <reference refuri="https://example.com/search?q=foo&bar=baz">
+            link
+.
+
+URL with angle brackets (percent-encoded by normalizeLink, not HTML-escaped)
+.
+[link](https://example.com/path<with>brackets)
+.
+<document source="notset">
+    <paragraph>
+        <reference refuri="https://example.com/path%3Cwith%3Ebrackets">
+            link
+.
+
+URL with double quotes (percent-encoded by normalizeLink, not HTML-escaped)
+.
+[link](https://example.com/path"with"quotes)
+.
+<document source="notset">
+    <paragraph>
+        <reference refuri="https://example.com/path%22with%22quotes">
+            link
+.

--- a/tests/test_renderers/fixtures/myst-config.txt
+++ b/tests/test_renderers/fixtures/myst-config.txt
@@ -143,7 +143,7 @@ www.commonmark.org/he<lp
         <reference refuri="http://www.google.com/search?q=(business))+ok">
             www.google.com/search?q=(business))+ok
     <paragraph>
-        <reference refuri="http://www.google.com/search?q=commonmark&amp;hl=en">
+        <reference refuri="http://www.google.com/search?q=commonmark&hl=en">
             www.google.com/search?q=commonmark&hl=en
     <paragraph>
         <reference refuri="http://www.google.com/search?q=commonmark">

--- a/tests/test_renderers/fixtures/sphinx_link_resolution.md
+++ b/tests/test_renderers/fixtures/sphinx_link_resolution.md
@@ -3,6 +3,7 @@
 [alt2](https://www.google.com)
 [](https://www.google.com)
 <https://www.google.com>
+<https://example.com?foo=bar&a=1>
 .
 <document source="<src>/index.md">
     <paragraph>
@@ -13,6 +14,9 @@
 
         <reference refuri="https://www.google.com">
             https://www.google.com
+
+        <reference refuri="https://example.com?foo=bar&a=1">
+            https://example.com?foo=bar&a=1
 .
 
 [missing] 

--- a/tests/test_sphinx/sourcedirs/references/index.md
+++ b/tests/test_sphinx/sourcedirs/references/index.md
@@ -8,6 +8,8 @@
 
 [nested *syntax*](https://example.com)
 
+[query params](https://example.com?foo=bar&a=1)
+
 [](title)
 
 [plain text](title)

--- a/tests/test_sphinx/test_sphinx_builds/test_references.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.html
@@ -34,6 +34,11 @@
      </a>
     </p>
     <p>
+     <a class="reference external" href="https://example.com?foo=bar&amp;a=1">
+      query params
+     </a>
+    </p>
+    <p>
      <a class="reference internal" href="#title">
       <span class="std std-ref">
        Title with nested a=1

--- a/tests/test_sphinx/test_sphinx_builds/test_references.resolved.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.resolved.xml
@@ -19,6 +19,9 @@
                 <emphasis>
                     syntax
         <paragraph>
+            <reference refuri="https://example.com?foo=bar&a=1">
+                query params
+        <paragraph>
             <reference internal="True" refid="title">
                 <inline classes="std std-ref">
                     Title with nested a=1

--- a/tests/test_sphinx/test_sphinx_builds/test_references.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_references.xml
@@ -19,6 +19,9 @@
                 <emphasis>
                     syntax
         <paragraph>
+            <reference refuri="https://example.com?foo=bar&a=1">
+                query params
+        <paragraph>
             <pending_xref refdoc="index" refdomain="True" refexplicit="False" reftarget="title" reftype="myst">
                 <inline classes="xref myst">
         <paragraph>


### PR DESCRIPTION
`escapeHtml` was called on the URL before storing it in the `refuri` attribute of a reference node, converting `&` to `&amp;`. This caused double-escaping when Sphinx's HTML writer later escaped the `&` in `&amp;` to produce `&amp;amp;` in the final `href` attribute, breaking URLs with query parameters.

The `refuri` attribute should hold the raw URL; HTML-escaping is the responsibility of the output writer. The other characters `escapeHtml` converts (`<`, `>`, `"`) are already percent-encoded by `normalizeLink` before reaching this point, so removing the call has no other effect.

Found while taking a look at https://bugzilla.mozilla.org/show_bug.cgi?id=2023603.

Discovered that there exist a similar patch shortly before creating this pull request. So this is an alternative approach to https://github.com/executablebooks/MyST-Parser/pull/929. I've imported the tests from the other patch to verify that the patch behaves the same.

Would fix https://github.com/executablebooks/MyST-Parser/issues/760, fix https://github.com/executablebooks/MyST-Parser/issues/1028, and fix #1116.