### PR TITLE
🐛 FIX: Pin mdit-py-plugins>=0.6.1 for nested field list fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "docutils>=0.20,<0.23",
     "jinja2", # required for substitutions, but let sphinx choose version
     "markdown-it-py~=4.2",
-    "mdit-py-plugins~=0.6",
+    "mdit-py-plugins~=0.6,>=0.6.1",
     "pyyaml",
     "sphinx>=8,<10",
 ]


### PR DESCRIPTION
Requires the fix from mdit-py-plugins#139 which corrects field lists inside list items (and other indented containers) incorrectly nesting each field inside the previous one.