### PR TITLE
🐛 FIX: Correct included source line attribution

### DIFF
--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -515,7 +515,7 @@ class MockIncludeDirective:
                 )
             self.renderer.nested_render_text(
                 file_content,
-                startline + 1,
+                startline,
                 heading_offset=self.options.get("heading-offset", 0),
             )
         finally:

--- a/tests/test_renderers/fixtures/mock_include_errors.md
+++ b/tests/test_renderers/fixtures/mock_include_errors.md
@@ -19,5 +19,22 @@ Error in include file:
 ```{include} bad.md
 ```
 .
-tmpdir/bad.md:2: (WARNING/2) Unknown interpreted text role "a". [myst.role_unknown]
+tmpdir/bad.md:1: (WARNING/2) Unknown interpreted text role "a". [myst.role_unknown]
+.
+
+Error in include file with start line:
+.
+```{include} bad_start.md
+:start-line: 1
+```
+.
+tmpdir/bad_start.md:2: (WARNING/2) Unknown interpreted text role "a". [myst.role_unknown]
+.
+
+Error in nested include file:
+.
+```{include} outer.md
+```
+.
+tmpdir/bad.md:1: (WARNING/2) Unknown interpreted text role "a". [myst.role_unknown]
 .

--- a/tests/test_renderers/test_include_directive.py
+++ b/tests/test_renderers/test_include_directive.py
@@ -41,6 +41,8 @@ def test_errors(file_params, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     tmp_path.joinpath("bad.md").write_text("{a}`b`")
+    tmp_path.joinpath("bad_start.md").write_text("skip\n{a}`b`")
+    tmp_path.joinpath("outer.md").write_text("```{include} bad.md\n```")
 
     report_stream = StringIO()
     publish_doctree(


### PR DESCRIPTION
Fixes #1165.

Included Markdown passed `startline + 1` to a renderer that already converts zero-based token maps to one-based source lines. Passing `startline` keeps diagnostics on the actual line; regression cases cover plain, `:start-line:`, and nested includes.

Tested with `python -m pytest -q` (1160 passed, 11 skipped).
