### PR TITLE
use pathlib

### DIFF
--- a/.github/workflows/docutils_setup.py
+++ b/.github/workflows/docutils_setup.py
@@ -2,6 +2,7 @@
 """Script to convert package setup to myst-docutils."""
 
 import sys
+from pathlib import Path
 
 import tomlkit
 
@@ -43,15 +44,12 @@ def modify_readme(content: str) -> str:
 
 
 if __name__ == "__main__":
-    project_path = sys.argv[1]
-    readme_path = sys.argv[2]
-    with open(project_path) as f:
-        content = f.read()
+    project_path = Path(sys.argv[1])
+    content = project_path.read_text()
     content = modify_toml(content)
-    with open(project_path, "w") as f:
-        f.write(content)
-    with open(readme_path) as f:
-        content = f.read()
+    project_path.write_text(content)
+
+    readme_path = Path(sys.argv[2])
+    content = readme_path.read_text()
     content = modify_readme(content)
-    with open(readme_path, "w") as f:
-        f.write(content)
+    readme_path.write_text(content)

--- a/myst_parser/inventory.py
+++ b/myst_parser/inventory.py
@@ -15,6 +15,7 @@ import re
 import zlib
 from collections.abc import Iterator
 from dataclasses import asdict, dataclass
+from pathlib import Path
 from typing import IO, TYPE_CHECKING, TypedDict
 from urllib.request import urlopen
 
@@ -417,7 +418,7 @@ def fetch_inventory(
     if uri.startswith(("http://", "https://")):
         with urlopen(uri, timeout=timeout) as stream:
             return load(stream, base_url=base_url)
-    with open(uri, "rb") as stream:
+    with Path(uri).open("rb") as stream:
         return load(stream, base_url=base_url)
 
 
@@ -478,7 +479,7 @@ def inventory_cli(inputs: None | list[str] = None):
                 invdata = load(stream)
             base_url = args.uri
     else:
-        with open(args.uri, "rb") as stream:
+        with Path(args.uri).open("rb") as stream:
             invdata = load(stream)
 
     filtered: InventoryType = {

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -10,6 +10,7 @@ import re
 from collections.abc import Callable, Iterable, Iterator, MutableMapping, Sequence
 from contextlib import contextmanager, suppress
 from datetime import date, datetime
+from pathlib import Path
 from types import ModuleType
 from typing import (
     TYPE_CHECKING,
@@ -1225,10 +1226,8 @@ class DocutilsRenderer(RendererProtocol):
             # make the path relative to an "including" document
             # this is set when using the `relative-images` option of the MyST `include` directive
             destination = os.path.normpath(
-                os.path.join(
-                    self.md_env.get("relative-images", ""),
-                    os.path.normpath(destination),
-                )
+                Path(self.md_env.get("relative-images", ""))
+                / os.path.normpath(destination)
             )
 
         img_node["uri"] = destination

--- a/myst_parser/mdit_to_docutils/sphinx_.py
+++ b/myst_parser/mdit_to_docutils/sphinx_.py
@@ -66,7 +66,7 @@ class SphinxRenderer(DocutilsRenderer):
         if relative_include is not None and destination.startswith(relative_include[0]):
             source_dir, include_dir = relative_include[1:]
             destination = os.path.relpath(
-                os.path.join(include_dir, os.path.normpath(destination)), source_dir
+                Path(include_dir) / os.path.normpath(destination), source_dir
             )
         return destination
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-extend-select = ["B", "C4", "FA", "FURB", "I", "ICN", "ISC", "N", "PERF", "PGH", "PIE", "RUF", "SIM", "UP"]
+extend-select = ["B", "C4", "FA", "FURB", "I", "ICN", "ISC", "N", "PERF", "PGH", "PIE", "PTH", "RUF", "SIM", "UP"]
 extend-ignore = ["ISC001", "RUF005", "RUF012"]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/test_commonmark/test_commonmark.py
+++ b/tests/test_commonmark/test_commonmark.py
@@ -3,7 +3,7 @@ provided by https://github.com/commonmark/CommonMark.git.
 """
 
 import json
-import os
+from pathlib import Path
 
 import pytest
 from markdown_it.renderer import RendererHTML
@@ -11,9 +11,7 @@ from markdown_it.renderer import RendererHTML
 from myst_parser.config.main import MdParserConfig
 from myst_parser.parsers.mdit import create_md_parser
 
-with open(
-    os.path.join(os.path.dirname(__file__), "commonmark.json"), encoding="utf8"
-) as fin:
+with (Path(__file__).parent / "commonmark.json").open(encoding="utf8") as fin:
     tests = json.load(fin)
 
 

--- a/tests/test_sphinx/conftest.py
+++ b/tests/test_sphinx/conftest.py
@@ -32,9 +32,8 @@ parameters available to parse to ``@pytest.mark.sphinx``:
 
 """
 
-import os
-import pathlib
 import shutil
+from pathlib import Path
 
 import pytest
 from bs4 import BeautifulSoup
@@ -42,15 +41,14 @@ from docutils import nodes
 
 from myst_parser._compat import findall
 
-SOURCE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "sourcedirs"))
+SOURCE_DIR = (Path(__file__).parent / "sourcedirs").resolve()
 
 
 @pytest.fixture(scope="session", autouse=True)
 def remove_sphinx_builds():
     """remove all build directories from the test folder"""
     yield
-    srcdirs = pathlib.Path(SOURCE_DIR)
-    for entry in srcdirs.iterdir():  # type: pathlib.Path
+    for entry in SOURCE_DIR.iterdir():
         if entry.is_dir() and entry.joinpath("_build").exists():
             shutil.rmtree(str(entry.joinpath("_build")))
 
@@ -66,7 +64,7 @@ def get_sphinx_app_output(file_regression):
         regress_ext=".html",
         replace=None,
     ):
