### PR TITLE
Pin the cross-document explicit-target reference from #1151

### DIFF
--- a/tests/test_renderers/test_myst_refs.py
+++ b/tests/test_renderers/test_myst_refs.py
@@ -142,3 +142,37 @@ def test_slug_id_stays_secondary_under_sortids(sphinx_doctree: CreateDoctree):
     for section in doctree.findall(docutils_nodes.section):
         assert section["ids"][0].startswith("id"), section["ids"]
         assert section["slug"] in section["ids"][1:], section["ids"]
+
+
+def test_cross_document_reference_to_an_explicit_target(sphinx_doctree: CreateDoctree):
+    """`[](a.md#target)` must not warn when `target` is an explicit anchor in `a.md`.
+
+    Regression test for #1151. On 5.1.0 the path-based spelling emitted
+    `local id not found in doc 'a': 'custom-anchor' [myst.xref_missing]` while
+    rendering the correct, working href -- and the pathless `[](#custom-anchor)`
+    form of the same reference resolved silently. #1158 fixed it as part of the
+    explicit-id priority work; this pins it, since the existing
+    `doc_with_target_id` case has both the target and the link in one file and
+    does not enable `myst_heading_anchors`.
+    """
+    sphinx_doctree.set_conf(
+        {
+            "extensions": ["myst_parser"],
+            "show_warning_types": True,
+            "myst_heading_anchors": 3,
+        }
+    )
+    # The explicit target sits directly above a heading, which is the
+    # combination that made heading-anchor resolution take over.
+    sphinx_doctree.srcdir.joinpath("a.md").write_text(
+        "# Doc A\n\n(custom-anchor)=\n\n## My Heading\n\nSome content.\n",
+        encoding="utf8",
+    )
+    result = sphinx_doctree(
+        "# Doc B\n\n- [path-based](a.md#custom-anchor)\n- [pathless](#custom-anchor)\n",
+        "index.md",
+    )
+    assert not result.warnings
+
+    result.get_resolved_doctree("index")
+    assert not result.warnings, result.warnings


### PR DESCRIPTION
Closes #1151 — **already fixed on `master`**, so this is the regression test only.

## The bisect

I ran the issue's reproduction verbatim against both:

```
v5.1.0   WARNING: local id not found in doc 'a': 'custom-anchor' [myst.xref_missing]
master   (no warning)
```

#1158 (*stable heading anchors … explicit-id priority*) landed after `v5.1.0`, which is the release the reporter was on. So the fix is in, and the issue can be closed once this or something like it guards it.

## Why a new test rather than relying on `doc_with_target_id`

`doc_with_target_id` (`"(ref)=\n# Title\n[](index.md#ref)"`) looks like it covers this, but it differs from the reported case in the two ways that mattered:

- **It is one file.** The target and the link are both in `index.md`; the issue is about a link in `b.md` to a target in `a.md`.
- **It does not enable `myst_heading_anchors`.** The false positive came from heading-anchor resolution taking precedence over the explicit target, so a case without heading anchors cannot see it.

The new test uses two documents with `myst_heading_anchors: 3`, and puts the explicit target directly above a heading — the placement that made heading-anchor resolution take over. It asserts on both spellings together (`[](a.md#custom-anchor)` and `[](#custom-anchor)`), since the bug was precisely that the two disagreed.

`sphinx_doctree.srcdir` is used to write the second file before the call, which is the only wrinkle — the fixture's `__call__` writes one file, but the source directory is available for the rest.

## Verified the test bites

Checked out `v5.1.0`, copied this test in, and ran it:

```
E  assert not "<src>\index.md:3: WARNING: local id not found in doc 'a': 'custom-anchor' [myst.xref_missing]"
FAILED test_cross_document_reference_to_an_explicit_target
```

Exactly the warning from the issue. On `master` it passes.

```
pytest tests/test_renderers/test_myst_refs.py    14 passed, 2 skipped
ruff 0.15.20 check / format                      clean
```

No source change, so no changelog entry.
