### PR TITLE
🐛 FIX `RemovedInSphinx10Warning` for inventory item iteration

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -197,8 +197,9 @@ rediraffe_redirects = {
 tippy_skip_anchor_classes = ("headerlink", "sd-stretched-link", "sd-rounded-pill")
 tippy_anchor_parent_selector = "article.bd-article"
 tippy_rtd_urls = [
-    "https://www.sphinx-doc.org/en/master",
-    "https://markdown-it-py.readthedocs.io/en/latest",
+    # TODO these are failing the build: Expecting value: line 1 column 1 (char 0)
+    # "https://www.sphinx-doc.org/en/master",
+    # "https://markdown-it-py.readthedocs.io/en/latest",
 ]
 # TODO failing
 tippy_enable_wikitips = False

--- a/docs/syntax/cross-referencing.md
+++ b/docs/syntax/cross-referencing.md
@@ -379,6 +379,8 @@ Sphinx offers numerous [roles for referencing](#usage/restructuredtext/roles) sp
 These can also be used within MyST documents, although it is recommended to use the Markdown syntax where possible, which is more portable and native to MyST.
 
 :::{myst-example}
+Sphinx roles:
+
 - {ref}`syntax/referencing`, {ref}`Explicit text <syntax/referencing>`
 - {term}`my other term`
 - {doc}`../intro`, {doc}`Explicit text <../intro>`
@@ -387,7 +389,7 @@ These can also be used within MyST documents, although it is recommended to use 
 - {external:class}`sphinx.application.Sphinx`, {external:class}`Explicit text <sphinx.application.Sphinx>`
 - {external+sphinx:ref}`code-examples`, {external+sphinx:ref}`Explicit text <code-examples>`
 
----
+MyST native:
 
 - <project:#syntax/referencing>, [][syntax], [Explicit text][syntax]
 - [](<#my other term>)

--- a/docs/syntax/organising_content.md
+++ b/docs/syntax/organising_content.md
@@ -15,11 +15,15 @@ All headings at the root level of the document are included in the Table of Cont
 
 Many HTML themes will already include this ToC in a sidebar, but you can also include it in the main content of the page using the contents {{directive}}:
 
-:::{myst-example}
+````myst
 ```{contents} Table of Contents
 :depth: 3
 ```
-:::
+````
+
+```{contents} Table of Contents
+:depth: 3
+```
 
 Options:
 

--- a/myst_parser/inventory.py
+++ b/myst_parser/inventory.py
@@ -366,7 +366,15 @@ def filter_sphinx_inventories(
                 continue
             for target in data:
                 if match_with_wildcard(target, targets):
-                    project, version, loc, text = data[target]
+                    data_target = data[target]
+                    if hasattr(data_target, "project_name"):
+                        # Sphinx >= 8.2
+                        project = data_target.project_name
+                        version = data_target.project_version
+                        loc = data_target.uri
+                        text = data_target.display_name
+                    else:
+                        project, version, loc, text = data_target
                     yield (
                         InvMatch(
                             inv=inv_name,


### PR DESCRIPTION
Fixes the deprecation warning from Sphinx >= 8.2:

```
RemovedInSphinx10Warning: The iter() interface for _InventoryItem objects is deprecated.
Please access the `project_name`, `project_version`, `uri`, and `displayname` attributes directly.
```

The previous code unpacked `_InventoryItem` as a tuple (`project, version, loc, text = data[target]`), which triggers the warning.

This uses `hasattr` to detect whether the new attribute-based API is available and falls back to tuple unpacking for older Sphinx versions. This approach is more robust than version checking (cf. #1079 which used `sphinx.__version_info__` — an attribute that doesn't exist; the correct attribute is `sphinx.version_info`).

Note: the correct attribute name on `_InventoryItem` is `display_name` (with underscore), despite the warning message saying `displayname`.