### PR TITLE
🐛 FIX: attrs: KeyError on aliased image attributes, duplicate {#id} headings, new-tab link attributes

### DIFF
--- a/myst_parser/config/main.py
+++ b/myst_parser/config/main.py
@@ -242,7 +242,9 @@ class MdParserConfig:
         default=False,
         metadata={
             "validator": instance_of(bool),
-            "help": "Open all external links in a new tab",
+            "help": "Open all external links in a new tab "
+            '(sets target="_blank" and rel="noreferrer noopener", '
+            "unless the link already sets them)",
         },
     )
 

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -430,7 +430,7 @@ class DocutilsRenderer(RendererProtocol):
                         value = converters[key](str(value))
                     except ValueError:
                         self.create_warning(
-                            f"Invalid {key!r} attribute value: {token.attrs[key]!r}",
+                            f"Invalid {key!r} attribute value: {value!r}",
                             MystWarnings.INVALID_ATTRIBUTE,
                             line=token_line(token, default=0),
                             append_to=node,

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -1009,8 +1009,8 @@ class DocutilsRenderer(RendererProtocol):
         self.add_line_and_source_path(ref_node, token)
         attribute_keys = ["class", "id", "reftitle", "target", "rel"]
         if self.md_config.links_external_new_tab:
-            token.attrs["target"] = "_blank"
-            token.attrs["rel"] = "noreferrer noopener"
+            token.attrs.setdefault("target", "_blank")
+            token.attrs.setdefault("rel", "noreferrer noopener")
         self.copy_attributes(
             token, ref_node, attribute_keys, aliases={"title": "reftitle"}
         )

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -851,8 +851,20 @@ class DocutilsRenderer(RendererProtocol):
         # TODO this is purely to mimic docutils, but maybe we don't need it?
         # (since we have the slugify logic below)
         name = nodes.fully_normalize_name(implicit_text)
-        node["names"].append(name)
-        self.document.note_implicit_target(node, node)
+        # Register only this new, implicit name.
+        # ``note_implicit_target`` re-registers *every* name already on the node,
+        # as an implicit one -- including an explicit ``{#id}`` name that
+        # ``copy_attributes`` has already added and registered. The node then
+        # collides with itself: docutils demotes the explicit name into
+        # ``dupnames`` while its name map still points here, so a later,
+        # genuine duplicate of that name raises
+        # ``ValueError: list.remove(x): x not in list``.
+        explicit_names = node["names"]
+        node["names"] = [name]
+        try:
+            self.document.note_implicit_target(node, node)
+        finally:
+            node["names"] = explicit_names + node["names"]
 
         if level > self.md_config.heading_anchors:
             return

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -659,7 +659,7 @@ class DocutilsRenderer(RendererProtocol):
 
         hl_lines = parselinenos(emphasize_lines, num_lines)
         if any(i >= num_lines for i in hl_lines):
-            raise ValueError(f"out of range(1-{num_lines}")
+            raise ValueError(f"out of range(1-{num_lines})")
 
         return [x + 1 for x in hl_lines if x < num_lines]
 

--- a/myst_parser/mdit_to_docutils/base.py
+++ b/myst_parser/mdit_to_docutils/base.py
@@ -1010,7 +1010,7 @@ class DocutilsRenderer(RendererProtocol):
         attribute_keys = ["class", "id", "reftitle", "target", "rel"]
         if self.md_config.links_external_new_tab:
             token.attrs["target"] = "_blank"
-            token.attrs["rel"] = "noreferer noopener"
+            token.attrs["rel"] = "noreferrer noopener"
         self.copy_attributes(
             token, ref_node, attribute_keys, aliases={"title": "reftitle"}
         )

--- a/tests/test_docutils.py
+++ b/tests/test_docutils.py
@@ -113,6 +113,8 @@ def test_help_text():
             assert not exc.code
 
     assert "MyST options" in stream.getvalue()
+    # the option's help text is its only user-facing documentation
+    assert 'rel="noreferrer noopener"' in " ".join(stream.getvalue().split())
 
 
 def test_include_from_rst(tmp_path):

--- a/tests/test_renderers/fixtures/attributes.md
+++ b/tests/test_renderers/fixtures/attributes.md
@@ -81,12 +81,9 @@ list-style
 heading with id
 .
 {#hid}
-## First
+# First
 .
 <document source="<src>/index.md">
-    <system_message level="2" line="2" source="<src>/index.md" type="WARNING">
-        <paragraph>
-            Document headings start at H2, not H1 [myst.header]
     <section ids="hid" names="hid first">
         <title>
             First

--- a/tests/test_renderers/fixtures/attributes.md
+++ b/tests/test_renderers/fixtures/attributes.md
@@ -77,3 +77,30 @@ list-style
             <paragraph>
                 b
 .
+
+heading with id
+.
+{#hid}
+## First
+.
+<document source="<src>/index.md">
+    <system_message level="2" line="2" source="<src>/index.md" type="WARNING">
+        <paragraph>
+            Document headings start at H2, not H1 [myst.header]
+    <section ids="hid" names="hid first">
+        <title>
+            First
+.
+
+rubric with id
+.
+```{note}
+{#rid}
+## First
+```
+.
+<document source="<src>/index.md">
+    <note>
+        <rubric ids="rid" level="2" names="rid first">
+            First
+.

--- a/tests/test_renderers/fixtures/myst-config.txt
+++ b/tests/test_renderers/fixtures/myst-config.txt
@@ -551,6 +551,6 @@ content
 .
 <document source="<string>">
     <paragraph>
-        <reference refuri="https://example.com" rel="noreferer noopener" target="_blank">
+        <reference refuri="https://example.com" rel="noreferrer noopener" target="_blank">
             text
 .

--- a/tests/test_renderers/fixtures/myst-config.txt
+++ b/tests/test_renderers/fixtures/myst-config.txt
@@ -389,6 +389,24 @@ a
 <string>:1: (WARNING/2) Invalid 'align' attribute value: 'other' [myst.attribute]
 .
 
+[attrs_inline_image_warnings_alias_and_long] --myst-enable-extensions=attrs_inline
+.
+![a](b){w=1x width=2x}
+.
+<document source="<string>">
+    <paragraph>
+        <image alt="a" uri="b">
+            <system_message level="2" line="1" source="<string>" type="WARNING">
+                <paragraph>
+                    Invalid 'width' attribute value: '1x' [myst.attribute]
+            <system_message level="2" line="1" source="<string>" type="WARNING">
+                <paragraph>
+                    Invalid 'width' attribute value: '2x' [myst.attribute]
+
+<string>:1: (WARNING/2) Invalid 'width' attribute value: '1x' [myst.attribute]
+<string>:1: (WARNING/2) Invalid 'width' attribute value: '2x' [myst.attribute]
+.
+
 [attrs_block] --myst-enable-extensions=attrs_block
 .
 {#myid1 .class1 .class2}

--- a/tests/test_renderers/fixtures/myst-config.txt
+++ b/tests/test_renderers/fixtures/myst-config.txt
@@ -554,3 +554,28 @@ content
         <reference refuri="https://example.com" rel="noreferrer noopener" target="_blank">
             text
 .
+
+[links-external-new-tab-authored] --myst-links-external-new-tab="true" --myst-enable-extensions=attrs_inline
+.
+[a](https://example.com){target=_self rel=nofollow}
+
+[a](https://example.com){target=_self}
+
+[a](https://example.com){rel=nofollow}
+
+<https://example.com>{rel=nofollow}
+.
+<document source="<string>">
+    <paragraph>
+        <reference refuri="https://example.com" rel="nofollow" target="_self">
+            a
+    <paragraph>
+        <reference refuri="https://example.com" rel="noreferrer noopener" target="_self">
+            a
+    <paragraph>
+        <reference refuri="https://example.com" rel="nofollow" target="_blank">
+            a
+    <paragraph>
+        <reference refuri="https://example.com" rel="nofollow" target="_blank">
+            https://example.com
+.

--- a/tests/test_renderers/fixtures/myst-config.txt
+++ b/tests/test_renderers/fixtures/myst-config.txt
@@ -367,6 +367,28 @@ a
 <string>:1: (WARNING/2) Invalid 'align' attribute value: 'other' [myst.attribute]
 .
 
+[attrs_inline_image_warnings_aliases] --myst-enable-extensions=attrs_inline
+.
+![a](b){w=1x h=2x a=other }
+.
+<document source="<string>">
+    <paragraph>
+        <image alt="a" uri="b">
+            <system_message level="2" line="1" source="<string>" type="WARNING">
+                <paragraph>
+                    Invalid 'width' attribute value: '1x' [myst.attribute]
+            <system_message level="2" line="1" source="<string>" type="WARNING">
+                <paragraph>
+                    Invalid 'height' attribute value: '2x' [myst.attribute]
+            <system_message level="2" line="1" source="<string>" type="WARNING">
+                <paragraph>
+                    Invalid 'align' attribute value: 'other' [myst.attribute]
+
+<string>:1: (WARNING/2) Invalid 'width' attribute value: '1x' [myst.attribute]
+<string>:1: (WARNING/2) Invalid 'height' attribute value: '2x' [myst.attribute]
+<string>:1: (WARNING/2) Invalid 'align' attribute value: 'other' [myst.attribute]
+.
+
 [attrs_block] --myst-enable-extensions=attrs_block
 .
 {#myid1 .class1 .class2}

--- a/tests/test_renderers/test_parse_linenos.py
+++ b/tests/test_renderers/test_parse_linenos.py
@@ -8,6 +8,8 @@ import re
 
 import pytest
 
+pytest.importorskip("sphinx")
+
 from myst_parser.mdit_to_docutils.base import DocutilsRenderer
 
 

--- a/tests/test_renderers/test_parse_linenos.py
+++ b/tests/test_renderers/test_parse_linenos.py
@@ -1,0 +1,22 @@
+"""Test ``DocutilsRenderer._parse_linenos``.
+
+This is the helper behind the ``emphasize-lines`` attribute,
+and is only reached on the sphinx code path.
+"""
+
+import re
+
+import pytest
+
+from myst_parser.mdit_to_docutils.base import DocutilsRenderer
+
+
+def test_parse_linenos():
+    """A line within the block is returned, 1-based."""
+    assert DocutilsRenderer._parse_linenos("2", 3) == [2]
+
+
+def test_parse_linenos_out_of_range():
+    """A line past the end of the block reports the allowed range."""
+    with pytest.raises(ValueError, match=re.escape("out of range(1-3)")):
+        DocutilsRenderer._parse_linenos("5", 3)

--- a/tests/test_sphinx/sourcedirs/attrs_block_duplicate_ids/conf.py
+++ b/tests/test_sphinx/sourcedirs/attrs_block_duplicate_ids/conf.py
@@ -1,0 +1,3 @@
+extensions = ["myst_parser"]
+exclude_patterns = ["_build"]
+myst_enable_extensions = ["attrs_block"]

--- a/tests/test_sphinx/sourcedirs/attrs_block_duplicate_ids/index.md
+++ b/tests/test_sphinx/sourcedirs/attrs_block_duplicate_ids/index.md
@@ -1,0 +1,21 @@
+# Page
+
+{#sec}
+## First
+
+{#sec}
+## Second
+
+{#para}
+Paragraph one.
+
+{#para}
+Paragraph two.
+
+```{note}
+{#rub}
+### Third
+
+{#rub}
+### Fourth
+```

--- a/tests/test_sphinx/test_sphinx_builds.py
+++ b/tests/test_sphinx/test_sphinx_builds.py
@@ -473,6 +473,33 @@ def test_substitutions_missing(
 
 
 @pytest.mark.sphinx(
+    buildername="html",
+    srcdir=os.path.join(SOURCE_DIR, "attrs_block_duplicate_ids"),
+    freshenv=True,
+)
+def test_attrs_block_duplicate_ids(
+    app,
+    status,
+    warning,
+):
+    """Test that a duplicated ``{#id}`` warns, rather than aborting the build."""
+    app.build()
+    assert "build succeeded" in status.getvalue()  # Build succeeded
+    warnings = strip_colors(warning.getvalue()).strip().splitlines()
+    assert len(warnings) == 3
+    assert warnings[0].endswith(
+        'index.md:7: WARNING: Duplicate explicit target name: "sec". [docutils]'
+    )
+    assert warnings[1].endswith(
+        'index.md:: WARNING: Duplicate explicit target name: "para". [docutils]'
+    )
+    assert warnings[2].endswith(
+        'index.md:20: WARNING: Duplicate explicit target name: "rub". [docutils]'
+    )
+    assert Path(app.outdir, "index.html").exists()
+
+
+@pytest.mark.sphinx(
     buildername="gettext", srcdir=os.path.join(SOURCE_DIR, "gettext"), freshenv=True
 )
 def test_gettext(


### PR DESCRIPTION
## Summary

- `[i](f.png){w=1x}` (and `{h=…}`, `{a=…}`) aborted the build with `KeyError: 'width'`; an invalid value
  given by its short alias now warns, exactly as the long form already did.
- Two headings carrying the same `{#id}` aborted the build with
  `ValueError: list.remove(x): x not in list` and wrote no page; they now emit docutils' ordinary
  `Duplicate explicit target name` warning, as duplicate ids on paragraphs already did. A single `{#id}`
  heading also stops silently losing that name.
- `myst_links_external_new_tab` emitted `rel="noreferer noopener"` — one `r`, a token no browser
  recognises. It is now spelled `noreferrer`.
- `myst_links_external_new_tab` overwrote an authored `{target=…}`/`{rel=…}`; the config values now apply
  only to keys the author did not supply.
- The `emphasize_lines` range warning read `out of range(1-3` — the closing parenthesis is restored.

## Compatibility

- **Aliased image attributes: crash → warning.** `{w=1x}`/`{h=2y}`/`{a=middle}` previously aborted
  `sphinx-build` (exit 2, no HTML) and the docutils CLI (exit 1). The long forms' message text is
  byte-unchanged — the new fixture row's expected output is a byte copy of the existing long-form row's.
  One further, deliberate change: where an alias **and** its long form are both given for the same
  attribute (`{w=1x width=2x}`), the alias's warning now reports the alias's own value (`'1x'`) instead of
  the long form's (`'2x'`, which is what it happened to print before). Both warnings are still emitted, and
  the long form's own message is unchanged. A fixture row pins it.
- **Duplicate `{#id}` headings: crash → warning.** The build now completes and writes the page. The warning
  is docutils' own message under Sphinx's `[docutils]` subtype — character for character what the paragraph
  case already produced — so it is suppressible today with `suppress_warnings = ["docutils"]`. HTML ids are
  unchanged (measured: identical id sets with and without the fix, on docutils 0.21.2 and 0.22.4). A single
  `{#id}` heading now keeps that name in `names` instead of losing it to `dupnames`. The change is a
  measured no-op on docutils 0.23, which guards against the underlying self-collision itself.
- **`noreferer` → `noreferrer`.** The old value was inert, so nothing that worked stops working. Nothing in
  the docs mentioned either spelling.
- **Authored `target`/`rel` now win.** Non-breaking for anyone not authoring them: with no attribute group
  the rendering is byte-identical. The two keys are independent. An authored *empty* value counts as
  supplied, so `[a](url){rel=""}` now renders `rel=""` where it previously rendered the configured value;
  an unquoted `{rel=}` does not parse as an attribute group at all, before or after. The option's help
  text — its only user-facing documentation — now states what it sets and that authored values win.
- **`out of range(1-3)`.** Warning text only. Note this now differs by one character from Sphinx's own
  `line number spec is out of range(1-%d): %r`, which is unbalanced too; the divergence is deliberate.
- No other rendering changes. Exactly one pre-existing test line moves: the one fixture word
  `noreferer` → `noreferrer` in `tests/test_renderers/fixtures/myst-config.txt`.

## Tests

- **Aliased image attributes** — new `myst-config.txt` row `[attrs_inline_image_warnings_aliases]`
  (`[a](b){w=1x h=2x a=other }`). Before: the row raised `KeyError: 'width'` inside `copy_attributes`.
  After: three `Invalid '…' attribute value` warnings, output byte-identical to the long-form sibling row.
  A second row `[attrs_inline_image_warnings_alias_and_long]` (`[a](b){w=1x width=2x}`) pins the
  alias-plus-long-form case: before, both warnings read `'2x'`; after, `'1x'` then `'2x'`. Both rows run
  Sphinx-less, so the docutils-only CI job covers them too (green on docutils 0.20 and 0.23).
- **Duplicate `{#id}` headings** — new sourcedir `tests/test_sphinx/sourcedirs/attrs_block_duplicate_ids/`
  with three duplicate pairs (headings, paragraphs, and headings inside a `{note}` fence, i.e. the rubric
  path) plus `test_attrs_block_duplicate_ids`. Before: `ValueError: list.remove(x): x not in list`, no page.
  After: `build succeeded`, exactly three `Duplicate explicit target name` warnings, `index.html` written.
  Two `attributes.md` rows pin the doctree: before, `<section dupnames="hid" ids="hid" names="first">` plus
  an INFO `Duplicate implicit target name: "hid".`, and `<rubric dupnames="rid" … names="first">`; after,
  `<section ids="hid" names="hid first">` and `<rubric ids="rid" level="2" names="rid first">`.
  **Note:** the integration test passes without the fix on docutils 0.23, which already guards the
  self-collision. Every Sphinx-paired CI cell runs docutils < 0.23 (Sphinx 8 caps `<0.22`, Sphinx 9 caps
  `<0.23`), so the test is genuinely red in CI on the unfixed tree.
- **`noreferrer`** — the existing `[links-external-new-tab]` row was updated to the correct spelling first;
  it then failed with `-noreferrer / +noreferer`, and passes after the source change.
- **Authored `target`/`rel`** — new row `[links-external-new-tab-authored]` covering both keys authored,
  each key alone, and an autolink. Before: all four rendered `rel="noreferrer noopener" target="_blank"`.
  After: `rel="nofollow" target="_self"`, `rel="noreferrer noopener" target="_self"`,
  `rel="nofollow" target="_blank"`, `rel="nofollow" target="_blank"`. The option's help text is pinned by a
  new assertion in `tests/test_docutils.py::test_help_text` (red with the old text, green with the new).
- **`out of range(1-3)`** — new `tests/test_renderers/test_parse_linenos.py`, a unit test on the
  `_parse_linenos` static method (the message is unreachable without Sphinx, so a fixture row cannot pin
  it; the module skips itself when Sphinx is absent). Before: the regex did not match `out of range(1-3`.
  After: it matches, and a valid case still returns `[2]`.

## Gates

Python 3.11, four environments, all measured at the branch tip:

- Sphinx 9.0.4 / docutils 0.22.4: `tests/test_renderers` 398 passed 8 skipped; `tests/test_sphinx`
  24 passed; the rest 831 passed 3 skipped. **1253 passed, 0 failed** (master baseline 1245).
- Sphinx 8.2.3 / docutils 0.21.2: 396 passed 10 skipped; 22 passed 2 skipped; 831 passed 3 skipped.
  **1249 passed, 0 failed** (master baseline 1241).
- docutils 0.23, no Sphinx (the `check-myst-docutils` job's four files): **180 passed, 0 failed**
  (baseline 177).
- docutils 0.20, no Sphinx, same four files: **178 passed, 2 skipped, 0 failed**.
- `pre-commit run --all-files`: all hooks passed, exit 0.

Every delta is the new tests; the skip lists are unchanged from master in all four environments.

## Changelog lines

- 🐛 FIX: warn instead of raising `KeyError` on an invalid image attribute given by its alias (`{w=…}`,
  `{h=…}`, `{a=…}`)
- 🐛 FIX: a duplicate `{#id}` on headings warns instead of aborting the build, and a single `{#id}` heading
  keeps its name
- 🐛 FIX: `myst_links_external_new_tab` spells `rel="noreferrer"`
- 🐛 FIX: `myst_links_external_new_tab` no longer overwrites an authored `target` or `rel`
- 🐛 FIX: balance the parenthesis in the `emphasize_lines` out-of-range warning

## Follow-ups noticed

- `render_link_url` mutates the parser's own token stream (`token.attrs`) just to pass two values to
  `copy_attributes` three lines later — the only writes to `token.attrs` in the package. Passing the
  defaults to `copy_attributes`, or setting them on the reference node when absent, would be cleaner; that
  is a refactor, not a bug fix.
- On docutils < 0.22 a rubric that receives a system message before its implicit name is computed gets the
  warning's text baked into `names` (measured on the unfixed tree with a non-crashing trigger:
  `names="…\ (warning/2)\ duplicate\ explicit\ target\ name:\ "dupe".h"`; absent on 0.22.4). Pre-existing
  and untouched here; computing the rubric's implicit text before noting the explicit target would fix it.
- Sphinx's own `line number spec is out of range(1-%d): %r` (`sphinx/directives/code.py:131,297,483` in
  8.2.3 and 9.0.4) is unbalanced in the same way.
- `tests/test_renderers/test_fixtures_docutils.py::test_docutils_roles[112-code]` fails if
  `tests/test_sphinx` is collected before `tests/test_renderers` in one process (Sphinx's `code` role leaks
  a `language=""` default into the global docutils role registry). Pre-existing; never fires in CI or tox,
  which collect alphabetically.
- Documenting attribute-group precedence (`docs/syntax/optional.md`) is blocked on an mdit-py-plugins
  release carrying the span/link class-accumulation fix: `pyproject.toml` pins
  `mdit-py-plugins~=0.6,>=0.6.1`, and 0.6.1 is the newest release on PyPI, so "classes accumulate" is not
  yet true for spans and links with the dependency as pinned.
- `CHANGELOG.md` is deliberately untouched; the entries above are for the maintainer.

## Out of scope by ruling

- A newline inside a quoted attribute value truncates it to the first line — changing that changes accepted
  input.
- The disabled "full line consumed" check in `_attr_block_rule` (`{.a}{#b}` on one line applies only the
  first group); re-enabling it turns such lines into paragraphs.
- Keys that are not valid HTML attribute names (`{-=v}`, `{1=v}`) are accepted.
- A span inside a link label (`[a [b]{.c} d](u)`) breaks the link.
- Surfacing `ParseError` positions as warnings — a feature, not a fix.
- `attrs_block` before a `{directive}` fence, or before an `<img>` under `html_image`, being dropped —
  feature-sized (the directive mapping exists for `myst_fence_as_directive` and could be reused).

