### PR TITLE
♻️ REFACTOR: docs example directive via `sphinx-syntax-example`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
       - sphinx~=8.2
       - markdown-it-py~=4.2
       - mdit-py-plugins~=0.6.0
+      - sphinx-syntax-example~=0.2.0
       files: >
         (?x)^(
             myst_parser/.*py|

--- a/docs/_static/local.css
+++ b/docs/_static/local.css
@@ -9,21 +9,24 @@ h1:not(.rubric) {
     text-decoration: underline;
 }
 
-/** MyST examples */
-.myst-example {
+/** Syntax examples */
+.syntax-example {
     border: 1px solid var(--pst-color-border);
     border-left-color: var(--pst-color-info);
     border-left-width: .2em;
     box-shadow: rgba(0, 0, 0, 0.25) 0px 5px 15px;
     margin-bottom: 1rem;
 }
-.myst-example-source > div[class*="highlight-"]{
+/* The source pane *is* the highlight-<lang> div (not a wrapper around one),
+   so zero its margin here to keep it flush inside the frame.
+   local.css loads last, so this wins. */
+.syntax-example > .syntax-example-source {
     margin: 0;
 }
-.myst-example-render {
+.syntax-example-render {
     padding: 0.5rem;
 }
-.myst-example-render > :first-child {
+.syntax-example-render > :first-child {
     margin-top: 0.5rem;
 }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -223,19 +223,21 @@ def setup(app: Sphinx):
         DocutilsCliHelpDirective,
         MystAdmonitionDirective,
         MystConfigDirective,
-        MystExampleDirective,
         MystLexer,
         MystToHTMLDirective,
         MystWarningsDirective,
         NumberSections,
         StripUnsupportedLatex,
+        SyntaxExampleDocsDirective,
     )
 
     app.add_directive("myst-config", MystConfigDirective)
     app.add_directive("docutils-cli-help", DocutilsCliHelpDirective)
     app.add_directive("doc-directive", DirectiveDoc)
     app.add_directive("myst-warnings", MystWarningsDirective)
-    app.add_directive("myst-example", MystExampleDirective)
+    # NOTE: if `sphinx_syntax_example` is ever added to `extensions` (e.g. to pick
+    # up its stylesheet), drop this line too — it registers the same directive.
+    app.add_directive("syntax-example", SyntaxExampleDocsDirective)
     app.add_directive("myst-admonitions", MystAdmonitionDirective)
     app.add_directive("myst-to-html", MystToHTMLDirective)
     app.add_post_transform(StripUnsupportedLatex)

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -147,7 +147,7 @@ extensions = [
 
 Now, we can use the `design` directive to add a web-component to our Markdown file!
 
-::::{myst-example}
+::::{syntax-example}
 :::{card} Card Title
 Header
 ^^^
@@ -158,7 +158,7 @@ Footer
 ::::
 
 
-::::::{myst-example}
+::::::{syntax-example}
 
 ::::{tab-set}
 
@@ -196,7 +196,7 @@ Content 2
 % Now, add a **mermaid directive** to your Markdown file.
 % For example:
 
-% :::{myst-example}
+% :::{syntax-example}
 % Here's a cool mermaid diagram!
 %
 % ```{mermaid}

--- a/docs/syntax/admonitions.md
+++ b/docs/syntax/admonitions.md
@@ -10,7 +10,7 @@ The [alert extension](syntax/alerts) provides GitHub-style alerts as a lightweig
 Admonitions are a special case of {{directive}} extensions.
 It is advised to use admonitions with the [colon_fence](#syntax/colon_fence) extension, which signify that the content of the block is also MyST Markdown.
 
-::::{myst-example}
+::::{syntax-example}
 
 :::{tip}
 Let's give readers a helpful hint!
@@ -30,7 +30,7 @@ These admonitions take no argument, but may be specified with options:
 :class: A space-separated list of CSS classes to add to the admonition, conforming to the [identifier normalization rules](https://docutils.sourceforge.io/docs/ref/rst/directives.html#identifier-normalization).
 :name: A reference target for the admonition (see [cross-referencing](#syntax/referencing)).
 
-::::{myst-example}
+::::{syntax-example}
 
 :::{tip}
 :class: myclass1 myclass2
@@ -44,7 +44,7 @@ Let's give readers a helpful hint!
 
 Sphinx also adds a number of additional admonition types, for denoting changes to the documentation, or to the codebase:
 
-::::{myst-example}
+::::{syntax-example}
 
 :::{versionadded} 1.2.3
 Explanation of the new feature.
@@ -66,7 +66,7 @@ To provide a custom title for an admonition, use the `admonition` directive.
 If you also want to style the admonition as one of the core admonition types,
 you can use the `admonition` directive with the `class` option.
 
-::::{myst-example}
+::::{syntax-example}
 
 :::{admonition} My custom title with *Markdown*!
 :class: tip
@@ -80,7 +80,7 @@ This is a custom title for a tip admonition.
 
 The [sphinx-togglebutton](https://sphinx-togglebutton.readthedocs.io) extension allows you to create collapsible admonitions, by adding a `dropdown` class to the admonition.
 
-::::{myst-example}
+::::{syntax-example}
 
 :::{note}
 :class: dropdown
@@ -97,7 +97,7 @@ without it taking up too much space on the page.
 Using the [colon_fence](#syntax/colon_fence) extension,
 content block can be wrapped in containers with a custom CSS class.
 
-::::{myst-example}
+::::{syntax-example}
 :::bg-primary
 This is a container with a custom CSS class.
 
@@ -108,7 +108,7 @@ This is a container with a custom CSS class.
 Using the [sphinx-design](https://github.com/executablebooks/sphinx-design) extension,
 it is also possible to create beautiful, screen-size responsive web-components.
 
-::::{myst-example}
+::::{syntax-example}
 :::{card} Card Title
 Header
 ^^^
@@ -119,7 +119,7 @@ Footer
 ::::
 
 
-::::::{myst-example}
+::::::{syntax-example}
 
 ::::{tab-set}
 

--- a/docs/syntax/code_and_apis.md
+++ b/docs/syntax/code_and_apis.md
@@ -6,7 +6,7 @@
 Code blocks contain a language identifier, which is used to determine the language of the code.
 This language is used to determine the syntax highlighting, using an available [pygments lexer](https://pygments.org/docs/lexers/).
 
-:::{myst-example}
+:::{syntax-example}
 ```python
 from a import b
 c = "string"
@@ -27,7 +27,7 @@ you can do so by nesting them in backticks of a greater length.
 Markdown will treat the outer-most backticks as the edges of the "raw" block and everything inside will show up.
 For example:
 
-:::{myst-example}
+:::{syntax-example}
 `` `hi` ``
 
 ````
@@ -43,7 +43,7 @@ hi
 
 The [attrs_inline](#syntax/attributes/inline) extension can be used to apply syntax highlighting to inline code:
 
-:::{myst-example}
+:::{syntax-example}
 Inline Python code `a = "b"`{l=python}
 :::
 
@@ -59,7 +59,7 @@ myst_number_code_blocks = ["typescript"]
 
 Will number all code blocks with the `typescript` lexer by default.
 
-:::{myst-example}
+:::{syntax-example}
 ```typescript
 type MyBool = true | false;
 
@@ -73,7 +73,7 @@ interface User {
 To apply numbering and highlighting to a specific code block,
 the [attrs_block](#syntax/attributes/block) extension can be used:
 
-:::{myst-example}
+:::{syntax-example}
 {lineno-start=1 emphasize-lines="2,3"}
 ```python
 a = 1
@@ -87,7 +87,7 @@ c = 3
 With the `code-block` {{directive}},
 a caption can be added to a code blocks, as well as other options:
 
-:::{myst-example}
+:::{syntax-example}
 ```{code-block} python
 :caption: This is a caption
 :emphasize-lines: 2,3
@@ -136,7 +136,7 @@ The [Sphinx documentation](inv:sphinx#code-block)
 
 Longer pieces of code can be included from files using the `literalinclude` {{directive}}:
 
-:::{myst-example}
+:::{syntax-example}
 ```{literalinclude} examples/example.py
 ```
 :::
@@ -145,7 +145,7 @@ The file name is usually relative to the current file’s path. However, if it i
 
 To select only a sub-section of the file, the `lines`, `pyobject` or `start-after` and `end-before` options can be used:
 
-:::{myst-example}
+:::{syntax-example}
 ```{literalinclude} examples/example.py
 :start-after: start example
 :end-before: end example
@@ -175,7 +175,7 @@ As opposed to `sphinx.ext.autodoc`, `sphinx-autodoc2` performs static (rather th
 Alternatively, the `autodoc2-object` directive can be used to generate documentation for a single object.
 To embed in a MyST document the MyST `render_plugin` should be specified, for example:
 
-````{myst-example}
+````{syntax-example}
 ```{autodoc2-object} myst_parser.sphinx_ext.main.setup_sphinx
 render_plugin = "myst"
 no_index = true
@@ -184,14 +184,14 @@ no_index = true
 
 This can be referenced elsewhere in the document using the `:py:obj:` role, or a `#` link (see [cross-referencing](#syntax/referencing)).
 
-````{myst-example}
+````{syntax-example}
 - {py:obj}`myst_parser.sphinx_ext.main.setup_sphinx`
 - [](#myst_parser.sphinx_ext.main.setup_sphinx)
 ````
 
 Additionally, summaries of multiple objects can be generated using the `autodoc2-summary` directive:
 
-````{myst-example}
+````{syntax-example}
 ```{autodoc2-summary}
 :renderer: myst
 
@@ -215,7 +215,7 @@ autodoc2_docstring_parser_regexes = [
 
 For example:
 
-````{myst-example}
+````{syntax-example}
 ```{autodoc2-object} myst_parser.setup
 render_plugin = "myst"
 no_index = true
@@ -231,7 +231,7 @@ docstring_parser_regexes = [
 [Sphinx extension `autodoc`](inv:sphinx#sphinx.ext.autodoc) also can generate documentation for Python objects.
 However, because it is hard-coded to generate RestructureText, the special [`eval-rst` directive](#syntax/directives/parsing) needs to be used:
 
-````{myst-example}
+````{syntax-example}
 ```{eval-rst}
 .. autofunction:: myst_parser.sphinx_ext.main.setup_sphinx
     :noindex:
@@ -240,7 +240,7 @@ However, because it is hard-coded to generate RestructureText, the special [`eva
 
 Summaries can also be generated with [`autosummary`](inv:sphinx#sphinx.ext.autosummary):
 
-````{myst-example}
+````{syntax-example}
 ```{eval-rst}
 .. autosummary::
     :nosignatures:

--- a/docs/syntax/cross-referencing.md
+++ b/docs/syntax/cross-referencing.md
@@ -23,7 +23,7 @@ primary HTML id, used by tocs, permalinks and `objects.inv`; the implicit
 heading id is kept as a secondary anchor, so existing fragment links keep working.
 ```
 
-::::{myst-example}
+::::{syntax-example}
 
 (heading-target)=
 ### Heading
@@ -47,7 +47,7 @@ This is a directive with a `name` option
 There are also other ways to create targets, specific to certain directives,
 such as [glossaries](#syntax/glossaries) create targets for terms, and [code APIs](#syntax/apis) create targets for objects:
 
-::::{myst-example}
+::::{syntax-example}
 {.glossary}
 my other term
 : Definition of the term
@@ -79,7 +79,7 @@ By default the anchor "slugs" are created according to the [GitHub implementatio
 
 For example, using `myst_heading_anchors = 2`:
 
-::::{myst-example}
+::::{syntax-example}
 ## A heading with slug
 
 ## A heading with slug
@@ -191,7 +191,7 @@ Otherwise, the link text will be the destination itself.
 
 #### Autolinks
 
-:::{myst-example}
+:::{syntax-example}
 
 :External URL: <https://example.com>
 :Internal target reference: <project:#cross-references>
@@ -204,7 +204,7 @@ Otherwise, the link text will be the destination itself.
 
 #### Inline links with implicit text
 
-:::{myst-example}
+:::{syntax-example}
 
 :External URL: [](https://example.com)
 :Internal target reference: [](#cross-references)
@@ -217,7 +217,7 @@ Otherwise, the link text will be the destination itself.
 
 #### Inline links with explicit text
 
-:::{myst-example}
+:::{syntax-example}
 
 :External URL: [Explicit text](https://example.com)
 :Internal target reference: [Explicit text](#cross-references)
@@ -389,7 +389,7 @@ Sphinx offers numerous [roles for referencing](#usage/restructuredtext/roles) sp
 
 These can also be used within MyST documents, although it is recommended to use the Markdown syntax where possible, which is more portable and native to MyST.
 
-:::{myst-example}
+:::{syntax-example}
 Sphinx roles:
 
 - {ref}`syntax/referencing`, {ref}`Explicit text <syntax/referencing>`

--- a/docs/syntax/images_and_figures.md
+++ b/docs/syntax/images_and_figures.md
@@ -6,7 +6,7 @@ MyST Markdown can be used to include images and figures in your documents as wel
 
 The standard Markdown syntax for images is:
 
-:::{myst-example}
+:::{syntax-example}
 ![fishy](img/fun-fish.png)
 :::
 
@@ -14,13 +14,13 @@ This will create an **inline** image, which is displayed in the flow of the text
 
 The [attrs_inline](syntax/attributes/inline) extension can be used to add attributes to an inline image:
 
-:::{myst-example}
+:::{syntax-example}
 ![fishy](img/fun-fish.png){.bg-warning w=100px align=center}
 :::
 
 The [html_image](syntax/images/html) extension can also be used, to allow MyST to parse HTML image tags:
 
-:::{myst-example}
+:::{syntax-example}
 :highlight: html
 
 <img src="img/fun-fish.png" alt="fishy" width="200px" class="bg-primary">
@@ -30,7 +30,7 @@ The [html_image](syntax/images/html) extension can also be used, to allow MyST t
 
 To create a **block** image, use the `image` directive:
 
-:::{myst-example}
+:::{syntax-example}
 ```{image} img/fun-fish.png
 :alt: fishy
 :class: bg-primary
@@ -84,7 +84,7 @@ The following options are recognized:
 
 To create a **figure**, use the `figure` directive:
 
-:::{myst-example}
+:::{syntax-example}
 ```{figure} img/fun-fish.png
 :scale: 50 %
 :alt: map to buried treasure
@@ -121,7 +121,7 @@ figclass : text
 
 See the <project:#syntax/md-figures> section for information on how to create figures that use native Markdown images.
 
-::::{myst-example}
+::::{syntax-example}
 :::{figure-md}
 ![fishy](img/fun-fish.png){width=200px}
 
@@ -140,7 +140,7 @@ See the [sphinx-subfigure](https://sphinx-subfigure.readthedocs.io) extension fo
 
 % It is possible to use [mermaid diagrams](https://mermaid-js.github.io/mermaid) using the `sphinxcontrib.mermaid` extension.
 
-% :::{myst-example}
+% :::{syntax-example}
 % ```{mermaid}
 % flowchart LR
 %   A[Jupyter Notebook] --> C

--- a/docs/syntax/math.md
+++ b/docs/syntax/math.md
@@ -14,7 +14,7 @@ Each single equation can have multiple aligned lines, which should be separated 
 The `label` option can also be used to reference the equation later on, with the `eq` role.
 
 
-:::{myst-example}
+:::{syntax-example}
 Since Pythagoras, we know that {math}`a^2 + b^2 = c^2`.
 
 ```{math}
@@ -46,7 +46,7 @@ Additionally if `myst_dmath_allow_labels=True` is set (the default):
 - Display (block) math with equation label: `$$...$$ (1)`
 
 
-:::{myst-example}
+:::{syntax-example}
 :highlight: latex
 
 $$
@@ -75,7 +75,7 @@ Enabling the [amsmath](#syntax/amsmath) extension will directly parse the follow
 
 As expected, environments ending in `*` will not be numbered, for example:
 
-:::{myst-example}
+:::{syntax-example}
 :highlight: latex
 
 \begin{gather*}

--- a/docs/syntax/optional.md
+++ b/docs/syntax/optional.md
@@ -148,7 +148,7 @@ Conversely `\\` will negate the escaping, so `\\$a$` renders as \\$a$.
 Block-level math can be specified with `$$` signs that wrap the math block you'd like to parse.
 For example:
 
-:::{myst-example}
+:::{syntax-example}
 :highlight: latex
 
 $$
@@ -159,7 +159,7 @@ $$
 
 This is equivalent to the following directive:
 
-:::{myst-example}
+:::{syntax-example}
 
 ```{math}
     y    & = ax^2 + bx + c \\
@@ -170,7 +170,7 @@ This is equivalent to the following directive:
 
 You can also add labels to block equations:
 
-:::{myst-example}
+:::{syntax-example}
 :highlight: latex
 
 $$
@@ -195,7 +195,7 @@ These options can both be useful if you also wish to use `$` as a unit of curren
 To allow display math (i.e. `$$`) within an inline context, set `myst_dmath_double_inline = True` (`False` by default).
 This allows for example:
 
-:::{myst-example}
+:::{syntax-example}
 :highlight: latex
 
 Hence, for $\alpha \in (0, 1)$,
@@ -209,7 +209,7 @@ i.e., $[\alpha \bar{X}, \infty)$ is a lower 1-sided $1-\alpha$ confidence bound 
 
 Math will also work when nested in other block elements, like lists or quotes:
 
-:::{myst-example}
+:::{syntax-example}
 
 - A list
 - $$ a = 1 $$
@@ -230,7 +230,7 @@ These top-level math environments will then be directly parsed:
 
 As expected, environments ending in `*` will not be numbered, for example:
 
-:::{myst-example}
+:::{syntax-example}
 :highlight: latex
 
 \begin{gather*}
@@ -254,7 +254,7 @@ We hope to implement this in a future update (see [executablebooks/MyST-Parser#2
 
 This syntax will also work when nested in other block elements, like lists or quotes:
 
-:::{myst-example}
+:::{syntax-example}
 
 - A list
 - \begin{gather*}
@@ -363,7 +363,7 @@ Keys in the front-matter will override ones in the `conf.py`.
 
 You can use these substitutions inline or as blocks, and you can even nest substitutions in other substitutions (but circular references are prohibited):
 
-:::{myst-example}
+:::{syntax-example}
 
 Inline: {{ key1 }}
 
@@ -382,7 +382,7 @@ Block level:
 
 Substitutions will only be assessed where you would normally use Markdown, e.g. not in code blocks:
 
-:::{myst-example}
+:::{syntax-example}
 
 ```
 {{ key1 }}
@@ -397,7 +397,7 @@ This may lead to unexpected outcomes.
 Substitution references are assessed as [Jinja2 expressions](http://jinja.palletsprojects.com) which can use [filters](https://jinja.palletsprojects.com/en/2.11.x/templates/#list-of-builtin-filters), and also contains the [Sphinx Environment](inv:sphinx#extdev/envapi) in the context (as `env`).
 Therefore you can do things like:
 
-:::{myst-example}
+:::{syntax-example}
 - version: {{ env.config.version }}
 - docname: {{ env.docname | upper }}
 - {{ "a" + "b" }}
@@ -424,7 +424,7 @@ The exact logic for handling substitutions is:
 Substitutions cannot be directly used in URLs, such as `[a link](https://{{key4}}.com)` or `<https://{{key4}}.com>`.
 However, since Jinja2 substitutions allow for Python methods to be used, you can use string formatting or replacements:
 
-:::{myst-example}
+:::{syntax-example}
 
 {{ '[a link](https://{}.com)'.format(key4) }}
 
@@ -448,7 +448,7 @@ It is ideal for admonition type directives (as documented in [Directives](syntax
 By default, a closing colon fence with *at least* as many colons as the opening fence will close the block (matching the behaviour of backtick fences).
 To require the closing fence to have *exactly* the same number of colons as the opening, set `myst_colon_fence_exact_match = True` in your {{ confpy }}.
 
-:::::{myst-example}
+:::::{syntax-example}
 
 :::{note}
 This text is **standard** _Markdown_
@@ -467,7 +467,7 @@ abc | mnp | xyz
 
 Similar to normal directives, these directives can also be nested:
 
-:::::{myst-example}
+:::::{syntax-example}
 
 ::::{important}
 :::{note}
@@ -479,7 +479,7 @@ This text is **standard** _Markdown_
 
 and also parameter options can be used:
 
-:::::{myst-example}
+:::::{syntax-example}
 
 :::{admonition} This *is* also **Markdown**
 :class: warning
@@ -516,13 +516,13 @@ myst_heading_anchors = 3
 
 You can then insert markdown links directly to anchors that are generated from your header titles in your documentation:
 
-:::{myst-example}
+:::{syntax-example}
 [](#auto-generated-header-anchors)
 :::
 
 The paths to other files should be relative to the current file:
 
-:::{myst-example}
+:::{syntax-example}
 [**link text**](./typography.md#headings)
 :::
 
@@ -621,7 +621,7 @@ Definition lists utilise the [markdown-it-py deflist plugin](inv:markdown_it#md/
 
 This syntax can be useful, for example, as an alternative to nested bullet-lists:
 
-:::{myst-example}
+:::{syntax-example}
 - Term 1
   - Definition
 - Term 2
@@ -630,7 +630,7 @@ This syntax can be useful, for example, as an alternative to nested bullet-lists
 
 Using instead:
 
-:::{myst-example}
+:::{syntax-example}
 Term 1
 : Definition
 
@@ -647,7 +647,7 @@ From the Pandoc documentation:
 
 Here is a more complex example, demonstrating some of these features:
 
-:::{myst-example}
+:::{syntax-example}
 Term *with Markdown*
 : Definition [with reference](syntax/definition-lists)
 
@@ -674,7 +674,7 @@ you will be able to utilise task lists.
 Task lists utilise the [markdown-it-py tasklists plugin](inv:markdown_it#md/plugins),
 and are applied to markdown list items starting with `[ ]` or `[x]`:
 
-:::{myst-example}
+:::{syntax-example}
 - [ ] An item that needs doing
 - [x] An item that is complete
 :::
@@ -691,7 +691,7 @@ These are rendered as admonition nodes in the output.
 
 The syntax is a blockquote beginning with a special marker like `[!NOTE]`:
 
-:::{myst-example}
+:::{syntax-example}
 > [!NOTE]
 > This is a note alert.
 
@@ -722,7 +722,7 @@ you will be able to utilise field lists.
 Field lists are mappings from field names to field bodies,
 based on the [reStructureText syntax](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#field-lists).
 
-:::{myst-example}
+:::{syntax-example}
 
 :name only:
 :name: body
@@ -745,7 +745,7 @@ based on the [reStructureText syntax](https://docutils.sourceforge.io/docs/ref/r
 
 A prominent use case of field lists is for use in API docstrings, as used in [Sphinx's docstring renderers](inv:sphinx#usage/domains/python):
 
-:::{myst-example}
+:::{syntax-example}
 ```{py:function} send_message(sender, priority)
 
 Send a message to a recipient
@@ -825,7 +825,7 @@ you can enable parsing of block attributes before certain block syntaxes.
 
 For example, the following Markdown:
 
-:::{myst-example}
+:::{syntax-example}
 {#mypara .bg-warning}
 Here is a paragraph with attributes.
 
@@ -838,7 +838,7 @@ but only certain key-value attributes are supported for each syntax.
 
 For **ordered lists**, the `style` key is supported, and can be one of `decimal`, `lower-alpha`, `upper-alpha`, `lower-roman`, `upper-roman`:
 
-:::{myst-example}
+:::{syntax-example}
 {style=lower-alpha}
 1. a
 2. b
@@ -858,7 +858,7 @@ For **ordered lists**, the `style` key is supported, and can be one of `decimal`
 
 For **code fences**, the `lineno-start` and `emphasize-lines` keys are supported:
 
-:::{myst-example}
+:::{syntax-example}
 {lineno-start=1 emphasize-lines="2,3"}
 ```python
 a = 1
@@ -869,14 +869,14 @@ c = 3
 
 For **block quotes**, the `attribution` key is supported:
 
-:::{myst-example}
+:::{syntax-example}
 {attribution="Chris Sewell, [link](https://example.com)"}
 > Hallo
 :::
 
 For *definition lists*, the adding a glossary key turns the definition list into a glossary (similar to using the [`glossary` directive](inv:sphinx:rst:directive#glossary) in Sphinx):
 
-:::{myst-example}
+:::{syntax-example}
 {.glossary}
 term name
 : Definition of the term
@@ -892,7 +892,7 @@ you can enable parsing of inline attributes after certain inline syntaxes.
 
 For example, the following Markdown:
 
-:::{myst-example}
+:::{syntax-example}
 
 - [A span of text with attributes]{#spanid .bg-warning},
   {ref}`a reference to the span <spanid>`
@@ -933,7 +933,7 @@ MyST provides a few different syntaxes for including images in your documentatio
 
 The first is the standard Markdown syntax:
 
-:::{myst-example}
+:::{syntax-example}
 ![fishy](img/fun-fish.png)
 :::
 
@@ -942,7 +942,7 @@ However, it is limited in the configuration that can be applied, for example set
 
 As discussed [above](syntax/directives), MyST allow for directives to be used such as `image` and `figure` (see {ref}`the sphinx documentation <sphinx:rst-primer>`):
 
-:::{myst-example}
+:::{syntax-example}
 ```{image} img/fun-fish.png
 :alt: fishy
 :class: bg-primary
@@ -961,7 +961,7 @@ HTML parsing to the rescue!
 By adding `"html_image"` to `myst_enable_extensions` (in the {{ confpy }}),
 MySt-Parser will attempt to convert any isolated `img` tags (i.e. not wrapped in any other HTML) to the internal representation used in sphinx.
 
-:::{myst-example}
+:::{syntax-example}
 :highlight: html
 
 <img src="img/fun-fish.png" alt="fishy" width="200px">
@@ -991,7 +991,7 @@ The figure block must contain **only** two components; an image, in either Markd
 
 The first line argument is optional and taken as the reference target of the figure:
 
-::::{myst-example}
+::::{syntax-example}
 
 :::{figure-md}
 ![fishy](img/fun-fish.png){.bg-primary .mb-1 width=200px}
@@ -1011,7 +1011,7 @@ This is a caption in **Markdown**
 
 As we see here, the target we set can be referenced:
 
-:::{myst-example}
+:::{syntax-example}
 [Go to the fish!](#fig-target)
 :::
 
@@ -1027,7 +1027,7 @@ This is helpful when you care about viewing the "source" Markdown, such as in Ju
 If the first element within the `div` is `<div class="title">` or `<p class="title">`, then this will be set as the admonition title.
 All internal text (and the title) will be parsed as MyST-Markdown and all classes and an optional name will be passed to the admonition:
 
-:::{myst-example}
+:::{syntax-example}
 :highlight: html
 
 <div class="admonition note" name="html-admonition" style="background: lightgreen; padding: 10px">
@@ -1042,7 +1042,7 @@ During the Sphinx render, both the `class` and `name` attributes will be used by
 There can be no empty lines in the block, otherwise they will be read as two separate blocks.
 If you want to use multiple paragraphs then they can be enclosed in `<p>`:
 
-:::{myst-example}
+:::{syntax-example}
 :highlight: html
 <div class="admonition note">
 <p>Paragraph 1</p>
@@ -1054,7 +1054,7 @@ If you want to use multiple paragraphs then they can be enclosed in `<p>`:
 
 You can also nest HTML admonitions:
 
-:::{myst-example}
+:::{syntax-example}
 :highlight: html
 <div class="admonition">
 <p>Some **content**</p>

--- a/docs/syntax/organising_content.md
+++ b/docs/syntax/organising_content.md
@@ -88,7 +88,7 @@ The `include` directive allows you to insert the contents of another document di
 The [`literalinclude` directive](#syntax/literalinclude), for including source code from files.
 :::
 
-:::{myst-example}
+:::{syntax-example}
 ```{literalinclude} example.txt
 ```
 
@@ -103,7 +103,7 @@ The following options allow you to include only part of a document:
 :start-after: Only the content after the first occurrence of the specified text will be included.
 :end-before: Only the content before the first occurrence of the specified text (but after any after text) will be included.
 
-:::{myst-example}
+:::{syntax-example}
 ```{literalinclude} example.txt
 ```
 
@@ -125,7 +125,7 @@ to make it relative to the location that it is being inserted:
 :relative-docs: Make Markdown file references, relative to the current document, if they start with a certain prefix
 :relative-images: Make Markdown image references, relative to the current document
 
-:::{myst-example}
+:::{syntax-example}
 ```{literalinclude} examples/example_relative_include.txt
 ```
 
@@ -145,7 +145,7 @@ Additional options:
 As explained in [this section](#syntax/directives/parsing), all MyST directives will parse their content as Markdown.
 So to include rST, we must first "wrap" the directive in the [eval-rst directive](#syntax/directives/parsing):
 
-:::{myst-example}
+:::{syntax-example}
 ```{eval-rst}
 .. include:: ../faq/snippets/include-rst.rst
 ```
@@ -172,7 +172,7 @@ To structure a project, with multiple documents, the [toctree directive](inv:sph
 The designate documents as children of the current document,
 building up a nested hierarchy of documents starting from a [`root_doc`](inv:sphinx:*:confval#root_doc).
 
-:::{myst-example}
+:::{syntax-example}
 ```{toctree}
 examples/content_child1.md
 examples/content_child2.md

--- a/docs/syntax/roles-and-directives.md
+++ b/docs/syntax/roles-and-directives.md
@@ -48,7 +48,7 @@ Here is the basic structure:
 
 For example:
 
-:::{myst-example}
+:::{syntax-example}
 ```{admonition} This is my admonition
 This is my note
 ```
@@ -62,7 +62,7 @@ The option block starts on the first line of the directive body and is defined b
 
 The block then follows a YAML-like mapping syntax, where the key (string) and value (string) are separated by a colon (`:`):
 
-:::{myst-example}
+:::{syntax-example}
 ```{code-block} python
 :lineno-start: 10
 :emphasize-lines: 1, 3
@@ -76,7 +76,7 @@ print(f'my {a}nd line')
 The values can be enclosed in quotes (`"` or `'`) and span multiple lines.
 Newline behaviour can be controlled by starting the value with `|` (preserve newlines) or `>` (collapse newlines):
 
-:::{myst-example}
+:::{syntax-example}
 ```{code-block} python
 :lineno-start: 10
 :emphasize-lines: "1, 3"
@@ -94,7 +94,7 @@ print(f'my {a}nd line')
 
 Option blocks can also be enclosed by `---`, with no `:` prefix, for example:
 
-:::{myst-example}
+:::{syntax-example}
 ```{code-block} python
 ---
 lineno-start: 10
@@ -120,7 +120,7 @@ MyST parses this content **as Markdown**.
 
 This means that MyST markdown can be written in the content areas of any directives written in MyST markdown. For example:
 
-:::{myst-example}
+:::{syntax-example}
 ```{admonition} My markdown link
 Here is [markdown link syntax](https://jupyter.org)
 ```
@@ -129,7 +129,7 @@ Here is [markdown link syntax](https://jupyter.org)
 As a short-hand for directives that require no arguments, and when no parameter options are used (see below),
 you may start the content directly after the directive name.
 
-:::{myst-example}
+:::{syntax-example}
 ```{note} Notes require **no** arguments, so content can start here.
 ```
 :::
@@ -137,7 +137,7 @@ you may start the content directly after the directive name.
 For special cases, MySt also offers the `eval-rst` directive.
 This will parse the content **as ReStructuredText**:
 
-:::{myst-example}
+:::{syntax-example}
 ```{eval-rst}
 .. figure:: img/fun-fish.png
   :width: 100px
@@ -159,7 +159,7 @@ You can nest directives by ensuring that the tick-lines corresponding to the
 outermost directive are longer than the tick-lines for the inner directives.
 For example, nest a warning inside a note block like so:
 
-:::{myst-example}
+:::{syntax-example}
 ````{note}
 The next info should be nested
 ```{warning}
@@ -171,7 +171,7 @@ Here's my warning
 You can indent inner-code fences, so long as they aren't indented by more than 3 spaces.
 Otherwise, they will be rendered as "raw code" blocks:
 
-:::{myst-example}
+:::{syntax-example}
 ````{note}
 The warning block will be properly-parsed
 
@@ -189,7 +189,7 @@ But the next block will be parsed as raw text
 
 This can really be abused if you'd like ;-)
 
-:::{myst-example}
+:::{syntax-example}
 ``````{note}
 The next info should be nested
 `````{warning}
@@ -209,7 +209,7 @@ print('yep!')
 Want to use syntax that renders correctly in standard Markdown editors?
 See [the extended syntax option](syntax/colon_fence).
 
-::::{myst-example}
+::::{syntax-example}
 :::{note}
 This text is **standard** *Markdown*
 :::
@@ -237,14 +237,14 @@ To define an in-line role, use the following form:
 
 For example:
 
-:::{myst-example}
+:::{syntax-example}
 Since Pythagoras, we know that {math}`a^2 + b^2 = c^2`
 :::
 
 You can use roles to do things like reference equations and other items in
 your book. For example:
 
-:::{myst-example}
+:::{syntax-example}
 ```{math} e^{i\pi} + 1 = 0
 :label: euler
 ```
@@ -283,7 +283,7 @@ You may insert the "last updated" date and estimated reading time into your docu
 
 For example:
 
-:::{myst-example}
+:::{syntax-example}
 > {sub-ref}`today` | {sub-ref}`wordcount-words` words | {sub-ref}`wordcount-minutes` min read
 :::
 

--- a/docs/syntax/tables.md
+++ b/docs/syntax/tables.md
@@ -4,7 +4,7 @@
 
 Tables can be written using the standard [Github Flavoured Markdown syntax](https://github.github.com/gfm/#tables-extension-):
 
-:::{myst-example}
+:::{syntax-example}
 | foo | bar |
 | --- | --- |
 | baz | bim |
@@ -12,7 +12,7 @@ Tables can be written using the standard [Github Flavoured Markdown syntax](http
 
 Cells in a column can be aligned using the `:` character:
 
-:::{myst-example}
+:::{syntax-example}
 | left | center | right |
 | :--- | :----: | ----: |
 | a    | b      | c     |
@@ -41,7 +41,7 @@ It is then necessary for the theme you are using to include the appropriate css 
 
 The `table` directive can be used to create a table with a caption:
 
-::::{myst-example}
+::::{syntax-example}
 :::{table} Table caption
 :widths: auto
 :align: center
@@ -76,7 +76,7 @@ The following options are recognized:
 The `list-table` directive is used to create a table from data in a uniform two-level bullet list.
 "Uniform" means that each sublist (second-level list) must contain the same number of list items.
 
-::::{myst-example}
+::::{syntax-example}
 :::{list-table} Frozen Delights!
 :widths: 15 10 30
 :header-rows: 1
@@ -132,7 +132,7 @@ The following options are recognized:
 
 The `csv-table` directive is used to create a table from Comma-Separated-Values data.
 
-:::{myst-example}
+:::{syntax-example}
 ```{csv-table} Frozen Delights!
 :header: >
 :    "Treat", "Quantity", "Description"

--- a/docs/syntax/typography.md
+++ b/docs/syntax/typography.md
@@ -9,7 +9,7 @@ It adds features focussed on scientific and technical documentation authoring, a
 
 Markdown syntax denotes headers starting with between 1 to 6 #.
 
-:::{myst-example}
+:::{syntax-example}
 ### Heading Level 3
 :::
 
@@ -18,7 +18,7 @@ will not be included in the table of contents.
 Using the [attrs_block](#syntax/attributes/block) extension,
 you can also add classes to headings
 
-:::{myst-example}
+:::{syntax-example}
 > {.bg-primary}
 > ### Paragraph heading
 :::
@@ -36,7 +36,7 @@ Paragraphs are block of text separated by a blank line.
 Using the [attrs_block](#syntax/attributes/block) extension,
 you can also add classes to paragraphs:
 
-:::{myst-example}
+:::{syntax-example}
 {.bg-primary}
 Here is a paragraph with a class to control its formatting.
 :::
@@ -47,7 +47,7 @@ Here is a paragraph with a class to control its formatting.
 
 You can create a thematic break, to break content between themes, using three or more `*`, `-`, or `_` characters on a line by themselves.
 
-:::{myst-example}
+:::{syntax-example}
 :alt-output: <hr class="docutils">
 * * *
 :::
@@ -56,20 +56,20 @@ You can create a thematic break, to break content between themes, using three or
 
 Standard inline formatting including bold, italic, code, as well as escaped symbols and line breaks:
 
-:::{myst-example}
+:::{syntax-example}
 **strong**, _emphasis_, `literal text`, \*escaped symbols\*
 :::
 
 The [strikethrough](syntax/strikethrough) extension allows you to add strike-through text:
 
-:::{myst-example}
+:::{syntax-example}
 ~~strikethrough with *emphasis*~~
 :::
 
 The [smartquotes](syntax/smartquotes) and [replacements](syntax/replacements) extensions can improve the typography of common symbols:
 
 
-:::{myst-example}
+:::{syntax-example}
 Smart-quotes 'single quotes' and "double quotes".
 
 +-, --, ---, ... and other replacements.
@@ -78,7 +78,7 @@ Smart-quotes 'single quotes' and "double quotes".
 Using the [attrs_inline](syntax/attributes/inline) extension,
 you can also add classes to inline text spans:
 
-:::{myst-example}
+:::{syntax-example}
 A paragraph with a span of [text with attributes]{.bg-warning}
 :::
 
@@ -86,7 +86,7 @@ A paragraph with a span of [text with attributes]{.bg-warning}
 
 To put a line break, without a paragraph, use a `\` followed by a new line. This corresponds to a `<br>` in HTML and `\\` in LaTeX.
 
-:::{myst-example}
+:::{syntax-example}
 **Fleas** \
 Adam \
 Had 'em.
@@ -97,7 +97,7 @@ Had 'em.
 
 Alternatively, you can use the `line-block` directive, which constructs a block where all line breaks (and also initial indentations) are respected:
 
-::::{myst-example}
+::::{syntax-example}
 :::{line-block}
 **Fleas**
   Adam
@@ -111,7 +111,7 @@ You can use bullet points and numbered lists as you would in standard Markdown.
 Starting a line with either a `-` or `*` for a bullet point, and `1.` for numbered lists.
 These lists can be nested using two spaces at the start of the line.
 
-:::{myst-example}
+:::{syntax-example}
 - Lists can start with `-` or `*`
   * My other, nested
   * bullet point list!
@@ -129,7 +129,7 @@ The exception is the first number, which if it is not `1.` this will change the 
 Using the [attrs_block](#syntax/attributes/block) extension,
 you can also specify a alternative numbering styles:
 
-:::{myst-example}
+:::{syntax-example}
 {style=lower-alpha}
 1. a
 2. b
@@ -152,7 +152,7 @@ you can also specify a alternative numbering styles:
 Using the [tasklist](syntax/tasklists) extension,
 you can also create task lists:
 
-:::{myst-example}
+:::{syntax-example}
 - [ ] An item that needs doing
 - [x] An item that is complete
 :::
@@ -162,7 +162,7 @@ you can also create task lists:
 For inline typography for subscript and superscript formatting,
 the `sub` and `sup` {{role}}, can be used respectively.
 
-:::{myst-example}
+:::{syntax-example}
 H{sub}`2`O, and 4{sup}`th` of July
 :::
 
@@ -171,14 +171,14 @@ H{sub}`2`O, and 4{sup}`th` of July
 
 Quotations are controlled with standard Markdown syntax, by inserting a caret (>) symbol in front of one or more lines of text.
 
-:::{myst-example}
+:::{syntax-example}
 > We know what we are, but know not what we may be.
 :::
 
 Using the [attrs_block](#syntax/attributes/block) extension,
 you can also add an `attribution` attribute to a block quote:
 
-:::{myst-example}
+:::{syntax-example}
 {attribution="Hamlet act 4, Scene 5"}
 > We know what we are, but know not what we may be.
 :::
@@ -189,7 +189,7 @@ you can also add an `attribution` attribute to a block quote:
 Using the [definition lists](syntax/definition-lists) extension,
 you can define terms in your documentation, using the syntax:
 
-:::{myst-example}
+:::{syntax-example}
 Term 1
 : Definition
 
@@ -205,7 +205,7 @@ Term 2
 Using the [attrs_block](#syntax/attributes/block) extension,
 you can also add a `glossary` class to a definition list, that will allow you to reference terms in your text using the [`term` role](syntax/roles):
 
-:::{myst-example}
+:::{syntax-example}
 {.glossary}
 my term
 : Definition of the term
@@ -218,7 +218,7 @@ my term
 Using the [field lists](syntax/fieldlists) extension,
 you can create field lists, which are useful in source code documentation (see [Sphinx docstrings](inv:sphinx#info-field-lists)):
 
-:::{myst-example}
+:::{syntax-example}
 
 :param arg1: A description of arg1
 :param arg2: A longer description,
@@ -238,7 +238,7 @@ prevent the line from being parsed into the output document.
 
 For example, this won't be parsed into the document:
 
-:::{myst-example}
+:::{syntax-example}
 % my comment
 :::
 
@@ -249,7 +249,7 @@ Since comments are a block-level entity, they will terminate the previous block.
 In practical terms, this means that the following lines
 will be broken up into two paragraphs, resulting in a new line between them:
 
-:::{myst-example}
+:::{syntax-example}
 a line
 % a comment
 another line
@@ -269,7 +269,7 @@ Their labels **start with `^`** and can then be any alphanumeric string (no spac
 All footnote definitions are collected, and displayed at the bottom of the page (in the order they are referenced).
 Note that un-referenced footnote definitions will not be displayed.
 
-:::{myst-example}
+:::{syntax-example}
 - This is a manually-numbered footnote reference.[^3]
 - This is an auto-numbered footnote reference.[^myref]
 
@@ -280,7 +280,7 @@ Note that un-referenced footnote definitions will not be displayed.
 Any preceding text after a footnote definitions, which is
 indented by four or more spaces, will also be included in the footnote definition, and the text is rendered as MyST Markdown, e.g.
 
-:::{myst-example}
+:::{syntax-example}
 A longer footnote definition.[^mylongdef]
 
 [^mylongdef]: This is the _**footnote definition**_.

--- a/myst_parser/_docs.py
+++ b/myst_parser/_docs.py
@@ -14,6 +14,7 @@ from sphinx.directives import other
 from sphinx.transforms.post_transforms import SphinxPostTransform
 from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
+from sphinx_syntax_example import SyntaxExampleDirective
 
 from myst_parser.parsers.docutils_ import to_html5_demo
 
@@ -280,41 +281,62 @@ class MystWarningsDirective(SphinxDirective):
         return node.children
 
 
-class MystExampleDirective(SphinxDirective):
-    """Directive to create an example, showing the source and output."""
+class SyntaxExampleDocsDirective(SyntaxExampleDirective):
+    """Directive to create an example, showing the source and output.
 
-    has_content = True
+    This is the generic ``syntax-example`` directive from the
+    ``sphinx-syntax-example`` package, adapted to these docs: it never shows a
+    title, frames itself as a sphinx-design div, and gains an ``:alt-output:``
+    option for the (rare) case where the rendered half must differ from the
+    source shown above it.
+
+    The source pane's language needs no override: the base class' lexer probe
+    consults Sphinx's ``add_lexer`` registry, so it finds the ``MystLexer``
+    registered in ``docs/conf.py`` and infers ``myst`` for these Markdown docs.
+    """
+
+    # The previous implementation took no argument; keeping it that way means a
+    # stray argument cannot become a rubric — MyST folds the opening-line text
+    # into the content of a directive that declares no arguments.
+    optional_arguments = 0
     option_spec = {
+        **SyntaxExampleDirective.option_spec,
         "alt-output": directives.unchanged,
-        "highlight": directives.unchanged,
-        # "html": directives.flag,
     }
 
-    def run(self):
-        """Run the directive."""
-        content_str = "\n".join(self.content)
-        output_str = self.options.get("alt-output", content_str)
-        highlight = self.options.get("highlight", "myst")
-        backticks = "```"
-        while backticks in content_str:
-            backticks += "`"
-        content = f"""
-{backticks}``{{div}} myst-example
+    #: These docs never label their examples, so no rubric is emitted.
+    default_title = ""
 
-{backticks}`{{div}} myst-example-source
-{backticks}{highlight}
-{content_str}
-{backticks}
-{backticks}`
-{backticks}`{{div}} myst-example-render
+    def build_wrapper_node(self) -> nodes.Element:
+        """Frame the example as a sphinx-design div rather than a container.
 
-{output_str}
-{backticks}`
-{backticks}``
-"""
-        node_ = nodes.Element()
-        self.state.nested_parse(content.splitlines(), self.content_offset, node_)
-        return node_.children
+        A plain ``container`` renders as ``<div class="docutils container">``,
+        and that ``container`` class attracts the theme's Bootstrap layout
+        rules; sphinx-design's overridden container visitor drops it for nodes
+        flagged ``is_div``, which is what the previous implementation got by
+        wrapping its content in ``{div}`` directives. ``design_component`` is
+        inert for a plain div — only sphinx-design's ``is_component()`` reads
+        it, for tab-set/grid/card children — and is set to match what ``{div}``
+        produced.
+
+        Per the seam's contract, the CSS classes are left to ``run()``.
+        """
+        return nodes.container(is_div=True, design_component="div")
+
+    def build_render_node(self) -> nodes.Element:
+        """Emit the render pane as a sphinx-design div, as for the wrapper."""
+        return nodes.container(is_div=True, design_component="div")
+
+    def render_into(self, container: nodes.Element) -> None:
+        """Render ``:alt-output:`` when given, otherwise the verbatim content.
+
+        The alternative output is parsed as MyST, just like the content it
+        replaces, so it may be raw HTML, markup, or a mix of the two.
+        """
+        if "alt-output" in self.options:
+            self.nested_parse_text(self.options["alt-output"], container)
+        else:
+            super().render_into(container)
 
 
 class MystAdmonitionDirective(SphinxDirective):
@@ -362,7 +384,7 @@ class MystToHTMLDirective(SphinxDirective):
             cli_opt += f"--myst-enable-extensions={self.options['extensions']}"
         html = to_html5_demo(content_str, **kwargs)
         content = f"""\
-::::myst-example
+::::syntax-example
 ```bash
 myst-docutils-demo example.md {cli_opt}
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ rtd = [
     "sphinx-tippy>=0.4.3",
     "sphinx-autodoc2~=0.5.0",
     "sphinx-togglebutton",
+    "sphinx-syntax-example~=0.2.0",
 ]
 testing = [
     "beautifulsoup4",


### PR DESCRIPTION

## What

Replaces the bespoke `myst-example` docs directive (`myst_parser/_docs.py`) with a
thin subclass of the published
[`sphinx-syntax-example`](https://pypi.org/project/sphinx-syntax-example/) 0.2.0,
and renames the directive — and its CSS classes — to the canonical
`syntax-example`.

This is a docs-tooling change only. Nothing in the shipped parser changes: the
only touched runtime module is `myst_parser/_docs.py`, which is imported solely
by `docs/conf.py` (it is excluded from the autodoc2 API docs and omitted from
coverage).

## Why

**Reuse over bespoke.** The "show this markup as source and as rendered output"
directive is generic; it is now maintained as a standalone package rather than as
~35 lines of string templating inside this repo.

**It removes a re-serialisation hack.** The old implementation did not build
nodes — it built a *synthetic MyST document* that wrapped the content in
sphinx-design `{div}` fences and re-parsed it, growing its own backtick fence
(` ``` ` → ` ```` ` → …) until it was longer than any fence in the content, just
so nested code fences would survive the round trip:

```python
backticks = "```"
while backticks in content_str:
    backticks += "`"
```

The base class builds the container / literal-block / container subtree directly,
so that whole class of quoting problem disappears. As a side effect **source-line
attribution improves**: content is now nested-parsed at its real offset instead of
inside a re-generated string, so warnings inside an example point at the line the
author actually wrote.

**One canonical directive name across the ecosystem.** `syntax-example` is the
name used by the published extension, by sphinx-needs, and by the ubCode docs; the
ubCode Rust engine recognises `syntax-example` natively. Aligning here means the
same markup works in all of them, and a reader who learns the directive in one
project already knows it in the next.

## Exact parity

The subclass pins every behaviour the old directive had:

| Behaviour | How it is preserved |
| --- | --- |
| Never renders a title / rubric | `default_title = ""` (the base suppresses the rubric element entirely, rather than emitting an empty one) |
| Takes no argument | `optional_arguments = 0` — the base allows an optional title argument, which would otherwise let a stray argument silently *create* a rubric. With it set to 0, MyST folds any opening-line text into the content instead |
| `:highlight:` option | Same option name, inherited from the base's `option_spec` |
| `:alt-output:` option | Added to `option_spec`; `render_into()` hands that value to the base class' `nested_parse_text()` helper, which parses it with the host document's parser — MyST here (used once, `docs/syntax/typography.md`) |
| Source pane highlights as `myst` | Inferred, with no override. `MystLexer` is registered via `app.add_lexer()`, and the base class' lexer probe consults Sphinx's `add_lexer` registries as well as Pygments', so a Markdown document resolves to `myst` on its own |
| HTML divs carry no `container` class | `build_wrapper_node()` and `build_render_node()` return `nodes.container(is_div=True, design_component="div")`. `is_div` is the flag sphinx-design's overridden container visitor keys on; without it the divs would render as `class="docutils container"` and pick up the theme's Bootstrap `.container` layout rules. `design_component` is inert here — read only by sphinx-design's `is_component()` for tab-set/grid/card children — and is set to match what `{div}` produced |

`MystLexer`, `MystToHTMLDirective` and every other `_docs.py` member are otherwise
untouched.

**One deliberate behaviour change**: a bodyless `syntax-example` now hard-errors
(the base class calls `assert_has_content()`), where the old directive rendered an
empty frame. No current usage is bodyless.

The subclass is only four members: two one-line node factories, `render_into()`
for `:alt-output:`, and the class attributes. It re-implements nothing — per the
package's contract the node factories return bare nodes and `run()` applies
`wrapper_classes` / `render_classes` to them, so the CSS classes cannot drift out
of sync with the stylesheet.

## The rename

`myst-example` → `syntax-example`, applied consistently in three places that must
move together, because `MystToHTMLDirective` shares the frame styling via the CSS
class:

1. `docs/conf.py` registers the subclass as `syntax-example`.
2. All 126 usages in `docs/**/*.md` (124 active + the 2 commented-out ones, so
   re-enabling them later still works).
3. The CSS classes become the base class defaults (`syntax-example`,
   `syntax-example-source`, `syntax-example-render`), with the selectors in
   `docs/_static/local.css` renamed to match and the `myst-to-html` directive now
   emitting `::::syntax-example`.

The packaged extension's own stylesheet is **not** loaded: `sphinx_syntax_example`
is deliberately kept out of the `extensions` list and only the class is imported,
so `local.css` remains the single source of styling and there is no
double-styling despite the shared class names.

`local.css` rule bodies are unchanged, with one necessary exception. The base
class puts the source class directly on the `literal_block`, so the source pane
*is* the `highlight-<lang>` div rather than a wrapper around it, and the old
child-combinator selector no longer matches:

```css
/* before */
.myst-example-source > div[class*="highlight-"] { margin: 0; }
/* after */
.syntax-example > .syntax-example-source { margin: 0; }
```

Same declaration, re-pointed at the new DOM, keeping the source pane flush inside
the frame (`local.css` loads last).

## Verification

Built from a clean worktree with `pip install -e .[linkify,rtd]`:

- `sphinx-build -nW --keep-going` succeeds for **html, text, man and latex** (the
  four strict builders between CI and RTD), with zero warnings.
- Full test suite: 1241 passed, 15 skipped.
- `ruff check`, `ruff format` and `mypy` clean. `sphinx-syntax-example~=0.2.0` is
  added to the `rtd` extra and to the mypy pre-commit hook's
  `additional_dependencies` (the package ships `py.typed`).

Output compared against a build of unmodified `master`, in an environment pinned
to the same docutils and Sphinx:

- **All 127 example blocks are byte-for-byte identical** after accounting for the
  class rename and the one collapsed wrapper level — 124 from the directive plus
  3 from `myst-to-html`, with the same per-file distribution.
- Source-pane languages unchanged: 113 `highlight-myst`, 6 `highlight-latex`,
  5 `highlight-html`.
- No `container` class on any `syntax-example` div.
- The `:alt-output:` example still shows `* * *` as its source and an
  `<hr class="docutils">` as its rendered output.
- `intro.html`'s `myst-to-html` blocks are unchanged and keep their frame.
- Text-builder output differs only by 7 removed blank lines, all of them the extra
  blank line the old redundant source-pane wrapper used to produce.

## Note for reviewers

Because `syntax-example` is now registered directly by `docs/conf.py`, adding
`sphinx_syntax_example` to the `extensions` list later would register the
directive twice. If we ever want the packaged stylesheet, the local registration
should be dropped at the same time.
