### PR TITLE
✨ Expose MyST substitutions to reStructuredText

### DIFF
--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -295,6 +295,17 @@ class DocutilsRenderer(RendererProtocol):
                     substitution_node, f"wordcount-{key}"
                 )
 
+        for key, value in self.md_config.substitutions.items():
+            if value is None:
+                continue
+
+            substitution_node = nodes.substitution_definition(
+                str(value), nodes.Text(str(value))
+            )
+            substitution_node.source = self.document["source"]
+            substitution_node["names"].append(key)
+            self.document.note_substitution_def(substitution_node, key)
+
     def nested_render_text(
         self,
         text: str,

--- a/tests/test_sphinx/sourcedirs/substitutions/index.md
+++ b/tests/test_sphinx/sourcedirs/substitutions/index.md
@@ -23,6 +23,7 @@ myst:
       - item1
     nested_dict:
       key1: value1
+    unused: null
 
 ---
 
@@ -50,6 +51,12 @@ This will not process the substitution
 
 ```python
 {{ text_with_nest }}
+```
+
+Test substitutions are processed within eval-rst
+
+```{eval-rst}
+a |text| b
 ```
 
 Using env and filters:

--- a/tests/test_sphinx/test_sphinx_builds/test_substitutions.html
+++ b/tests/test_sphinx/test_sphinx_builds/test_substitutions.html
@@ -63,6 +63,12 @@
     </div>
    </div>
    <p>
+    Test substitutions are processed within eval-rst
+   </p>
+   <p>
+    a - text b
+   </p>
+   <p>
     Using env and filters:
    </p>
    <p>

--- a/tests/test_sphinx/test_sphinx_builds/test_substitutions.xml
+++ b/tests/test_sphinx/test_sphinx_builds/test_substitutions.xml
@@ -48,6 +48,12 @@
     <literal_block language="python" xml:space="preserve">
         {{ text_with_nest }}
     <paragraph>
+        Test substitutions are processed within eval-rst
+    <paragraph>
+        a 
+        - text
+         b
+    <paragraph>
         Using env and filters:
     <paragraph>
         INDEX


### PR DESCRIPTION
Supersedes #966 by rebasing Chance Zibolski's original implementation onto current `master`; the original commit authorship is preserved.

This registers configured MyST substitutions as docutils substitution definitions, making them available inside `{eval-rst}` blocks. It retains the original Sphinx regression coverage and adds coverage for substitutions whose value is `None`.

Validation:

- `uvx --with tox-uv tox`: 1,245 passed, 11 skipped
- `uvx --with tox-uv tox -e ruff-check`: passed
- mypy: passed after installing the tox environment's omitted existing `sphinx-syntax-example` dependency

The unmodified `master` branch reproduces that missing-dependency mypy failure.
