### PR TITLE
🐛 FIX: Make a document's own front matter available in env.metadata

### DIFF
--- a/docs/syntax/optional.md
+++ b/docs/syntax/optional.md
@@ -403,6 +403,32 @@ Therefore you can do things like:
 - {{ "a" + "b" }}
 :::
 
+This includes `env.metadata`, which holds the [front matter](syntax/frontmatter) of each document,
+keyed by docname, and so allows a document to refer to its own metadata:
+
+````md
+---
+last_review_date: 1970-09-08
+---
+
+Last reviewed on {{ env.metadata[env.docname]["last_review_date"] }}
+````
+
+```{versionadded} 5.2.0
+Previously, only *other* documents' metadata was available; a document could not read its own.
+```
+
+Note that these values are always strings (non-scalars are JSON encoded), since this is how Sphinx
+stores them, so use e.g. string methods or Jinja2 filters rather than date methods.
+
+:::{warning}
+Referring to *another* document's metadata, e.g. `env.metadata["other-doc"]["key"]`, is fragile:
+the value is only present if that document has already been read in this build,
+which depends on build order, and is not the case at all under parallel reads.
+It is also not registered as a dependency, so the referring document will not be rebuilt
+when the other document's front matter changes.
+:::
+
 You can also change the delimiter if necessary, for example setting in the `conf.py`:
 
 ```python

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -1325,9 +1325,49 @@ class DocutilsRenderer(RendererProtocol):
                 fields, language_code=self.document.settings.language_code
             )
             self.current_node.append(field_list)
+            self._add_fm_env_metadata(field_list, self.document.settings.language_code)
 
         if data.get("title") and self.md_config.title_to_header:
             self.nested_render_text(f"# {data['title']}", 0)
+
+    def _add_fm_env_metadata(
+        self, field_list: nodes.field_list, language_code: str
+    ) -> None:
+        """Eagerly add the front matter to the sphinx ``env.metadata``.
+
+        Sphinx's ``MetadataCollector`` only populates ``env.metadata`` on the
+        ``doctree-read`` event, i.e. after the whole document has been parsed.
+        Adding the metadata here as well makes it available *during* the parse,
+        so that a document can reference its own front matter,
+        e.g. ``{{ env.metadata[env.docname]["key"] }}`` in a substitution.
+
+        The values are read back off the rendered fields,
+        so that they mirror what the collector will store later,
+        and thus do not change between build phases.
+
+        :param field_list: the field list rendered from the front matter.
+        :param language_code: used to resolve localised bibliographic field names.
+        """
+        if self.sphinx_env is None:
+            return
+        bibliofields = get_language(language_code).bibliographic_fields
+        meta = self.sphinx_env.metadata[self.sphinx_env.docname]
+        for field in field_list:
+            name: str = field[0].astext()
+            value: Any = field[1].astext()
+            # the `DocInfo` transform converts bibliographic fields to dedicated
+            # nodes, which the collector then keys by the canonical (English) name
+            name = bibliofields.get(name.lower(), name)
+            if name in ("dedication", "abstract"):
+                # these are placed outside the `docinfo`, so are never collected
+                continue
+            if name == "tocdepth":
+                # as per MetadataCollector
+                try:
+                    value = int(value)
+                except ValueError:
+                    value = 0
+            meta[name] = value
 
     def dict_to_fm_field_list(
         self, data: dict[str, Any], language_code: str, line: int = 0
@@ -1362,7 +1402,10 @@ class DocutilsRenderer(RendererProtocol):
         by the `DoctreeReadEvent` transform (priority 880),
         calling `MetadataCollector.process_doc`.
         In this case keys and values will be converted to strings and stored in
-        `app.env.metadata[app.env.docname]`
+        `app.env.metadata[app.env.docname]`.
+        Note that this only happens once the whole document has been parsed,
+        so `_add_fm_env_metadata` additionally seeds the same values during the
+        render, to make them readable from within the document itself.
 
         See
         https://www.sphinx-doc.org/en/master/usage/restructuredtext/field-lists.html

--- a/tests/test_sphinx/sourcedirs/frontmatter_metadata/conf.py
+++ b/tests/test_sphinx/sourcedirs/frontmatter_metadata/conf.py
@@ -1,0 +1,3 @@
+extensions = ["myst_parser"]
+exclude_patterns = ["_build"]
+myst_enable_extensions = ["substitution"]

--- a/tests/test_sphinx/sourcedirs/frontmatter_metadata/index.md
+++ b/tests/test_sphinx/sourcedirs/frontmatter_metadata/index.md
@@ -1,0 +1,21 @@
+---
+tocdepth: 2
+last_review_date: 1970-09-08
+reviewers:
+  - alice
+  - bob
+links:
+  home: https://example.com
+---
+
+# Index
+
+Own metadata: {{ env.metadata[env.docname]["last_review_date"] }}
+
+Own list: {{ env.metadata[env.docname]["reviewers"] }}
+
+Own dict: {{ env.metadata[env.docname]["links"] }}
+
+```{toctree}
+other.md
+```

--- a/tests/test_sphinx/sourcedirs/frontmatter_metadata/other.md
+++ b/tests/test_sphinx/sourcedirs/frontmatter_metadata/other.md
@@ -1,0 +1,9 @@
+---
+last_review_date: 2037-09-08
+---
+
+# Other
+
+Own metadata: {{ env.metadata[env.docname]["last_review_date"] }}
+
+Metadata of an already-read document: {{ env.metadata["index"]["last_review_date"] }}

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -453,6 +453,42 @@ def test_substitutions(
 
 @pytest.mark.sphinx(
     buildername="html",
+    srcdir=os.path.join(SOURCE_DIR, "frontmatter_metadata"),
+    freshenv=True,
+)
+def test_frontmatter_metadata(
+    app,
+    status,
+    warning,
+    get_sphinx_app_doctree,
+    file_regression,
+    normalize_doctree_xml,
+):
+    """Test that a document can access its own front matter via ``env.metadata``."""
+    app.build()
+    assert "build succeeded" in status.getvalue()
+    assert warning.getvalue().strip() == ""
+
+    # values should be the same strings that sphinx's MetadataCollector stores,
+    # except for ``tocdepth``, which it converts to an integer
+    ignore = {"myst_slugs", "wordcount"}  # added separately by the renderer
+    metadata = {k: v for k, v in app.env.metadata["index"].items() if k not in ignore}
+    assert metadata == {
+        "tocdepth": 2,
+        "last_review_date": "1970-09-08",
+        "reviewers": '["alice", "bob"]',
+        "links": '{"home": "https://example.com"}',
+    }
+
+    get_sphinx_app_doctree(app, docname="index", regress=True)
+    file_regression.check(
+        normalize_doctree_xml(get_sphinx_app_doctree(app, docname="other").pformat()),
+        extension=".other.xml",
+    )
+
+
+@pytest.mark.sphinx(
+    buildername="html",
     srcdir=os.path.join(SOURCE_DIR, "substitutions_missing"),
     freshenv=True,
 )

--- a/tests/test_sphinx/test_sphinx_builds/test_frontmatter_metadata.other.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_frontmatter_metadata.other.xml
@@ -1,0 +1,10 @@
+<document source="other.md">
+    <section ids="other" names="other">
+        <title>
+            Other
+        <paragraph>
+            Own metadata: 
+            2037-09-08
+        <paragraph>
+            Metadata of an already-read document: 
+            1970-09-08

--- a/tests/test_sphinx/test_sphinx_builds/test_frontmatter_metadata.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_frontmatter_metadata.xml
@@ -1,0 +1,15 @@
+<document source="index.md">
+    <section ids="index" names="index">
+        <title>
+            Index
+        <paragraph>
+            Own metadata: 
+            1970-09-08
+        <paragraph>
+            Own list: 
+            [“alice”, “bob”]
+        <paragraph>
+            Own dict: 
+            {“home”: “https://example.com”}
+        <compound classes="toctree-wrapper">
+            <toctree caption="True" entries="(None,\ 'other')" glob="False" hidden="False" includefiles="other" includehidden="False" maxdepth="-1" numbered="0" parent="index" rawentries="" titlesonly="False">


### PR DESCRIPTION
Closes #947

## Problem

Sphinx's `MetadataCollector` only populates `env.metadata` on the `doctree-read` event, i.e. after the whole document has been parsed, whereas MyST substitutions are evaluated *during* the parse. A document could therefore read other documents' front matter via `env.metadata["other"]["key"]`, but its own entry was still empty, so `{{ env.metadata[env.docname]["key"] }}` failed with an `UndefinedError`:

```markdown
---
last_review_date: 1970-09-08
---
The last review date of _this_ file was on {{ env.metadata[env.docname]["last_review_date"] }}
```

## Fix

The renderer now eagerly seeds `env.metadata[docname]` when the front matter token is rendered (the first token of the document), so the rest of the parse can see it. This also benefits anything else reading `env.metadata` mid-parse (directives, `eval-rst`, myst-nb).

Values are read back off the already-built field list rather than re-stringified from the raw YAML, so they are identical to what the collector stores later at `doctree-read` (which then harmlessly overwrites them). Three details needed to mirror the collector exactly:

- bibliographic field names are canonicalized via the docutils language module (the collector keys them by node class name after the `DocInfo` transform);
- `dedication`/`abstract` are skipped — docutils moves them outside the `docinfo`, so the collector never stores them (without the skip they would leak into `env.metadata` permanently, caught by the existing `test_basic`);
- `tocdepth` is cast to `int`, as the collector does.

## Scope note

The linked gist demonstrates two distinct problems. This PR fixes the self-reference case. Reading *another* document's metadata (`env.metadata["other-doc"]["key"]`) remains inherently order-dependent (alphabetical read order, parallel-read partitioning, stale values on incremental builds since no dependency is recorded) — that would need post-read aggregation, a different feature. The docs update adds a warning admonition documenting this limitation.

## Testing

- New Sphinx build test `test_frontmatter_metadata` with doctree regressions; asserts the exact `env.metadata` contents (string values, `int` tocdepth) and a warning-free build. It fails without the fix.
- The existing `test_basic` asserts the full metadata dict for a rich front matter (author/date/dedication/abstract), acting as a contract test that the eager values match the collector's.
- Full suite passes; verified end-to-end against the reproduction gist from the issue.

## AI assistance disclosure

This PR was developed with substantial assistance from Claude Code (Anthropic): root-cause investigation, and drafting of the implementation, tests, and docs. I directed the work and made the design decisions (storing the same stringified values the collector produces, deriving them from the rendered field list so parity holds by construction, and limiting scope to the self-reference bug), and I have reviewed and verified the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)