### PR TITLE
🔧 Disable "colorrows" latex table style to fix PDF docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -208,6 +208,10 @@ tippy_enable_wikitips = False
 # -- LaTeX output -------------------------------------------------
 
 latex_engine = "xelatex"
+# drop the default "colorrows" style: colortbl in TeX Live 2026 breaks it
+# (https://github.com/sphinx-doc/sphinx/issues/14465);
+# it can be restored once CI runs a Sphinx release (>=9.1.1) containing the fix
+latex_table_style = ["booktabs"]
 
 # -- Local Sphinx extensions -------------------------------------------------
 


### PR DESCRIPTION
Fixes the failing `build-doc-formats` / latex ("Make PDF") CI job, which has been broken on all branches since the unpinned `ghcr.io/xu-cheng/texlive-full:latest` image picked up TeX Live 2026 (first observed failure after 2026-06-29). The failure is pre-existing and unrelated to any recent PR.

## Root cause

TeX Live 2026 ships colortbl rebuilt on the array 2026/02/24 hooks, under which `\CT@everycr` and `\everycr` become the same register. Sphinx's `colorrows` table style executes `\global\CT@everycr{\the\everycr}` per table, which is now self-referential, so the PDF build dies with `TeX capacity exceeded, sorry [input stack size=10000]` at the first table.

This is upstream sphinx-doc/sphinx#14465, fixed and milestoned for Sphinx 9.1.1 — but the latest release is 9.1.0, so CI cannot pick up the fix yet.

## Fix

One line in `docs/conf.py`: `latex_table_style = ["booktabs"]` (dropping `colorrows` from the default `["booktabs", "colorrows"]`). Without the `colorrows` package option, the affected row-colour macros are never activated. Cosmetic effect only: PDF tables lose alternating row shading. The line is commented so it can be reverted once CI runs a Sphinx release containing the upstream fix.

## Verification

- Built the docs with the exact CI command (`sphinx-build -nW --keep-going -b latex`); the only warnings are offline-environment intersphinx noise, none from this change.
- Generated preamble changes from `\PassOptionsToPackage{booktabs}{sphinx}` + `\PassOptionsToPackage{colorrows}{sphinx}` to the `booktabs` line only; `colorrows` no longer appears anywhere in the `.tex`.
- All three self-referential `\CT@everycr` assignment sites in `sphinxlatextables.sty` are only wired in by the colorrows table class, which the writer no longer emits.
- Same workaround reported effective by the upstream issue reporter.

A complementary hardening (pinning `texlive_version` via xu-cheng/latex-action v3, cf. #803) would prevent future image drift, but is left out to keep this a minimal unbreak.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GByoptRecR2GAwj5qrLz6C)_