### PR TITLE
Fix line attribution inside included markdown being off by one

### DIFF
--- a/myst_parser/mocking.py
+++ b/myst_parser/mocking.py
@@ -516,7 +516,12 @@ class MockIncludeDirective:
                 )
             self.renderer.nested_render_text(
                 file_content,
-                startline + 1,
+                # ``nested_render_text`` adds this to the 0-based token maps, and
+                # ``_render_tokens`` applies the 0-based to 1-based conversion
+                # afterwards. So the offset of the first included line is
+                # ``startline``, already 0-based; adding one here reported every
+                # line in the file one too low.
+                startline,
                 heading_offset=self.options.get("heading-offset", 0),
             )
         finally:

--- a/tests/test_renderers/fixtures/mock_include_errors.md
+++ b/tests/test_renderers/fixtures/mock_include_errors.md
@@ -19,5 +19,48 @@ Error in include file:
 ```{include} bad.md
 ```
 .
-tmpdir/bad.md:2: (WARNING/2) Unknown interpreted text role "a". [myst.role_unknown]
+tmpdir/bad.md:1: (WARNING/2) Unknown interpreted text role "a". [myst.role_unknown]
+.
+
+Error line in include file:
+.
+```{include} bad_line3.md
+```
+.
+tmpdir/bad_line3.md:3: (WARNING/2) Unknown interpreted text role "a". [myst.role_unknown]
+.
+
+Error line in include file, after content in the parent:
+.
+para
+
+```{include} bad_line3.md
+```
+.
+tmpdir/bad_line3.md:3: (WARNING/2) Unknown interpreted text role "a". [myst.role_unknown]
+.
+
+Error line in include file with start-line:
+.
+```{include} bad_skipped.md
+:start-line: 2
+```
+.
+tmpdir/bad_skipped.md:4: (WARNING/2) Unknown interpreted text role "a". [myst.role_unknown]
+.
+
+Error line in include file with front matter:
+.
+```{include} bad_frontmatter.md
+```
+.
+tmpdir/bad_frontmatter.md:5: (WARNING/2) Unknown interpreted text role "a". [myst.role_unknown]
+.
+
+Error line in nested include file:
+.
+```{include} bad_outer.md
+```
+.
+tmpdir/bad_inner.md:3: (WARNING/2) Unknown interpreted text role "a". [myst.role_unknown]
 .

--- a/tests/test_renderers/test_include_directive.py
+++ b/tests/test_renderers/test_include_directive.py
@@ -41,6 +41,15 @@ def test_errors(file_params, tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
 
     tmp_path.joinpath("bad.md").write_text("{a}`b`")
+    # The role sits on line 3, so a warning reported against any other line is
+    # the include's own line attribution being off.
+    tmp_path.joinpath("bad_line3.md").write_text("line one\n\n{a}`b`\n")
+    tmp_path.joinpath("bad_skipped.md").write_text("skipped\nskipped2\n\n{a}`b`\n")
+    tmp_path.joinpath("bad_frontmatter.md").write_text("---\nx: 1\n---\n\n{a}`b`\n")
+    tmp_path.joinpath("bad_inner.md").write_text("inner one\n\n{a}`b`\n")
+    tmp_path.joinpath("bad_outer.md").write_text(
+        "outer line\n\n```{include} bad_inner.md\n```\n"
+    )
 
     report_stream = StringIO()
     publish_doctree(


### PR DESCRIPTION
Fixes #1165.

## Cause

`MockIncludeDirective.run` calls:

```python
self.renderer.nested_render_text(file_content, startline + 1, ...)
```

`nested_render_text` adds that `lineno` to the **0-based** token maps, and `_render_tokens` then applies its own 0-based → 1-based `+ 1`. `startline` is already the 0-based offset of the first included line, so adding one here reports every warning inside an included file one line too low. Exactly as diagnosed in the issue — a one-token change.

## The existing fixture encoded the bug

`tests/test_renderers/fixtures/mock_include_errors.md` expected:

```
tmpdir/bad.md:2: (WARNING/2) Unknown interpreted text role "a".
```

while `bad.md` is written as `"{a}`b`"` — a single line. That expectation is now `:1`.

## Regression cases

The issue asked for these before touching the line, so the fixture gains five more, each with the offending role in a paragraph of its own (MyST attributes an inline warning to its enclosing block's start line, which is worth being deliberate about here):

| case | file | role on | expected |
|---|---|---|---|
| plain include | `bad_line3.md` | 3 | `:3` |
| include after content in the parent | `bad_line3.md` | 3 | `:3` |
| `:start-line: 2` | `bad_skipped.md` | 4 | `:4` |
| front matter stripped | `bad_frontmatter.md` | 5 | `:5` |
| nested include | `bad_inner.md` via `bad_outer.md` | 3 | `:3` |

All six cases fail on `master` and pass with the change — I checked by reverting only `mocking.py` and leaving the tests in place.

The nested case is worth calling out: before this change it *appeared* correct for a role sharing a paragraph with the preceding line, because the two errors cancelled. Putting the role in its own paragraph shows it was off by one like the rest.

`:heading-offset:` was also probed and is unaffected (heading offsetting shifts levels, not maps), as is front-matter stripping — the `front_matter` token is popped before the maps are adjusted, so it shifts nothing.

## Test run

`1240 passed, 18 skipped`. Three failures are pre-existing on an unmodified checkout in this environment (`test_cmdline[40-linkify]`, `test_extended_syntaxes`, `test_extended_syntaxes_text`) — I diffed the `FAILED` sets before and after, and those three are identical on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)