### PR TITLE
🐛 FIX: several small correctness bugs in the docutils renderer

### DIFF
--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -1644,6 +1644,7 @@ class DocutilsRenderer(RendererProtocol):
                             line=token_line(child),
                         )
                         self.current_node += [error]
+                        continue
                     with self.current_node_context(item):
                         definition = nodes.definition()
                         self.add_line_and_source_path(definition, child)
@@ -1690,7 +1691,7 @@ class DocutilsRenderer(RendererProtocol):
                 with self.current_node_context(field_name):
                     self.render_children(child)
                 field_body = nodes.field_body()
-                self.add_line_and_source_path(field_name, child)
+                self.add_line_and_source_path(field_body, child)
                 field += field_body
                 if children and children[0].type == "fieldlist_body":
                     child = children.pop(0)

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -1634,21 +1634,27 @@ class DocutilsRenderer(RendererProtocol):
                             )
                         self.current_node.append(term)
                 elif child.type == "dd":
+                    error = None
                     if item is None:
                         error = self.reporter.error(
                             (
                                 "Found a definition in a definition list, "
                                 "with no preceding term"
                             ),
-                            # nodes.literal_block(content, content),
                             line=token_line(child),
                         )
-                        self.current_node += [error]
-                        continue
+                        # create an item with an empty term,
+                        # so that the definition content is not dropped
+                        item = nodes.definition_list_item()
+                        self.add_line_and_source_path(item, child)
+                        self.current_node.append(item)
+                        item.append(nodes.term())
                     with self.current_node_context(item):
                         definition = nodes.definition()
                         self.add_line_and_source_path(definition, child)
                         with self.current_node_context(definition, append=True):
+                            if error is not None:
+                                self.current_node.append(error)
                             self.render_children(child)
                 else:
                     error_msg = self.reporter.error(
@@ -1695,6 +1701,8 @@ class DocutilsRenderer(RendererProtocol):
                 field += field_body
                 if children and children[0].type == "fieldlist_body":
                     child = children.pop(0)
+                    # prefer the body token for the source line, if available
+                    self.add_line_and_source_path(field_body, child)
                     with self.current_node_context(field_body):
                         self.render_children(child)
 

--- a/myst_parser/mdit_to_docutils/transforms.py
+++ b/myst_parser/mdit_to_docutils/transforms.py
@@ -160,8 +160,6 @@ class ResolveAnchorIds(Transform):
             labelid = self.document.nameids[name]
             if labelid is None:
                 continue
-            if labelid is None:
-                continue
             node = self.document.ids[labelid]
             if isinstance(node, nodes.target) and "refid" in node:
                 # indirect hyperlink targets

--- a/myst_parser/parsers/docutils_.py
+++ b/myst_parser/parsers/docutils_.py
@@ -29,7 +29,7 @@ from myst_parser.mdit_to_docutils.transforms import (
     SortFootnotes,
     UnreferencedFootnotesDetector,
 )
-from myst_parser.parsers.mdit import create_md_parser
+from myst_parser.parsers.mdit import create_md_parser, linkify_available
 from myst_parser.warnings_ import MystWarnings, create_warning
 
 
@@ -298,6 +298,16 @@ class Parser(RstParser):
                 "The `attrs_image` extension is deprecated, "
                 "please use `attrs_inline` instead.",
                 MystWarnings.DEPRECATED,
+            )
+
+        if "linkify" in config.enable_extensions and not linkify_available():
+            create_warning(
+                document,
+                "The `linkify` extension is enabled, "
+                "but the `linkify-it-py` package is not installed, "
+                "so it has been disabled "
+                "(install it with e.g. `pip install linkify-it-py`).",
+                MystWarnings.LINKIFY,
             )
 
         # update the global config with the file-level config

--- a/myst_parser/parsers/mdit.py
+++ b/myst_parser/parsers/mdit.py
@@ -4,7 +4,6 @@ which creates a parser from the config.
 
 from __future__ import annotations
 
-import warnings
 from collections.abc import Callable
 
 from markdown_it import MarkdownIt
@@ -27,13 +26,18 @@ from mdit_py_plugins.wordcount import wordcount_plugin
 from myst_parser.config.main import MdParserConfig
 
 
+def linkify_available() -> bool:
+    """Return whether the optional ``linkify-it-py`` dependency is installed."""
+    # this is the same symbol that ``MarkdownIt`` consults internally
+    from markdown_it.main import linkify_it
+
+    return linkify_it is not None
+
+
 def create_md_parser(
     config: MdParserConfig, renderer: Callable[[MarkdownIt], RendererProtocol]
 ) -> MarkdownIt:
     """Return a Markdown parser with the required MyST configuration."""