-        outpath = pathlib.Path(str(app.srcdir), "_build", buildername, filename)
+        outpath = Path(app.srcdir) / "_build" / buildername / filename
         if not outpath.exists():
             raise OSError(f"no output file exists: {outpath}")
 
@@ -115,7 +113,7 @@ def get_sphinx_app_doctree(file_regression, normalize_doctree_xml):
         for node in findall(doctree)(
             lambda n: "source" in n and not isinstance(n, str)
         ):
-            node["source"] = pathlib.Path(node["source"]).name
+            node["source"] = Path(node["source"]).name
 
         doctree = doctree.deepcopy()
 

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -13,12 +13,12 @@ from pathlib import Path
 import pytest
 from sphinx.util.console import strip_colors
 
-SOURCE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "sourcedirs"))
+SOURCE_DIR = (Path(__file__).parent / "sourcedirs").resolve()
 
 
 @pytest.mark.sphinx(
     buildername="html",
-    srcdir=os.path.join(SOURCE_DIR, "basic"),
+    srcdir=SOURCE_DIR / "basic",
     freshenv=True,
     confoverrides={"myst_enable_extensions": ["dollarmath"]},
 )
@@ -77,7 +77,7 @@ def test_basic(
 
 @pytest.mark.sphinx(
     buildername="html",
-    srcdir=os.path.join(SOURCE_DIR, "references"),
+    srcdir=SOURCE_DIR / "references",
     freshenv=True,
     confoverrides={
         "myst_enable_extensions": ["dollarmath"],
@@ -118,7 +118,7 @@ def test_references(
 
 @pytest.mark.sphinx(
     buildername="singlehtml",
-    srcdir=os.path.join(SOURCE_DIR, "references_singlehtml"),
+    srcdir=SOURCE_DIR / "references_singlehtml",
     freshenv=True,
     confoverrides={"nitpicky": True},
 )
@@ -177,7 +177,7 @@ def test_references_singlehtml(
 
 @pytest.mark.sphinx(
     buildername="html",
-    srcdir=os.path.join(SOURCE_DIR, "heading_slug_func"),
+    srcdir=SOURCE_DIR / "heading_slug_func",
     freshenv=True,
 )
 def test_heading_slug_func(
@@ -208,7 +208,7 @@ def test_heading_slug_func(
 
 @pytest.mark.sphinx(
     buildername="html",
-    srcdir=os.path.join(SOURCE_DIR, "extended_syntaxes"),
+    srcdir=SOURCE_DIR / "extended_syntaxes",
     freshenv=True,
 )
 def test_extended_syntaxes(
@@ -245,7 +245,7 @@ def test_extended_syntaxes(
 
 @pytest.mark.sphinx(
     buildername="text",
-    srcdir=os.path.join(SOURCE_DIR, "extended_syntaxes"),
+    srcdir=SOURCE_DIR / "extended_syntaxes",
     freshenv=True,
 )
 def test_extended_syntaxes_text(
@@ -276,9 +276,7 @@ def test_extended_syntaxes_text(
     sys.platform == "win32",
     reason="original_uri attribute handling differs on Windows",
 )
-@pytest.mark.sphinx(
-    buildername="html", srcdir=os.path.join(SOURCE_DIR, "includes"), freshenv=True
-)
+@pytest.mark.sphinx(buildername="html", srcdir=SOURCE_DIR / "includes", freshenv=True)
 def test_includes(
     app,
     status,
@@ -324,7 +322,7 @@ def test_includes(
 
 @pytest.mark.sphinx(
     buildername="html",
-    srcdir=os.path.join(SOURCE_DIR, "include_from_rst"),
+    srcdir=SOURCE_DIR / "include_from_rst",
     freshenv=True,
 )
 def test_include_from_rst(
@@ -348,9 +346,7 @@ def test_include_from_rst(
     )
 
 
-@pytest.mark.sphinx(
-    buildername="html", srcdir=os.path.join(SOURCE_DIR, "footnotes"), freshenv=True
-)
+@pytest.mark.sphinx(buildername="html", srcdir=SOURCE_DIR / "footnotes", freshenv=True)
 def test_footnotes(
     app,
     status,
@@ -392,7 +388,7 @@ source/footnote_rst.rst:28: WARNING: Footnote [#] is not referenced. [ref.footno
 
 @pytest.mark.sphinx(
     buildername="html",
-    srcdir=os.path.join(SOURCE_DIR, "commonmark_only"),
+    srcdir=SOURCE_DIR / "commonmark_only",
     freshenv=True,
 )
 def test_commonmark_only(
@@ -421,7 +417,7 @@ def test_commonmark_only(
 
 @pytest.mark.sphinx(
     buildername="html",
-    srcdir=os.path.join(SOURCE_DIR, "substitutions"),
+    srcdir=SOURCE_DIR / "substitutions",
     freshenv=True,
 )
 def test_substitutions(
@@ -453,7 +449,7 @@ def test_substitutions(
 
 @pytest.mark.sphinx(
     buildername="html",
-    srcdir=os.path.join(SOURCE_DIR, "substitutions_missing"),
+    srcdir=SOURCE_DIR / "substitutions_missing",
     freshenv=True,
 )
 def test_substitutions_missing(
@@ -472,9 +468,7 @@ def test_substitutions_missing(
     )
 
 
-@pytest.mark.sphinx(
-    buildername="gettext", srcdir=os.path.join(SOURCE_DIR, "gettext"), freshenv=True
-)
+@pytest.mark.sphinx(buildername="gettext", srcdir=SOURCE_DIR / "gettext", freshenv=True)
 def test_gettext(
     app,
     status,
@@ -501,7 +495,7 @@ def test_gettext(
 )
 @pytest.mark.sphinx(
     buildername="html",
-    srcdir=os.path.join(SOURCE_DIR, "gettext"),
+    srcdir=SOURCE_DIR / "gettext",
     freshenv=True,
     confoverrides={"language": "fr", "gettext_compact": False, "locale_dirs": ["."]},
 )
@@ -542,7 +536,7 @@ def test_gettext_html(
 
 @pytest.mark.sphinx(
     buildername="gettext",
-    srcdir=os.path.join(SOURCE_DIR, "gettext"),
+    srcdir=SOURCE_DIR / "gettext",
     freshenv=True,
     confoverrides={
         "gettext_additional_targets": [
@@ -576,7 +570,7 @@ def test_gettext_additional_targets(
 
 @pytest.mark.sphinx(
     buildername="html",
-    srcdir=os.path.join(SOURCE_DIR, "mathjax"),
+    srcdir=SOURCE_DIR / "mathjax",
     freshenv=True,
     confoverrides={"myst_enable_extensions": ["dollarmath"]},
 )
@@ -597,7 +591,7 @@ def test_mathjax_warning(
 
 @pytest.mark.sphinx(
     buildername="html",
-    srcdir=os.path.join(SOURCE_DIR, "mathjax_default"),
+    srcdir=SOURCE_DIR / "mathjax_default",
     freshenv=True,
     confoverrides={"myst_enable_extensions": ["dollarmath"]},
 )
@@ -623,7 +617,7 @@ def test_mathjax_default(
 
 @pytest.mark.sphinx(
     buildername="html",
-    srcdir=os.path.join(SOURCE_DIR, "mathjax_default"),
+    srcdir=SOURCE_DIR / "mathjax_default",
     freshenv=True,
     confoverrides={
         "myst_enable_extensions": ["dollarmath"],
@@ -651,7 +645,7 @@ def test_mathjax_no_override(
 )
 @pytest.mark.sphinx(
     buildername="html",
-    srcdir=os.path.join(SOURCE_DIR, "mathjax4"),
+    srcdir=SOURCE_DIR / "mathjax4",
     freshenv=True,
     confoverrides={"myst_enable_extensions": ["dollarmath"]},
 )
@@ -676,7 +670,7 @@ def test_mathjax4_warning(
 )
 @pytest.mark.sphinx(
     buildername="html",
-    srcdir=os.path.join(SOURCE_DIR, "mathjax"),
+    srcdir=SOURCE_DIR / "mathjax",
     freshenv=True,
     confoverrides={"myst_enable_extensions": ["dollarmath"]},
 )
@@ -702,7 +696,7 @@ def test_mathjax3_config_on_sphinx9(
 )
 @pytest.mark.sphinx(
     buildername="html",
-    srcdir=os.path.join(SOURCE_DIR, "fieldlist"),
+    srcdir=SOURCE_DIR / "fieldlist",
     freshenv=True,
 )
 def test_fieldlist_extension(
@@ -736,7 +730,7 @@ def test_fieldlist_extension(
 
 @pytest.mark.sphinx(
     buildername="texinfo",
-    srcdir=os.path.join(SOURCE_DIR, "texinfo"),
+    srcdir=SOURCE_DIR / "texinfo",
     freshenv=True,
 )
 def test_texinfo(app, status, warning):
@@ -749,7 +743,7 @@ def test_texinfo(app, status, warning):
 
 @pytest.mark.sphinx(
     buildername="html",
-    srcdir=os.path.join(SOURCE_DIR, "includes"),
+    srcdir=SOURCE_DIR / "includes",
     freshenv=True,
 )
 def test_include_read_event(app, status, warning):
@@ -770,7 +764,7 @@ def test_include_read_event(app, status, warning):
     expected = [
         ("../include_from_rst/include.md", "index"),
         ("include1.inc.md", "index"),
-        (os.path.join("subfolder", "include2.inc.md"), "include1.inc"),
+        (str(Path("subfolder", "include2.inc.md")), "include1.inc"),
         ("include_code.py", "index"),
         ("include_code.py", "index"),
         ("include_literal.txt", "index"),
@@ -778,7 +772,7 @@ def test_include_read_event(app, status, warning):
     ]
     expected_events = []
     for include_file_name, parent_docname in expected:
-        with open(os.path.join(SOURCE_DIR, "includes", include_file_name)) as file:
+        with (SOURCE_DIR / "includes" / include_file_name).open() as file:
             content = file.read()
         expected_events.append((Path(include_file_name), parent_docname, [content]))
     assert len(include_read_events) == len(expected_events), "Wrong number of events"


### PR DESCRIPTION
Replace os.path/string-based path handling with pathlib.Path throughout the codebase, and add the PTH (flake8-use-pathlib) ruff lint rule so future code stays consistent.