### PR TITLE
🐛 FIX: sorting of mixed manual/auto-numbered footnotes

### DIFF
--- a/myst_parser/mdit_to_docutils/transforms.py
+++ b/myst_parser/mdit_to_docutils/transforms.py
@@ -126,13 +126,16 @@ class CollectFootnotes(Transform):
             transition.source = self.document.source
             self.document += transition
 
-        def _sort_key(footnote: tuple[str, nodes.footnote]) -> int | str:
+        def _sort_key(footnote: tuple[str, nodes.footnote]) -> tuple[int, int, str]:
             label, _ = footnote
             try:
                 # ensure e.g 10 comes after 2
-                return int(label)
+                return (0, int(label), "")
             except ValueError:
-                return label
+                # non-numeric labels sort after numeric ones;
+                # the leading discriminant keeps the key totally ordered,
+                # since int and str cannot be compared with each other
+                return (1, 0, label)
 
         for _, footnote in sorted(footnotes, key=_sort_key):
             footnote.parent.remove(footnote)

--- a/tests/test_docutils.py
+++ b/tests/test_docutils.py
@@ -140,6 +140,36 @@ def test_include_from_rst(tmp_path):
     )
 
 
+def test_include_from_rst_mixed_footnotes(tmp_path):
+    """Test mixed manually- and auto-numbered footnotes, included from an RST file."""
+    from docutils.parsers.rst import Parser as RSTParser
+
+    include_path = tmp_path.joinpath("include.md")
+    include_path.write_text(
+        dedent(
+            """\
+            - manually numbered[^3]
+            - auto numbered[^myref]
+
+            [^myref]: auto definition.
+            [^3]: manual definition.
+            """
+        )
+    )
+
+    parser = RSTParser()
+    document = make_document(parser_cls=RSTParser)
+    parser.parse(
+        f".. include:: {include_path}\n   :parser: myst_parser.docutils_", document
+    )
+    document.transformer.populate_from_components([parser])
+    document.transformer.apply_transforms()
+
+    # the auto-numbered footnote has no label child assigned at this point,
+    # so sorting must not compare its text against the numeric label "3"
+    assert len(list(document.findall(nodes.footnote))) == 2
+
+
 def test_field_list_body_source_line():
     """A ``field_body`` node should carry its own source line.
 


### PR DESCRIPTION
Closes #1025

When a markdown file mixing a manually-numbered (`[^3]`) and an auto-numbered (`[^myref]`) footnote is included from an RST file, the auto-numbered footnote has not yet had its label child assigned when `CollectFootnotes` runs, so `label.astext()` returns the definition body instead of a number. `_sort_key` then returned an `int` for one footnote and a `str` for the other and `sorted()` aborted the build with `TypeError: '<' not supported between instances of 'str' and 'int'`.

The key is now a tuple with a leading numeric/non-numeric discriminant, so it is always totally ordered while keeping the existing numeric ordering (10 after 2). Added `test_include_from_rst_mixed_footnotes` beside the existing `test_include_from_rst`; it raises the reported TypeError without the fix.