-
-    # TODO warn if linkify required and linkify-it-py not installed
-    # (currently the parse will unceremoniously except)
 
     if config.commonmark_only:
         # see https://spec.commonmark.org/
@@ -71,19 +75,13 @@ def create_md_parser(
     if "replacements" in config.enable_extensions:
         md.enable("replacements")
         typographer = True
-    if "linkify" in config.enable_extensions:
-        if md.linkify is None:
-            warnings.warn(
-                "The `linkify` extension is enabled, but the `linkify-it-py` package "
-                "is not installed, so it has been disabled. "
-                "Install it with `pip install linkify-it-py` "
-                "(or `pip install myst-parser[linkify]`), "
-                "or remove `linkify` from `myst_enable_extensions`.",
-                stacklevel=2,
-            )
-        else:
-            md.enable("linkify")
-            md.linkify.set({"fuzzy_link": config.linkify_fuzzy_links})
+    linkify_enabled = False
+    if "linkify" in config.enable_extensions and md.linkify is not None:
+        # if linkify-it-py is not installed, the extension is simply disabled here;
+        # a warning is emitted by the sphinx/docutils parsers (see linkify_available)
+        md.enable("linkify")
+        md.linkify.set({"fuzzy_link": config.linkify_fuzzy_links})
+        linkify_enabled = True
     if "gfm_autolink" in config.enable_extensions:
         md.use(gfm_autolink_plugin)
     if "strikethrough" in config.enable_extensions:
@@ -140,9 +138,7 @@ def create_md_parser(
     md.options.update(
         {
             "typographer": typographer,
-            "linkify": (
-                "linkify" in config.enable_extensions and md.linkify is not None
-            ),
+            "linkify": linkify_enabled,
             "myst_config": config,
         }
     )

--- a/myst_parser/parsers/mdit.py
+++ b/myst_parser/parsers/mdit.py
@@ -71,9 +71,15 @@ def create_md_parser(
         md.enable("replacements")
         typographer = True
     if "linkify" in config.enable_extensions:
+        if md.linkify is None:
+            raise ImportError(
+                "The `linkify` extension requires the `linkify-it-py` package, "
+                "which is not installed. Install it with `pip install linkify-it-py` "
+                "(or `pip install myst-parser[linkify]`), "
+                "or remove `linkify` from `myst_enable_extensions`."
+            )
         md.enable("linkify")
-        if md.linkify is not None:
-            md.linkify.set({"fuzzy_link": config.linkify_fuzzy_links})
+        md.linkify.set({"fuzzy_link": config.linkify_fuzzy_links})
     if "gfm_autolink" in config.enable_extensions:
         md.use(gfm_autolink_plugin)
     if "strikethrough" in config.enable_extensions:

--- a/myst_parser/parsers/mdit.py
+++ b/myst_parser/parsers/mdit.py
@@ -4,6 +4,7 @@ which creates a parser from the config.
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 
 from markdown_it import MarkdownIt
@@ -72,14 +73,17 @@ def create_md_parser(
         typographer = True
     if "linkify" in config.enable_extensions:
         if md.linkify is None:
-            raise ImportError(
-                "The `linkify` extension requires the `linkify-it-py` package, "
-                "which is not installed. Install it with `pip install linkify-it-py` "
+            warnings.warn(
+                "The `linkify` extension is enabled, but the `linkify-it-py` package "
+                "is not installed, so it has been disabled. "
+                "Install it with `pip install linkify-it-py` "
                 "(or `pip install myst-parser[linkify]`), "
-                "or remove `linkify` from `myst_enable_extensions`."
+                "or remove `linkify` from `myst_enable_extensions`.",
+                stacklevel=2,
             )
-        md.enable("linkify")
-        md.linkify.set({"fuzzy_link": config.linkify_fuzzy_links})
+        else:
+            md.enable("linkify")
+            md.linkify.set({"fuzzy_link": config.linkify_fuzzy_links})
     if "gfm_autolink" in config.enable_extensions:
         md.use(gfm_autolink_plugin)
     if "strikethrough" in config.enable_extensions:
@@ -136,7 +140,9 @@ def create_md_parser(
     md.options.update(
         {
             "typographer": typographer,
-            "linkify": "linkify" in config.enable_extensions,
+            "linkify": (
+                "linkify" in config.enable_extensions and md.linkify is not None
+            ),
             "myst_config": config,
         }
     )

--- a/myst_parser/sphinx_ext/main.py
+++ b/myst_parser/sphinx_ext/main.py
@@ -13,6 +13,7 @@ from myst_parser.parsers.docutils_ import (
     depart_container_html,
     visit_container_html,
 )
+from myst_parser.parsers.mdit import linkify_available
 from myst_parser.warnings_ import MystWarnings
 
 
@@ -95,4 +96,17 @@ def create_myst_config(app):
             "please use `attrs_inline` instead.",
             type="myst",
             subtype=MystWarnings.DEPRECATED.value,
+        )
+
+    if (
+        "linkify" in app.env.myst_config.enable_extensions
+        and not linkify_available()
+    ):
+        logger.warning(
+            "The `linkify` extension is enabled, but the `linkify-it-py` package "
+            "is not installed, so it has been disabled "
+            "(install it with e.g. `pip install linkify-it-py` "
+            "or `pip install myst-parser[linkify]`).",
+            type="myst",
+            subtype=MystWarnings.LINKIFY.value,
         )

--- a/myst_parser/sphinx_ext/main.py
+++ b/myst_parser/sphinx_ext/main.py
@@ -98,10 +98,7 @@ def create_myst_config(app):
             subtype=MystWarnings.DEPRECATED.value,
         )
 
-    if (
-        "linkify" in app.env.myst_config.enable_extensions
-        and not linkify_available()
-    ):
+    if "linkify" in app.env.myst_config.enable_extensions and not linkify_available():
         logger.warning(
             "The `linkify` extension is enabled, but the `linkify-it-py` package "
             "is not installed, so it has been disabled "

--- a/myst_parser/warnings_.py
+++ b/myst_parser/warnings_.py
@@ -54,6 +54,8 @@ class MystWarnings(Enum):
     """A legacy domain found, which does not support `resolve_any_xref`."""
 
     # extensions
+    LINKIFY = "linkify"
+    """The linkify extension is enabled, but linkify-it-py is not installed."""
     HEADING_SLUG = "heading_slug"
     """An error occurred computing a heading slug."""
     STRIKETHROUGH = "strikethrough"

--- a/tests/test_docutils.py
+++ b/tests/test_docutils.py
@@ -128,3 +128,44 @@ def test_include_from_rst(tmp_path):
             """
         ).strip()
     )
+
+
+def test_field_list_body_source_line():
+    """A ``field_body`` node should carry its own source line.
+
+    Regression: ``render_field_list`` previously stamped the line/source onto the
+    ``field_name`` twice, leaving the ``field_body`` with no source mapping.
+    """
+    from docutils import nodes
+    from docutils.core import publish_doctree
+
+    doctree = publish_doctree(
+        source=":name: value\n",
+        parser=Parser(),
+        settings_overrides={"myst_enable_extensions": ["fieldlist"]},
+    )
+    bodies = list(doctree.findall(nodes.field_body))
+    assert bodies, "expected a field_body node"
+    field_name = bodies[0].parent[0]
+    assert bodies[0].line == field_name.line
+    assert bodies[0].line  # a real line, not 0/None
+
+
+def test_linkify_requires_linkify_it_py(monkeypatch):
+    """Enabling ``linkify`` without ``linkify-it-py`` raises a clear error.
+
+    Regression: previously the parse would fail later with an opaque
+    ``AttributeError`` on ``None``.
+    """
+    import markdown_it.main
+    import pytest
+
+    from myst_parser.config.main import MdParserConfig
+    from myst_parser.mdit_to_docutils.base import DocutilsRenderer
+    from myst_parser.parsers.mdit import create_md_parser
+
+    monkeypatch.setattr(markdown_it.main, "linkify_it", None)
+    with pytest.raises(ImportError, match="linkify-it-py"):
+        create_md_parser(
+            MdParserConfig(enable_extensions={"linkify"}), DocutilsRenderer
+        )

--- a/tests/test_docutils.py
+++ b/tests/test_docutils.py
@@ -151,8 +151,8 @@ def test_field_list_body_source_line():
     assert bodies[0].line  # a real line, not 0/None
 
 
-def test_linkify_requires_linkify_it_py(monkeypatch):
-    """Enabling ``linkify`` without ``linkify-it-py`` raises a clear error.
+def test_linkify_disabled_without_linkify_it_py(monkeypatch):
+    """Enabling ``linkify`` without ``linkify-it-py`` warns and disables it.
 
     Regression: previously the parse would fail later with an opaque
     ``AttributeError`` on ``None``.
@@ -165,7 +165,10 @@ def test_linkify_requires_linkify_it_py(monkeypatch):
     from myst_parser.parsers.mdit import create_md_parser
 
     monkeypatch.setattr(markdown_it.main, "linkify_it", None)
-    with pytest.raises(ImportError, match="linkify-it-py"):
-        create_md_parser(
+    with pytest.warns(UserWarning, match="linkify-it-py"):
+        md = create_md_parser(
             MdParserConfig(enable_extensions={"linkify"}), DocutilsRenderer
         )
+    assert md.options["linkify"] is False
+    # the parse must no longer crash
+    md.parse("see https://example.com\n")

--- a/tests/test_docutils.py
+++ b/tests/test_docutils.py
@@ -13,7 +13,6 @@ from markdown_it.token import Token
 
 from myst_parser.config.main import MdParserConfig
 from myst_parser.mdit_to_docutils.base import DocutilsRenderer, make_document
-from myst_parser.parsers.mdit import create_md_parser
 from myst_parser.parsers.docutils_ import (
     Parser,
     attr_to_optparse_option,
@@ -25,6 +24,7 @@ from myst_parser.parsers.docutils_ import (
     cli_xml,
     to_html5_demo,
 )
+from myst_parser.parsers.mdit import create_md_parser
 
 
 def test_attr_to_optparse_option():

--- a/tests/test_docutils.py
+++ b/tests/test_docutils.py
@@ -1,10 +1,19 @@
 import contextlib
+import importlib.util
 import io
 from dataclasses import dataclass, field, fields
 from textwrap import dedent
 from typing import Literal
 
-from myst_parser.mdit_to_docutils.base import make_document
+import markdown_it.main
+import pytest
+from docutils import nodes
+from docutils.core import publish_doctree
+from markdown_it.token import Token
+
+from myst_parser.config.main import MdParserConfig
+from myst_parser.mdit_to_docutils.base import DocutilsRenderer, make_document
+from myst_parser.parsers.mdit import create_md_parser
 from myst_parser.parsers.docutils_ import (
     Parser,
     attr_to_optparse_option,
@@ -136,9 +145,6 @@ def test_field_list_body_source_line():
     Regression: ``render_field_list`` previously stamped the line/source onto the
     ``field_name`` twice, leaving the ``field_body`` with no source mapping.
     """
-    from docutils import nodes
-    from docutils.core import publish_doctree
-
     doctree = publish_doctree(
         source=":name: value\n",
         parser=Parser(),
@@ -146,29 +152,92 @@ def test_field_list_body_source_line():
     )
     bodies = list(doctree.findall(nodes.field_body))
     assert bodies, "expected a field_body node"
-    field_name = bodies[0].parent[0]
-    assert bodies[0].line == field_name.line
     assert bodies[0].line  # a real line, not 0/None
 
 
 def test_linkify_disabled_without_linkify_it_py(monkeypatch):
     """Enabling ``linkify`` without ``linkify-it-py`` warns and disables it.
 
-    Regression: previously the parse would fail later with an opaque
-    ``AttributeError`` on ``None``.
+    Regression: previously the first parse crashed with
+    ``ModuleNotFoundError("Linkify enabled but not installed.")``.
     """
-    import markdown_it.main
-    import pytest
-
-    from myst_parser.config.main import MdParserConfig
-    from myst_parser.mdit_to_docutils.base import DocutilsRenderer
-    from myst_parser.parsers.mdit import create_md_parser
-
     monkeypatch.setattr(markdown_it.main, "linkify_it", None)
-    with pytest.warns(UserWarning, match="linkify-it-py"):
-        md = create_md_parser(
-            MdParserConfig(enable_extensions={"linkify"}), DocutilsRenderer
-        )
+    # the parser factory silently disables the extension (no crash on parse)
+    md = create_md_parser(
+        MdParserConfig(enable_extensions={"linkify"}), DocutilsRenderer
+    )
     assert md.options["linkify"] is False
-    # the parse must no longer crash
     md.parse("see https://example.com\n")
+    # the docutils parser emits a suppressible myst warning
+    stream = io.StringIO()
+    publish_doctree(
+        source="see https://example.com\n",
+        parser=Parser(),
+        settings_overrides={
+            "myst_enable_extensions": ["linkify"],
+            "warning_stream": stream,
+        },
+    )
+    assert "[myst.linkify]" in stream.getvalue()
+    stream = io.StringIO()
+    publish_doctree(
+        source="see https://example.com\n",
+        parser=Parser(),
+        settings_overrides={
+            "myst_enable_extensions": ["linkify"],
+            "myst_suppress_warnings": ["myst.linkify"],
+            "warning_stream": stream,
+        },
+    )
+    assert "[myst.linkify]" not in stream.getvalue()
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("linkify_it") is None,
+    reason="linkify-it-py not installed",
+)
+def test_linkify_no_warning_when_available():
+    """No warning is emitted when ``linkify-it-py`` is installed."""
+    stream = io.StringIO()
+    publish_doctree(
+        source="see https://example.com\n",
+        parser=Parser(),
+        settings_overrides={
+            "myst_enable_extensions": ["linkify"],
+            "warning_stream": stream,
+        },
+    )
+    assert "[myst.linkify]" not in stream.getvalue()
+
+
+def test_definition_list_orphan_definition():
+    """A definition with no preceding term errors, but keeps its content.
+
+    Not reachable via the deflist plugin (which never emits an orphan ``dd``),
+    so constructed as a synthetic token stream.
+    """
+    md = create_md_parser(
+        MdParserConfig(enable_extensions={"deflist"}), DocutilsRenderer
+    )
+    tokens = [
+        Token("dl_open", "dl", 1, map=[0, 2]),
+        Token("dd_open", "dd", 1, map=[0, 1]),
+        Token("paragraph_open", "p", 1, map=[0, 1]),
+        Token(
+            "inline",
+            "",
+            0,
+            content="important content",
+            map=[0, 1],
+            children=[Token("text", "", 0, content="important content")],
+        ),
+        Token("paragraph_close", "p", -1),
+        Token("dd_close", "dd", -1),
+        Token("dl_close", "dl", -1),
+    ]
+    document = make_document("source.md")
+    md.options["document"] = document
+    md.renderer.render(tokens, md.options, {})
+    output = document.pformat()
+    assert "no preceding term" in output
+    assert "important content" in output


### PR DESCRIPTION
A small batch of isolated, low-risk correctness fixes in the docutils renderer, each independent of the others.

### Changes

- **`render_field_list`** (`mdit_to_docutils/base.py`) — apply the source line/path to the `field_body` node (it was stamping `field_name` a second time, so field bodies had no source mapping); when a body token is present, prefer it for the source line.
- **`render_dl`** (`mdit_to_docutils/base.py`) — a definition (`dd`) with no preceding term (`dt`) previously fell into `current_node_context(item)` with `item is None` (an `AttributeError` crash path). It now reports the error and renders the definition into a synthesized item with an empty term, so the content is preserved and the error message sits validly inside the `definition` (not as a direct child of the `definition_list`). Not reachable via the deflist plugin (it never emits an orphan `dd`), so covered by a synthetic-token regression test.
- **`ResolveAnchorIds`** (`mdit_to_docutils/transforms.py`) — remove a duplicated `if labelid is None: continue` (dead copy-paste).
- **`linkify` without `linkify-it-py`** — previously the first parse crashed with `ModuleNotFoundError("Linkify enabled but not installed.")`. Now:
  - `create_md_parser` silently disables the extension (single `linkify_enabled` flag, also used for `md.options["linkify"]`), so builds complete;
  - a warning with a new suppressible **`myst.linkify`** subtype is emitted once per build via the sphinx logger (`create_myst_config`) and per document via `create_warning` in the docutils parser — following the same pattern as the existing `attrs_image` warning, so it is visible to `sphinx-build -W` and manageable via `suppress_warnings` / `myst_suppress_warnings`.
  - This implements the old `# TODO warn if linkify required and linkify-it-py not installed` (comment removed).

### Tests

New regression tests in `tests/test_docutils.py`:
- `test_field_list_body_source_line` — `field_body` carries a real source line.
- `test_linkify_disabled_without_linkify_it_py` — no crash, `md.options["linkify"] is False`, the `[myst.linkify]` warning is emitted and is suppressible.
- `test_linkify_no_warning_when_available` — no warning when the dependency is installed (skipped where it isn't).
- `test_definition_list_orphan_definition` — orphan `dd` errors but keeps its content.

Full suite locally: all pass except `test_cmdline[40-linkify]` and `test_extended_syntaxes*`, which fail only in an environment without `linkify-it-py` installed (they fail on `master` there too); they pass in CI where the `[linkify]` extra is present.

### Notes

- One edge intentionally left silent: `linkify` enabled only via per-file front matter (not global config) disables without the build-level warning — the config-site checks mirror the existing `attrs_image` pattern; the parser-level disable is the backstop.
- No `CHANGELOG.md` entry, per the release-time batching of the changelog.