### PR TITLE
📚 Document spaces in inventory object names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### 📚 Documentation
+
+- 📚 Explain how to percent-encode spaces in inventory autolinks (#991)
+
 ## 5.1.0 - 2026-05-13
 
 ### ✨ New Features

--- a/docs/syntax/cross-referencing.md
+++ b/docs/syntax/cross-referencing.md
@@ -347,6 +347,8 @@ myst-inventories:
 
 you can then reference inventory objects by prefixing the `inv` schema to the destination [URI]: `inv:key:domain:type#name`.
 
+For object names containing spaces, percent-encode the spaces as `%20` in an `inv` autolink, for example `<inv:ipywidgets:std:doc#examples/Using%20Interact>`.
+
 `key`, `domain` and `type` are optional, e.g. for `inv:#name`, all inventories, domains and types will be searched, with a [warning emitted](myst-warnings) if multiple matches are found.
 
 Additionally, `*` is a wildcard which matches zero or more characters, e.g. `inv:*:std:doc#a*` will match all `std:doc` objects in all inventories, with a `name` beginning with `a`.


### PR DESCRIPTION
## Summary

- document that spaces in inventory object names must be percent-encoded as `%20` in `inv` autolinks
- add the required Unreleased documentation changelog entry

## Validation

- `git diff --check`
- exact source checks for the encoded autolink, decoded inventory target, changelog placement, and non-overlap with #1102
- `pre-commit` and `tox -e docs-clean` were unavailable in this environment

Closes #991.

## Disclosure

This pull request was prepared with AI-assisted automation under explicit human authorization. The validation limitations are disclosed above.
